### PR TITLE
Use latest ubuntu for cypress job

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -2,7 +2,7 @@ name: Cypress chrome headless
 on: [push]
 jobs:
   cypress-run:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
       - uses: cypress-io/github-action@v2


### PR DESCRIPTION
## Done

- Fix cypress job running on old ubuntu image.

## QA

- Make sure all CI check pass (including cypress run)