### PR TITLE
fix(List): fix stepped list dom validation error for nested paragraphs

### DIFF
--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, within } from "@testing-library/react";
 import React from "react";
 
 import List from "./List";
+import type { ListItem, SteppedListItem } from "./List";
 
 describe("List ", () => {
-  let items: string[];
+  let items: ListItem[];
 
   beforeEach(() => {
     items = ["test", "items", "here"];
@@ -135,7 +136,7 @@ describe("List ", () => {
 
     it("should render item's content inside <div>", () => {
       // Prepare
-      const items = [{ title: "Title", content: "Content" }];
+      const items: SteppedListItem[] = [{ title: "Title", content: "Content" }];
 
       // Act
       render(<List stepped items={items} />);
@@ -153,7 +154,7 @@ describe("List ", () => {
 
     it("can have several paragraphs in item's content", () => {
       // Prepare
-      const items = [
+      const items: SteppedListItem[] = [
         {
           title: "With two paragraphs of text",
           content: (

--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -78,61 +78,103 @@ describe("List ", () => {
     expect(screen.getAllByRole("listitem")[0]).toHaveClass("is-ticked");
   });
 
-  it("can be stepped", () => {
-    render(
-      <List
-        stepped={true}
-        items={[
-          {
-            title: "Test title",
-            content: "test",
-            className: "item-class",
-            titleElement: "h1",
-          },
-        ]}
-      />
-    );
-    expect(screen.getByRole("list")).toHaveClass("p-stepped-list");
-    const item = screen.getAllByRole("listitem")[0];
-    expect(item).toHaveClass("p-stepped-list__item");
-    expect(within(item).getByText("Test title")).toHaveClass(
-      "p-stepped-list__title"
-    );
-    expect(within(item).getByText("test")).toHaveClass(
-      "p-stepped-list__content"
-    );
-  });
-
-  it("can be detailed stepped", () => {
-    render(
-      <List
-        detailed={true}
-        stepped={true}
-        items={[
-          {
-            title: "Test title",
-            content: "test",
-            className: "item-class",
-            titleElement: "h1",
-          },
-        ]}
-      />
-    );
-    expect(screen.getByRole("list")).toHaveClass("p-stepped-list--detailed");
-    const item = screen.getAllByRole("listitem")[0];
-    expect(item).toHaveClass("p-stepped-list__item");
-    expect(within(item).getByText("Test title")).toHaveClass(
-      "p-stepped-list__title"
-    );
-    expect(within(item).getByText("test")).toHaveClass(
-      "p-stepped-list__content"
-    );
-  });
-
   it("can add additional classes", () => {
     render(<List className="extra-class" items={items} />);
     const list = screen.getByRole("list");
     expect(list).toHaveClass("p-list");
     expect(list).toHaveClass("extra-class");
+  });
+
+  describe("Stepped List ", () => {
+    it("can be stepped", () => {
+      render(
+        <List
+          stepped={true}
+          items={[
+            {
+              title: "Test title",
+              content: "test",
+            },
+          ]}
+        />
+      );
+      expect(screen.getByRole("list")).toHaveClass("p-stepped-list");
+      const item = screen.getAllByRole("listitem")[0];
+      expect(item).toHaveClass("p-stepped-list__item");
+      expect(within(item).getByText("Test title")).toHaveClass(
+        "p-stepped-list__title"
+      );
+      expect(within(item).getByText("test")).toHaveClass(
+        "p-stepped-list__content"
+      );
+    });
+
+    it("can be detailed stepped", () => {
+      render(
+        <List
+          detailed={true}
+          stepped={true}
+          items={[
+            {
+              title: "Test title",
+              content: "test",
+            },
+          ]}
+        />
+      );
+      expect(screen.getByRole("list")).toHaveClass("p-stepped-list--detailed");
+      const item = screen.getAllByRole("listitem")[0];
+      expect(item).toHaveClass("p-stepped-list__item");
+      expect(within(item).getByText("Test title")).toHaveClass(
+        "p-stepped-list__title"
+      );
+      expect(within(item).getByText("test")).toHaveClass(
+        "p-stepped-list__content"
+      );
+    });
+
+    it("should render item's content inside <div>", () => {
+      // Prepare
+      const items = [{ title: "Title", content: "Content" }];
+
+      // Act
+      render(<List stepped items={items} />);
+
+      // Assess
+      const item = screen.getAllByRole("listitem")[0];
+      expect(item).toBeInTheDocument();
+      const divs = within(item).getAllByRole((content, element) => {
+        return (
+          element?.tagName.toLowerCase() === "div" && content === "generic"
+        );
+      });
+      expect(divs).toHaveLength(1);
+    });
+
+    it("can have several paragraphs in item's content", () => {
+      // Prepare
+      const items = [
+        {
+          title: "With two paragraphs of text",
+          content: (
+            <>
+              <p>Paragraph 1</p>
+              <p>Paragraph 2</p>
+            </>
+          ),
+        },
+      ];
+
+      // Act
+      render(<List stepped={true} items={items} />);
+
+      // Assess
+      const item = screen.getAllByRole("listitem")[0];
+      expect(item).toBeInTheDocument();
+      const content = within(item).getAllByRole("generic")[0];
+      expect(content).toBeInTheDocument();
+      const paragraphs = within(content).getAllByText(/Paragraph/);
+      expect(paragraphs).toHaveLength(2);
+    });
   });
 });

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -14,7 +14,7 @@ export type SteppedListItem = {
   content: ReactNode;
   title: ReactNode;
   titleElement?: Headings;
-} & HTMLProps<HTMLLIElement>;
+} & Omit<HTMLProps<HTMLLIElement>, "title" | "content">; // omit global attributes of HTMLProps since they can only be string or undefined
 
 export type Props = {
   /**

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -75,7 +75,7 @@ const generateItems = ({
           <TitleComponent className="p-stepped-list__title">
             {title}
           </TitleComponent>
-          <p className="p-stepped-list__content">{content}</p>
+          <div className="p-stepped-list__content">{content}</div>
         </>
       );
     } else {


### PR DESCRIPTION
## Description of the changes

Hello there! I hope you're doing great!

This PR is intended to fix DOM validation error for the stepped `List` with nested paragraphs.

**Related issues**: #875 #789 

Wrapper HTML element for the content of an item from `<p>` to `<div>`.

**Before changes**

```html
<ol class="p-stepped-list">
    <li class="p-stepped-list__item">
        <h3 class="p-stepped-list__title">Title and content as string</h3>
        <p class="p-stepped-list__content">Content as string</p>
    </li>
</ol>
```

**After changes**

```html
<ol class="p-stepped-list">
    <li class="p-stepped-list__item">
        <h3 class="p-stepped-list__title">Title and content as string</h3>
        <div class="p-stepped-list__content">Content as string</div>
    </li>
</ol>
```

After the change, when you provide one or several paragraphs as `content` it won't be an issue.

```typescript

const items = [
    {
        title: "With two paragraphs of text",
        content: (
            <>
              <p>Paragraph 1</p>
              <p>Paragraph 2</p>
            </>
        ),
    }
];

```

## QA

Unit tests were added for this case, and they pass with no regression on other tests. Linted the code and tests (I would suggest adding a pre-push hook for linting, because there are plenty of warnings in other components).

I checked the storybook: stepped `List` rendered correctly. Packed as a local package, installed in an empty Vite project: it also worked well.

Should I also add a story with this use case to the storybook?

If you have any questions, I would be happy to answer!

**Outside of the scope of this PR**

- I [issued](https://github.com/canonical/vanilla-framework/issues/4656) a bug in `vanilla framework`, that is connected to the stepped `List`.
- There is a problem with the types for `List` items, for the stepped list. Items prop always has the type `ListItem[]`, but supposed to be `SteppedListItem[]`. If you want I can create an issue and we can continue the conversation there.