### PR TITLE
feat(ContextualMenu): allow node label

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 import ContextualMenu from "./ContextualMenu";
@@ -251,5 +252,16 @@ describe("ContextualMenu ", () => {
     expect(wrapper.find("ContextualMenuDropdown").prop("data-testid")).toBe(
       "extra-prop"
     );
+  });
+
+  it("allows passing a component as a toggleLabel", () => {
+    render(
+      <ContextualMenu
+        links={[]}
+        position="right"
+        toggleLabel={<span>toggleLabel component text</span>}
+      />
+    );
+    expect(screen.getByText("toggleLabel component text")).toBeInTheDocument();
   });
 });

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -85,7 +85,7 @@ export type Props<L> = PropsWithSpread<
     /**
      * The toggle button's label.
      */
-    toggleLabel?: string | null;
+    toggleLabel?: string | React.ReactNode | null;
     /**
      * Whether the toggle lable or icon should appear first.
      */
@@ -209,7 +209,12 @@ const ContextualMenu = <L,>({
     },
   });
   const previousVisible = usePrevious(visible);
-  const labelNode = toggleLabel ? <span>{toggleLabel}</span> : null;
+  const labelNode =
+    toggleLabel && typeof toggleLabel === "string" ? (
+      <span>{toggleLabel}</span>
+    ) : React.isValidElement(toggleLabel) ? (
+      toggleLabel
+    ) : null;
   const wrapperClass = classNames(className, "p-contextual-menu", {
     [`p-contextual-menu--${adjustedPosition}`]: adjustedPosition !== "right",
   });


### PR DESCRIPTION
## Done

- allow passing a node for ContextualMenu toggleLabel

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: # .
