### PR TITLE
Fix storybook docs add-on

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   stories: ["../src/**/*.stories.@(js|ts|jsx|tsx|mdx)"],
   addons: [
-    "@storybook/addon-docs/preset",
+    "@storybook/addon-docs",
     "@storybook/addon-controls",
     "@storybook/addon-a11y",
   ],


### PR DESCRIPTION
## Done

Seems like I found this fix [long time ago](https://github.com/storybookjs/storybook/issues/18876#issuecomment-1211644672) but somehow didn't push it back then?
Time to fix it now, that we updated storybook dependencies and it got broken again…

## QA

Go to storybook (https://react-components-889.demos.haus/?path=/story/accordion--default-story) and make sure Docs tab is available:

<img width="588" alt="image" src="https://user-images.githubusercontent.com/83575/219694793-1ad378df-41f7-457e-978d-9812b6a64e6d.png">

