### PR TITLE
Add option for table captions

### DIFF
--- a/src/components/MainTable/MainTable.test.tsx
+++ b/src/components/MainTable/MainTable.test.tsx
@@ -280,5 +280,20 @@ describe("MainTable", () => {
       expect(heads.first().prop("sort")).toEqual("none");
       expect(heads.at(1).prop("sort")).toEqual("ascending");
     });
+
+    it("shows a hidden caption if provided", () => {
+      const captionText = "This is a caption for screen readers";
+      const wrapper = mount(
+        <MainTable
+          defaultSort="status"
+          defaultSortDirection="descending"
+          headers={headers}
+          rows={rows}
+          sortable={true}
+          caption={captionText}
+        />
+      );
+      expect(wrapper.find("caption").text()).toEqual(captionText);
+    });
   });
 });

--- a/src/components/MainTable/MainTable.test.tsx
+++ b/src/components/MainTable/MainTable.test.tsx
@@ -290,7 +290,7 @@ describe("MainTable", () => {
           headers={headers}
           rows={rows}
           sortable={true}
-          caption={captionText}
+          hiddenCaption={captionText}
         />
       );
       expect(wrapper.find("caption").text()).toEqual(captionText);

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -119,6 +119,10 @@ export type Props = PropsWithSpread<
       currentSortDirection: SortDirection,
       currentSortKey: MainTableHeader["sortKey"]
     ) => -1 | 0 | 1;
+    /**
+     * A hidden caption to display on the table for screen readers
+     */
+    caption?: string | null;
   },
   TableProps
 >;
@@ -289,6 +293,7 @@ const MainTable = ({
   responsive,
   sortable,
   sortFunction,
+  caption,
   ...props
 }: Props): JSX.Element => {
   const [currentSortKey, setSortKey] = useState(defaultSort);
@@ -334,6 +339,20 @@ const MainTable = ({
   return (
     <>
       <Table expanding={expanding} responsive={responsive} {...props}>
+        {caption && (
+          <caption
+            style={{
+              height: "1px",
+              left: "-1000px",
+              overflow: "hidden",
+              position: "absolute",
+              top: "auto",
+              width: "1px",
+            }}
+          >
+            {caption}
+          </caption>
+        )}
         {!!headers &&
           generateHeaders(
             currentSortKey,

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -122,7 +122,7 @@ export type Props = PropsWithSpread<
     /**
      * A hidden caption to display on the table for screen readers
      */
-    caption?: string | null;
+    hiddenCaption?: string | null;
   },
   TableProps
 >;
@@ -293,7 +293,7 @@ const MainTable = ({
   responsive,
   sortable,
   sortFunction,
-  caption,
+  hiddenCaption,
   ...props
 }: Props): JSX.Element => {
   const [currentSortKey, setSortKey] = useState(defaultSort);
@@ -339,7 +339,7 @@ const MainTable = ({
   return (
     <>
       <Table expanding={expanding} responsive={responsive} {...props}>
-        {caption && (
+        {hiddenCaption && (
           <caption
             style={{
               height: "1px",
@@ -350,7 +350,7 @@ const MainTable = ({
               width: "1px",
             }}
           >
-            {caption}
+            {hiddenCaption}
           </caption>
         )}
         {!!headers &&


### PR DESCRIPTION
## Done

Added the option to add a hidden `caption` element to tables. This is to improve the experience for screen readers. See https://www.w3.org/WAI/tutorials/tables/caption-summary/

## QA

Check that the main table contains a `caption` element as the first child but that it is not visible on the screen

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: #854 .
