### PR TITLE
Extend Button to ActionButton

### DIFF
--- a/src/components/ActionButton/ActionButton.stories.mdx
+++ b/src/components/ActionButton/ActionButton.stories.mdx
@@ -10,9 +10,15 @@ import ActionButton from "./ActionButton";
       control: {
         type: "text",
       },
+      defaultValue: "Click me!",
     },
+    appearance: {
+      defaultValue: "positive"
+    }
   }}
 />
+
+export const Template = (args) => <ActionButton {...args} />;
 
 ### ActionButton
 
@@ -27,9 +33,7 @@ ActionButton accepts the props from [Button](?path=/docs/button--base) in additi
 ### Default
 
 <Canvas>
-  <Story name="Default">
-    <ActionButton appearance="positive">Click me!</ActionButton>
-  </Story>
+  <Story name="Base">{Template.bind({})}</Story>
 </Canvas>
 
 ### Loading

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 import type { ButtonProps } from "../Button";
-import { ButtonAppearance } from "../Button";
+import Button, { ButtonAppearance } from "../Button";
 import Icon from "../Icon";
 
 import type { ClassName, PropsWithSpread } from "types";
@@ -121,7 +121,7 @@ const ActionButton = ({
   // forwardRef which is not currently supported by components that use
   // typescript generics.
   return (
-    <button
+    <Button
       className={buttonClasses}
       disabled={disabled}
       ref={ref}
@@ -144,7 +144,7 @@ const ActionButton = ({
       ) : (
         children
       )}
-    </button>
+    </Button>
   );
 };
 

--- a/src/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
+++ b/src/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
@@ -4,20 +4,25 @@ exports[`ActionButton matches loading snapshot 1`] = `
 <ActionButton
   loading={true}
 >
-  <button
+  <Button
     className="p-action-button p-button--neutral is-processing"
     disabled={false}
   >
-    <Icon
-      className="u-animation--spin"
-      light={false}
-      name="spinner"
+    <button
+      className="p-button--neutral p-action-button p-button--neutral is-processing"
+      disabled={false}
     >
-      <i
-        className="u-animation--spin p-icon--spinner"
-      />
-    </Icon>
-  </button>
+      <Icon
+        className="u-animation--spin"
+        light={false}
+        name="spinner"
+      >
+        <i
+          className="u-animation--spin p-icon--spinner"
+        />
+      </Icon>
+    </button>
+  </Button>
 </ActionButton>
 `;
 
@@ -26,19 +31,24 @@ exports[`ActionButton matches success snapshot 1`] = `
   loading={false}
   success={true}
 >
-  <button
+  <Button
     className="p-action-button p-button--neutral is-processing"
     disabled={false}
   >
-    <Icon
-      className={null}
-      light={false}
-      name="success"
+    <button
+      className="p-button--neutral p-action-button p-button--neutral is-processing"
+      disabled={false}
     >
-      <i
-        className="p-icon--success"
-      />
-    </Icon>
-  </button>
+      <Icon
+        className={null}
+        light={false}
+        name="success"
+      >
+        <i
+          className="p-icon--success"
+        />
+      </Icon>
+    </button>
+  </Button>
 </ActionButton>
 `;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -27,7 +27,7 @@ export type Props<P = null> = {
   /**
    * The appearance of the button.
    */
-  appearance?: ValueOf<typeof ButtonAppearance> | string;
+  appearance?: ValueOf<typeof ButtonAppearance>;
   /**
    * The content of the button.
    */

--- a/src/components/SummaryButton/SummaryButton.tsx
+++ b/src/components/SummaryButton/SummaryButton.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { MouseEventHandler } from "react";
-import classNames from "classnames";
 
 import ActionButton from "../ActionButton";
 import { ButtonAppearance } from "../Button/Button";
@@ -42,9 +41,6 @@ const SummaryButton = ({
     {onClick && (
       <ActionButton
         appearance={ButtonAppearance.NEUTRAL}
-        className={classNames("is-small", "is-dense", {
-          "is-inline": summary,
-        })}
         onClick={onClick}
         loading={isLoading}
         disabled={isLoading}

--- a/src/components/SummaryButton/__snapshots__/SummaryButton.test.tsx.snap
+++ b/src/components/SummaryButton/__snapshots__/SummaryButton.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`<SummaryButton /> renders and matches the snapshot 1`] = `
   </span>
   <ActionButton
     appearance="neutral"
-    className="is-small is-dense is-inline"
     onClick={[Function]}
   >
     Show more


### PR DESCRIPTION
## Done

Extend Button to ActionButton

## QA

### Storybook

Check rendered `ActionButton` https://react-components-589.demos.haus/?path=/story/actionbutton--default-story


## Fixes

Fixes: https://github.com/canonical-web-and-design/react-components/issues/189
