### PR TITLE
Feat: ModularTable now has the ability to use the useSortBy plugin.

### DIFF
--- a/src/components/ModularTable/ModularTable.stories.mdx
+++ b/src/components/ModularTable/ModularTable.stories.mdx
@@ -191,6 +191,98 @@ columns = {
   </Story>
 </Preview>
 
+### Sortable columns
+
+<Preview>
+  <Story name="Sortable">
+    <ModularTable
+      sortable
+      getCellProps={({ value }) => ({
+        className: value === "1 minute" ? "p-heading--5" : "",
+      })}
+      columns={React.useMemo(
+        () => [
+          {
+            Header: "ID",
+            accessor: "buildId",
+            sortType: 'basic',
+            Cell: ({ value }) => <a href="#">#{value}</a>,
+          },
+          {
+            Header: "Architecture",
+            accessor: "arch",
+            sortType: 'basic',
+          },
+          {
+            Header: "Build Duration",
+            accessor: "duration",
+            className: "u-hide--small",
+            sortType: 'basic',
+          },
+          {
+            Header: "Result",
+            accessor: "result",
+            sortType: 'basic',
+            Cell: ({ value }) => {
+              switch (value) {
+                case "released":
+                  return "Released";
+                case "failed":
+                  return "Failed";
+                default:
+                  return "Unknown";
+              }
+            },
+            getCellIcon: ({ value }) => {
+              switch (value) {
+                case "released":
+                  return ICONS.success;
+                case "failed":
+                  return ICONS.error;
+                default:
+                  return false;
+              }
+            },
+          },
+          {
+            Header: "Build Finished",
+            accessor: "finished",
+            className: "u-align-text--right",
+            sortType: 'basic',
+          },
+        ],
+        []
+      )}
+      data={React.useMemo(
+        () => [
+          {
+            buildId: "5432",
+            arch: "arm64",
+            duration: "5 minutes",
+            result: "released",
+            finished: "10 minutes ago",
+          },
+          {
+            buildId: "1234",
+            arch: "armhf",
+            duration: "5 minutes",
+            result: "failed",
+            finished: "over 1 year ago",
+          },
+          {
+            buildId: "1111",
+            arch: "test64",
+            duration: "1 minute",
+            result: "other",
+            finished: "ages ago",
+          },
+        ],
+        []
+      )}
+    />
+  </Story>
+</Preview>
+
 ### Load more items
 
 Example below shows a basic `ModularTable` with `SummaryButton` component in the footer.

--- a/src/components/ModularTable/ModularTable.test.tsx
+++ b/src/components/ModularTable/ModularTable.test.tsx
@@ -4,10 +4,25 @@ import React from "react";
 import ModularTable from "./ModularTable";
 
 const columns = [
-  { accessor: "status", Header: "Status" },
-  { accessor: "cores", Header: "Cores", className: "u-align--right" },
-  { accessor: "ram", Header: "RAM", className: "u-align--right" },
-  { accessor: "disks", Header: "Disks", className: "u-align--right" },
+  { accessor: "status", Header: "Status", sortType: "alphanumeric" },
+  {
+    accessor: "cores",
+    Header: "Cores",
+    className: "u-align--right",
+    sortType: "alphanumeric",
+  },
+  {
+    accessor: "ram",
+    Header: "RAM",
+    className: "u-align--right",
+    sortType: "alphanumeric",
+  },
+  {
+    accessor: "disks",
+    Header: "Disks",
+    className: "u-align--right",
+    sortType: "alphanumeric",
+  },
 ];
 const data = [
   {
@@ -39,6 +54,13 @@ it("renders all rows and columns", async () => {
   rowItems.forEach((row) => {
     const cells = within(row).getAllByRole("cell");
     expect(cells.length).toEqual(columns.length);
+  });
+});
+
+it("renders all rows and columns when the sortable option is set", async () => {
+  render(<ModularTable columns={columns} data={data} sortable={true} />);
+  screen.getAllByRole("columnheader").forEach((ch) => {
+    expect(ch).toHaveAttribute("aria-sort", "none");
   });
 });
 

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -4,6 +4,7 @@ import {
   TableHeaderProps,
   TableRowProps,
   useTable,
+  useSortBy,
 } from "react-table";
 import type {
   Column,
@@ -38,6 +39,10 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
      */
     footer?: ReactNode;
     /**
+     * Optional argument to make the tables be sortable and use the `useSortBy` plugin.
+     */
+    sortable?: Boolean;
+    /**
      * This function is used to resolve any props needed for a particular column's header cell.
      */
     getHeaderProps?: (
@@ -65,6 +70,7 @@ function ModularTable({
   columns,
   emptyMsg,
   footer,
+  sortable,
   getHeaderProps,
   getRowProps,
   getCellProps,
@@ -72,11 +78,14 @@ function ModularTable({
   ...props
 }: Props<Record<string, unknown>>): JSX.Element {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-    useTable<Record<string, unknown>>({
-      columns,
-      data,
-      getRowId: getRowId || undefined,
-    });
+    useTable<Record<string, unknown>>(
+      {
+        columns,
+        data,
+        getRowId: getRowId || undefined,
+      },
+      sortable ? useSortBy : undefined
+    );
 
   const showEmpty: boolean = !!emptyMsg && (!rows || rows.length === 0);
 
@@ -87,6 +96,13 @@ function ModularTable({
           <TableRow {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map((column) => (
               <TableHeader
+                sort={
+                  column.isSorted
+                    ? column.isSortedDesc
+                      ? "descending"
+                      : "ascending"
+                    : "none"
+                }
                 {...column.getHeaderProps([
                   {
                     className: column.className,
@@ -97,6 +113,8 @@ function ModularTable({
                       : "",
                   },
                   { ...getHeaderProps?.(column) },
+                  // Only call this if we want it to be sortable too.
+                  sortable ? column.getSortByToggleProps() : {},
                 ])}
               >
                 {column.render("Header")}

--- a/src/types/react-table-config.d.ts
+++ b/src/types/react-table-config.d.ts
@@ -1,7 +1,7 @@
 // check @types/react-table README for details on this config file:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-table/Readme.md
 
-import "react-table";
+import { UseSortByColumnProps } from "react-table";
 
 declare module "react-table" {
   export interface UseTableColumnOptions<D extends Record<string, unknown>>
@@ -9,4 +9,9 @@ declare module "react-table" {
     className?: string;
     getCellIcon?: (cell: Cell<D>) => string | false;
   }
+
+  export interface ColumnInstance<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseFiltersColumnProps<D>,
+      UseSortByColumnProps<D> {}
 }


### PR DESCRIPTION
## Done

- Added `useSortBy` plugin capabilities to the `ModularTable` component.
- Added `sortable` prop to the `ModularTable` component.

