### PR TITLE
fix: Broken homepage link in NPM #619

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check inclusive naming
-        uses: canonical-web-and-design/inclusive-naming@main
+        uses: canonical/inclusive-naming@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check

--- a/HACKING.md
+++ b/HACKING.md
@@ -8,7 +8,7 @@ Canonical `react-components` is developed with [TypeScript](https://www.typescri
 
 You can run [Storybook](https://storybook.js.org/) locally to develop new components. You may also need to validate that they work with other projects, in which case see the instructions below.
 
-Run Storybook with [dotrun](https://github.com/canonical-web-and-design/dotrun):
+Run Storybook with [dotrun](https://github.com/canonical/dotrun):
 
 ```shell
 dotrun

--- a/PUBLISH-NPM-PACKAGE.md
+++ b/PUBLISH-NPM-PACKAGE.md
@@ -34,22 +34,22 @@ Push your branch to GitHub, create a PR and land it (this might require approval
 
 #### Review release notes
 
-Make sure that the [release notes draft](https://github.com/canonical-web-and-design/react-components/releases) created automatically by release-drafter is up to date.
+Make sure that the [release notes draft](https://github.com/canonical/react-components/releases) created automatically by release-drafter is up to date.
 
 #### Publish
 
-Publish the [latest release on Github](https://github.com/canonical-web-and-design/react-components/releases) with the new version number and add the release notes you created earlier.
+Publish the [latest release on Github](https://github.com/canonical/react-components/releases) with the new version number and add the release notes you created earlier.
 
 #### Publish to NPM
 
-This should happen automatically after publishing the release on GH (thanks to [GH actions workflow](https://github.com/canonical-web-and-design/react-components/blob/main/.github/workflows/publish-on-release.yml)).
+This should happen automatically after publishing the release on GH (thanks to [GH actions workflow](https://github.com/canonical/react-components/blob/main/.github/workflows/publish-on-release.yml)).
 
 In case it fails and you need to publish manually, here are manual steps:
 
 Get a fresh copy of the main branch
 
 ```shell
-git clone git@github.com:canonical-web-and-design/react-components.git react-components-release
+git clone git@github.com:canonical/react-components.git react-components-release
 ```
 
 Build and publish the package.

--- a/PUBLISHING-DOCS.md
+++ b/PUBLISHING-DOCS.md
@@ -8,4 +8,4 @@ yarn build-docs
 
 Commit and create a new PR and land to main branch.
 
-That's it! The [docs](https://canonical-web-and-design.github.io/react-components/) will be updated shortly.
+That's it! The [docs](https://canonical.github.io/react-components/) will be updated shortly.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React components for Vanilla Framework.
+# React components for Vanilla Framework
 
 This is a collection of components designed to be the way to consume [Vanilla Framework](http://vanillaframework.io) when using React.
 
@@ -7,7 +7,7 @@ This is a collection of components designed to be the way to consume [Vanilla Fr
 See the [component docs](https://canonical.github.io/react-components/) for usage instructions.
 
 ![CI](https://github.com/canonical/react-components/workflows/CI/badge.svg?branch=main)
-![Cypress chrome headless](https://github.com/canonical-web-and-design/react-components/workflows/Cypress%20chrome%20headless/badge.svg)
+![Cypress chrome headless](https://github.com/canonical/react-components/workflows/Cypress%20chrome%20headless/badge.svg)
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/canonical/react-components/issues"
   },
-  "homepage": "https://github.com/canonical/react-components",
+  "homepage": "https://canonical.github.io/react-components",
   "devDependencies": {
     "@babel/cli": "7.18.9",
     "@babel/eslint-parser": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:canonical-web-and-design/react-components.git"
+    "url": "git@github.com:canonical/react-components.git"
   },
   "bugs": {
-    "url": "https://github.com/canonical-web-and-design/react-components/issues"
+    "url": "https://github.com/canonical/react-components/issues"
   },
-  "homepage": "/react-components/",
+  "homepage": "https://github.com/canonical/react-components",
   "devDependencies": {
     "@babel/cli": "7.18.9",
     "@babel/eslint-parser": "7.18.9",

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>canonical-web-and-design/vanilla-framework"]
+  "extends": ["github>canonical/vanilla-framework"]
 }

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -10,7 +10,7 @@ import { IS_DEV } from "../../utils";
 const Loader = (props: SpinnerProps): JSX.Element => {
   if (IS_DEV) {
     console.warn(
-      "The Loader component has been renamed to Spinner and will be removed in a future release. https://canonical-web-and-design.github.io/react-components/?path=/story/spinner--default-story"
+      "The Loader component has been renamed to Spinner and will be removed in a future release. https://canonical.github.io/react-components/?path=/story/spinner--default-story"
     );
   }
   return <Spinner {...props} />;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -109,7 +109,7 @@ const Notification = ({
 
   if (IS_DEV && (close || status || type)) {
     console.warn(
-      "The Notification component is using deprecated props. Refer to the deprecated list for details: https://canonical-web-and-design.github.io/react-components/?path=/docs/notification--information#deprecated"
+      "The Notification component is using deprecated props. Refer to the deprecated list for details: https://canonical.github.io/react-components/?path=/docs/notification--information#deprecated"
     );
   }
 


### PR DESCRIPTION
## Done

- fix Broken homepage link in NPM #619
- update all github urls to use canonical org

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: #619 .
