### PR TITLE
Add onClear prop to SearchBox

### DIFF
--- a/src/components/SearchBox/SearchBox.test.tsx
+++ b/src/components/SearchBox/SearchBox.test.tsx
@@ -88,4 +88,18 @@ describe("SearchBox ", () => {
     await userEvent.click(clearButton);
     expect(searchInput).toHaveFocus();
   });
+
+  it("calls onClear prop when the clear button is clicked", async () => {
+    const handleOnClear = jest.fn();
+    render(
+      <SearchBox
+        externallyControlled
+        onChange={jest.fn()}
+        onClear={handleOnClear}
+        value="admin"
+      />
+    );
+    await userEvent.click(screen.getByRole("button", { name: Label.Clear }));
+    expect(handleOnClear).toBeCalled();
+  });
 });

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -37,6 +37,10 @@ export type Props = PropsWithSpread<
      */
     onSearch?: () => void;
     /**
+     * A function that is called when the user clicks the reset icon
+     */
+    onClear?: () => void;
+    /**
      * A search input placeholder message.
      */
     placeholder?: string;
@@ -65,6 +69,7 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
       externallyControlled,
       onChange,
       onSearch,
+      onClear,
       placeholder = "Search",
       shouldRefocusAfterReset,
       value,
@@ -74,7 +79,8 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
   ): JSX.Element => {
     const internalRef = useRef<HTMLInputElement>();
     const resetInput = () => {
-      onChange && onChange("");
+      onChange?.("");
+      onClear?.();
       if (internalRef.current) {
         internalRef.current.value = "";
         if (shouldRefocusAfterReset) internalRef.current.focus();

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -102,7 +102,7 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
           disabled={disabled}
           id="search"
           name="search"
-          onChange={(evt) => onChange(evt.target.value)}
+          onChange={(evt) => onChange?.(evt.target.value)}
           placeholder={placeholder}
           ref={(input) => {
             internalRef.current = input;


### PR DESCRIPTION
## Done

- Add an optional onClear prop and call it when clear button is clicked

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Type in the SearchBox component
- Provide a function for the `onClear` prop
- Make sure that the function is called when clicking on the reset button
