### PR TITLE
Add centered prop to pagination component

### DIFF
--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -57,3 +57,17 @@ The pagination component should be used to navigate between pages of content. De
     />
   </Story>
 </Canvas>
+
+### Centered
+
+<Canvas>
+  <Story name="Centered">
+    <Pagination
+      itemsPerPage={10}
+      totalItems={50}
+      paginate={() => {}}
+      currentPage={1}
+      centered
+    />
+  </Story>
+</Canvas>

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -141,7 +141,7 @@ describe("<Pagination />", () => {
       />
     );
     // eslint-disable-next-line testing-library/no-node-access
-    expect(document.querySelector(".p-pagination")).toHaveClass(
+    expect(document.querySelector(".p-pagination__items")).toHaveClass(
       "u-align--center"
     );
   });

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -129,4 +129,20 @@ describe("<Pagination />", () => {
     await userEvent.click(screen.getByRole("button", { name: "99" }));
     expect(handleOnSubmit).not.toHaveBeenCalled();
   });
+
+  it("can be centered", () => {
+    render(
+      <Pagination
+        itemsPerPage={10}
+        totalItems={1000}
+        paginate={jest.fn()}
+        currentPage={98}
+        centered
+      />
+    );
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.querySelector(".p-pagination")).toHaveClass(
+      "u-align--center"
+    );
+  });
 });

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React from "react";
 import type { HTMLProps } from "react";
 
@@ -118,6 +119,10 @@ export type Props = PropsWithSpread<
      * The number of pages at which to truncate the pagination items.
      */
     truncateThreshold?: number;
+    /**
+     * Whether or not the pagination is ceneterd on the page.
+     */
+    centered?: boolean;
   },
   HTMLProps<HTMLElement>
 >;
@@ -129,6 +134,7 @@ const Pagination = ({
   currentPage,
   scrollToTop,
   truncateThreshold = 10,
+  centered,
   ...navProps
 }: Props): JSX.Element => {
   // return early if no pagination is required
@@ -149,7 +155,11 @@ const Pagination = ({
 
   return (
     <nav {...navProps}>
-      <ul className="p-pagination">
+      <ul
+        className={classNames("p-pagination", {
+          "u-align--center": centered,
+        })}
+      >
         <PaginationButton
           key="back"
           direction="back"

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -154,9 +154,9 @@ const Pagination = ({
   };
 
   return (
-    <nav {...navProps}>
-      <ul
-        className={classNames("p-pagination", {
+    <nav className="p-pagination" aria-label="Pagination" {...navProps}>
+      <ol
+        className={classNames("p-pagination__items", {
           "u-align--center": centered,
         })}
       >
@@ -180,7 +180,7 @@ const Pagination = ({
           disabled={currentPage === pageNumbers.length}
           onClick={() => changePage(currentPage + 1)}
         />
-      </ul>
+      </ol>
     </nav>
   );
 };

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Pagination /> renders and matches the snapshot 1`] = `
-<nav>
-  <ul
-    class="p-pagination"
+<nav
+  aria-label="Pagination"
+  class="p-pagination"
+>
+  <ol
+    class="p-pagination__items"
   >
     <li
       class="p-pagination__item"
@@ -85,6 +88,6 @@ exports[`<Pagination /> renders and matches the snapshot 1`] = `
         </i>
       </button>
     </li>
-  </ul>
+  </ol>
 </nav>
 `;


### PR DESCRIPTION
## Done
- Added a `centered` prop to the `Pagination` component
- Update the markup to the [current Vanilla pattern](https://vanillaframework.io/docs/patterns/pagination)

## QA
- Go to https://react-components-880.demos.haus/?path=/story/pagination--default-story
- Toggle the `centered` boolean and check that the pagination is centered when set to `true`
- Go to https://react-components-880.demos.haus/?path=/docs/pagination--default-story#centered
- Check that there is an example of centered pagination