### PR TITLE
fix: render tooltip only when open

### DIFF
--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -36,12 +36,13 @@ describe("Tooltip", () => {
     expect(screen.getByRole("link", { name: "Canonical" })).toHaveFocus();
   });
 
-  it("adds a description to the wrapped element", () => {
+  it("adds a description to the wrapped element", async () => {
     render(
       <Tooltip message="Additional description">
         <button>open the tooltip</button>
       </Tooltip>
     );
+    await userEvent.tab();
     expect(
       screen.getByRole("button", { name: /open the tooltip/ })
     ).toHaveAccessibleDescription("Additional description");
@@ -78,22 +79,23 @@ describe("Tooltip", () => {
   });
 
   it("does not show tooltip message by default", () => {
-    render(<Tooltip message="text">Child</Tooltip>);
-    expect(screen.getByTestId("tooltip-portal")).toHaveClass("u-off-screen");
+    render(<Tooltip message="tooltip text">Child</Tooltip>);
+    expect(screen.queryByText("tooltip text")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tooltip-portal")).not.toBeInTheDocument();
   });
 
   it("renders tooltip message on focus", async () => {
     render(
-      <Tooltip message="text">
+      <Tooltip message="tooltip text">
         <button>open the tooltip</button>
       </Tooltip>
     );
 
-    expect(screen.getByTestId("tooltip-portal")).toHaveClass("u-off-screen");
+    expect(screen.queryByTestId("tooltip-portal")).not.toBeInTheDocument();
+    expect(screen.queryByText("tooltip text")).not.toBeInTheDocument();
     await userEvent.tab();
-    expect(screen.getByTestId("tooltip-portal")).not.toHaveClass(
-      "u-off-screen"
-    );
+    expect(screen.getByTestId("tooltip-portal")).toBeInTheDocument();
+    expect(screen.getByText("tooltip text")).toBeInTheDocument();
   });
 
   it("updates the tooltip to fit on the screen", async () => {
@@ -114,25 +116,33 @@ describe("Tooltip", () => {
     expect(screen.getByTestId("tooltip-portal")).toHaveClass("is-detached");
   });
 
-  it("gives the correct class name to the tooltip", () => {
+  it("gives the correct class name to the tooltip", async () => {
+    // ensure the tooltip fits in the window and the positioning className remains unchanged
+    global.innerWidth = 500;
     render(
       <Tooltip message="text" position="right">
         <button>open the tooltip</button>
       </Tooltip>
     );
 
+    await userEvent.hover(
+      screen.getByRole("button", { name: "open the tooltip" })
+    );
     expect(screen.getByTestId("tooltip-portal")).toHaveClass(
       "p-tooltip--right"
     );
   });
 
-  it("assigns the correct z-index to the correct element", () => {
+  it("assigns the correct z-index to the correct element", async () => {
     render(
       <Tooltip message="text" zIndex={999}>
         <button>open the tooltip</button>
       </Tooltip>
     );
 
+    await userEvent.hover(
+      screen.getByRole("button", { name: "open the tooltip" })
+    );
     expect(screen.getByRole("tooltip")).toHaveStyle("z-index: 999");
   });
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -313,33 +313,29 @@ const Tooltip = ({
                 : child
             )}
           </span>
-          <Portal>
-            <span
-              className={classNames(
-                `p-tooltip--${adjustedPosition}`,
-                "is-detached",
-                { "u-off-screen": !isOpen },
-                tooltipClassName
-              )}
-              data-testid="tooltip-portal"
-              style={positionStyle as React.CSSProperties}
-              // style={
-              //   isOpen
-              //     ? (positionStyle as React.CSSProperties)
-              //     : { left: -9999 }
-              // }
-            >
+          {isOpen ? (
+            <Portal>
               <span
-                role="tooltip"
-                className="p-tooltip__message"
-                ref={messageRef}
-                id={tooltipId}
-                style={{ zIndex: zIndex }}
+                className={classNames(
+                  `p-tooltip--${adjustedPosition}`,
+                  "is-detached",
+                  tooltipClassName
+                )}
+                data-testid="tooltip-portal"
+                style={positionStyle as React.CSSProperties}
               >
-                {message}
+                <span
+                  role="tooltip"
+                  className="p-tooltip__message"
+                  ref={messageRef}
+                  id={tooltipId}
+                  style={{ zIndex: zIndex }}
+                >
+                  {message}
+                </span>
               </span>
-            </span>
-          </Portal>
+            </Portal>
+          ) : null}
         </span>
       ) : (
         <span className={className}>{children}</span>


### PR DESCRIPTION
## Done

- fix: render tooltip only when open
- this change removes the tooltip elements from the DOM when not open

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open the demo
- Make sure the tooltip works exactly the same way as before

## Fixes

Fixes: https://github.com/canonical/react-components/issues/897
