### PR TITLE
remove redundant id from useClickOutside

### DIFF
--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,17 +1,13 @@
 import { MutableRefObject, useCallback, useEffect, useRef } from "react";
 
-import { useId } from "./useId";
-
 /**
  * Handle clicks outside an element.
- * @returns An id and ref to pass to the element to handle clicks
- * outside of.
+ * @returns A ref to pass to the element to handle clicks outside of.
  */
 export const useClickOutside = <E extends HTMLElement>(
   onClickOutside: () => void
-): [MutableRefObject<E>, string] => {
+): [MutableRefObject<E>] => {
   const wrapperRef = useRef<E | null>(null);
-  const id = useId();
 
   const handleClickOutside = useCallback(
     (evt: MouseEvent) => {
@@ -24,12 +20,12 @@ export const useClickOutside = <E extends HTMLElement>(
         !isValidTarget ||
         (wrapperRef.current &&
           !wrapperRef.current?.contains(target) &&
-          target.id !== id)
+          wrapperRef.current !== target)
       ) {
         onClickOutside();
       }
     },
-    [id, onClickOutside]
+    [onClickOutside]
   );
 
   useEffect(() => {
@@ -37,5 +33,5 @@ export const useClickOutside = <E extends HTMLElement>(
     return () =>
       document.removeEventListener("click", handleClickOutside, false);
   }, [handleClickOutside]);
-  return [wrapperRef, id];
+  return [wrapperRef];
 };


### PR DESCRIPTION
## Done

- remove redundant id from useClickOutside

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: # .
