### PR TITLE
Notifications: allow override of title element, as the h5 might disturb the heading hierarchy

### DIFF
--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useEffect, useRef } from "react";
+import React, { ElementType, useEffect, useRef } from "react";
 import type { HTMLProps, ReactNode } from "react";
 
 import Button, { ButtonAppearance } from "../Button";
@@ -77,6 +77,10 @@ export type Props = PropsWithSpread<
      */
     title?: ReactNode;
     /**
+     * Optional element or component to use for the title.
+     */
+    titleElement?: ElementType;
+    /**
      * **Deprecated**. Use `severity` instead.
      */
     type?: never;
@@ -97,6 +101,7 @@ const Notification = ({
   timeout,
   timestamp,
   title,
+  titleElement: TitleComponent = "h5",
   type,
   ...props
 }: Props): JSX.Element => {
@@ -129,12 +134,12 @@ const Notification = ({
     >
       <div className="p-notification__content">
         {title && (
-          <h5
+          <TitleComponent
             className="p-notification__title"
             data-testid="notification-title"
           >
             {title}
-          </h5>
+          </TitleComponent>
         )}
         {inline && <>&ensp;</>}
         <p className="p-notification__message">{children}</p>


### PR DESCRIPTION
## Done

- Make the wrapper tag for Notification title configurable. The default `h5` might disturb the heading hierarchy of the page.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- check that notifications still render the same as before
