### PR TITLE
Fix wrong links

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.stories.mdx
+++ b/src/components/CheckboxInput/CheckboxInput.stories.mdx
@@ -39,7 +39,7 @@ export const Template = (args) => <CheckboxInput {...args} />;
 
 ### CheckboxInput
 
-This is a [React](https://reactjs.org/) component for the Vanilla [Checkbox input](https://docs.vanillaframework.io/docs/base/forms#checkbox).
+This is a [React](https://reactjs.org/) component for the Vanilla [Checkbox input](https://docs.vanillaframework.io/base/forms#checkbox).
 
 Use the checkbox component to select one or more options.
 

--- a/src/components/RadioInput/RadioInput.stories.mdx
+++ b/src/components/RadioInput/RadioInput.stories.mdx
@@ -37,7 +37,7 @@ import RadioInput from "./RadioInput";
 
 ### RadioInput
 
-This is a [React](https://reactjs.org/) component for the Vanilla [Radio input](https://docs.vanillaframework.io/docs/base/forms#radio-button).
+This is a [React](https://reactjs.org/) component for the Vanilla [Radio input](https://docs.vanillaframework.io/base/forms#radio-button).
 
 Use radio buttons to select one of the given set of options.
 


### PR DESCRIPTION
## Done

- Fixed two links that seem to be wrong on react-component [radio input](https://canonical.github.io/react-components/?path=/docs/radioinput--default-story) page and [checkbox input](https://canonical.github.io/react-components/?path=/docs/checkboxinput--default-story) page. 

## QA
Go to those page above in demo and click "Checkbox input" and "Radio input"
<img width="467" alt="image" src="https://user-images.githubusercontent.com/57550290/225615802-0caa3c7b-0812-4943-8ef7-6f0e57de5c12.png">

Fixes https://github.com/canonical/react-components/issues/904