### PR TITLE
feat: remove redundant id from useClickOutside

### DIFF
--- a/src/components/Navigation/NavigationMenu/NavigationMenu.tsx
+++ b/src/components/Navigation/NavigationMenu/NavigationMenu.tsx
@@ -27,7 +27,7 @@ const NavigationMenu = ({
 }: Props): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const closeMenu = useCallback(() => setIsOpen(false), [setIsOpen]);
-  const [menuRef] = useClickOutside<HTMLLIElement>(closeMenu);
+  const menuRef = useClickOutside<HTMLLIElement>(closeMenu);
   const menuId = useId();
   return (
     <li

--- a/src/components/Navigation/NavigationMenu/NavigationMenu.tsx
+++ b/src/components/Navigation/NavigationMenu/NavigationMenu.tsx
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import NavigationLink from "../NavigationLink";
 import type { GenerateLink, NavMenu } from "../types";
 import { PropsWithSpread } from "types";
-import { useClickOutside } from "hooks";
+import { useClickOutside, useId } from "hooks";
 
 type Props = PropsWithSpread<
   NavMenu & {
@@ -27,7 +27,8 @@ const NavigationMenu = ({
 }: Props): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const closeMenu = useCallback(() => setIsOpen(false), [setIsOpen]);
-  const [menuRef, menuId] = useClickOutside<HTMLButtonElement>(closeMenu);
+  const [menuRef] = useClickOutside<HTMLLIElement>(closeMenu);
+  const menuId = useId();
   return (
     <li
       {...props}
@@ -38,6 +39,7 @@ const NavigationMenu = ({
           "is-active": isOpen,
         }
       )}
+      ref={menuRef}
     >
       <button
         aria-controls={menuId}
@@ -46,7 +48,6 @@ const NavigationMenu = ({
           evt.preventDefault();
           setIsOpen(!isOpen);
         }}
-        ref={menuRef}
       >
         {label}
       </button>

--- a/src/hooks/useClickOutside.test.tsx
+++ b/src/hooks/useClickOutside.test.tsx
@@ -10,10 +10,10 @@ describe("useClickOutside", () => {
   }: PropsWithChildren<{
     onClickOutside: () => void;
   }>) => {
-    const [wrapperRef, id] = useClickOutside<HTMLDivElement>(onClickOutside);
+    const [wrapperRef] = useClickOutside<HTMLDivElement>(onClickOutside);
     return (
       <div>
-        <div id={id} ref={wrapperRef}>
+        <div ref={wrapperRef}>
           Menu
           <button>Inside</button>
         </div>

--- a/src/hooks/useClickOutside.test.tsx
+++ b/src/hooks/useClickOutside.test.tsx
@@ -10,7 +10,7 @@ describe("useClickOutside", () => {
   }: PropsWithChildren<{
     onClickOutside: () => void;
   }>) => {
-    const [wrapperRef] = useClickOutside<HTMLDivElement>(onClickOutside);
+    const wrapperRef = useClickOutside<HTMLDivElement>(onClickOutside);
     return (
       <div>
         <div ref={wrapperRef}>

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,17 +1,13 @@
 import { MutableRefObject, useCallback, useEffect, useRef } from "react";
 
-import { useId } from "./useId";
-
 /**
  * Handle clicks outside an element.
- * @returns An id and ref to pass to the element to handle clicks
- * outside of.
+ * @returns A ref to pass to the element to handle clicks outside of.
  */
 export const useClickOutside = <E extends HTMLElement>(
   onClickOutside: () => void
-): [MutableRefObject<E>, string] => {
+): [MutableRefObject<E>] => {
   const wrapperRef = useRef<E | null>(null);
-  const id = useId();
 
   const handleClickOutside = useCallback(
     (evt: MouseEvent) => {
@@ -24,12 +20,12 @@ export const useClickOutside = <E extends HTMLElement>(
         !isValidTarget ||
         (wrapperRef.current &&
           !wrapperRef.current?.contains(target) &&
-          target.id !== id)
+          wrapperRef.current !== target)
       ) {
         onClickOutside();
       }
     },
-    [id, onClickOutside]
+    [onClickOutside]
   );
 
   useEffect(() => {
@@ -37,5 +33,5 @@ export const useClickOutside = <E extends HTMLElement>(
     return () =>
       document.removeEventListener("click", handleClickOutside, false);
   }, [handleClickOutside]);
-  return [wrapperRef, id];
+  return [wrapperRef];
 };

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -6,8 +6,8 @@ import { MutableRefObject, useCallback, useEffect, useRef } from "react";
  */
 export const useClickOutside = <E extends HTMLElement>(
   onClickOutside: () => void
-): [MutableRefObject<E>] => {
-  const wrapperRef = useRef<E | null>(null);
+): MutableRefObject<E> => {
+  const ref = useRef<E | null>(null);
 
   const handleClickOutside = useCallback(
     (evt: MouseEvent) => {
@@ -18,9 +18,9 @@ export const useClickOutside = <E extends HTMLElement>(
         typeof (evt?.target as HTMLElement)?.className === "string";
       if (
         !isValidTarget ||
-        (wrapperRef.current &&
-          !wrapperRef.current?.contains(target) &&
-          wrapperRef.current !== target)
+        (ref.current &&
+          !ref.current?.contains(target) &&
+          ref.current !== target)
       ) {
         onClickOutside();
       }
@@ -33,5 +33,5 @@ export const useClickOutside = <E extends HTMLElement>(
     return () =>
       document.removeEventListener("click", handleClickOutside, false);
   }, [handleClickOutside]);
-  return [wrapperRef];
+  return ref;
 };


### PR DESCRIPTION
## Done

- remove redundant id from useClickOutside
  - this is redundant as verifying if the clicked element is the current element can be achieved by using ref only

This is safe to remove as it's only being used in react-components itself and [TagSelector](https://github.com/canonical/maas-ui/blob/5647d8ed12c1f8a547b7633d035c96be05e3e908/src/app/base/components/TagSelector/TagSelector.tsx) in maas-ui

https://github.com/search?q=org%3Acanonical+useClickOutside&type=code

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to the demo
- Verify that NavigationMenu opens and closes when clicking outside as before

## Fixes

Fixes: # .
