### PR TITLE
Scroll the search and filter dropdown

### DIFF
--- a/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.test.tsx
@@ -17,15 +17,39 @@ describe("ContextualMenuDropdown ", () => {
   describe("adjustForWindow", () => {
     const generateFits = (overrides = {}) => {
       const fits = {
-        fromTop: { fitsAbove: true, fitsBelow: true },
-        fromBottom: { fitsAbove: true, fitsBelow: true },
-        fromLeft: { fitsLeft: true, fitsRight: true },
-        fromRight: { fitsLeft: true, fitsRight: true },
+        fromTop: {
+          fitsAbove: true,
+          fitsBelow: true,
+          spaceAbove: 0,
+          spaceBelow: 768,
+        },
+        fromBottom: {
+          fitsAbove: true,
+          fitsBelow: true,
+          spaceAbove: 0,
+          spaceBelow: 768,
+        },
+        fromLeft: {
+          fitsLeft: true,
+          fitsRight: true,
+          spaceLeft: 0,
+          spaceRight: 1024,
+        },
+        fromRight: {
+          fitsLeft: true,
+          fitsRight: true,
+          spaceLeft: 0,
+          spaceRight: 1024,
+        },
         fromCenter: {
           fitsLeft: true,
           fitsRight: true,
           fitsAbove: true,
           fitsBelow: true,
+          spaceLeft: 0,
+          spaceRight: 1024,
+          spaceAbove: 0,
+          spaceBelow: 768,
           fitsCentered: {
             fitsLeft: true,
             fitsRight: true,

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -294,7 +294,7 @@ const SearchAndFilter = ({
           className="p-search-and-filter__panel"
           aria-hidden={filterPanelHidden}
           ref={panel}
-          style={{ maxHeight, overflowX: "auto" }}
+          style={{ maxHeight, minHeight: "5rem", overflowX: "auto" }}
         >
           <div>
             {searchTerm.length > 0 && (

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -4,7 +4,7 @@ import FilterPanelSection from "./FilterPanelSection";
 import Chip from "../Chip";
 import { overflowingChipsCount, isChipInArray } from "./utils";
 import type { SearchAndFilterChip, SearchAndFilterData } from "./types";
-import { useOnEscapePressed } from "hooks";
+import { useOnEscapePressed, useWindowFitment } from "hooks";
 
 export enum Label {
   AddFilter = "Add filter",
@@ -39,10 +39,12 @@ const SearchAndFilter = ({
   const [searchBoxExpanded, setSearchBoxExpanded] = useState(false);
   const [overflowSearchTermCounter, setOverflowSearchTermCounter] = useState(0);
   const [searchContainerActive, setSearchContainerActive] = useState(false);
+  const [maxHeight, setMaxHeight] = useState<number>();
 
   const searchAndFilterRef = useRef(null);
   const searchContainerRef = useRef(null);
   const searchBoxRef = useRef(null);
+  const panel = useRef();
 
   // Return searchData to parent component
   useEffect(() => {
@@ -177,6 +179,14 @@ const SearchAndFilter = ({
     };
   }, [searchData]);
 
+  useWindowFitment(
+    panel.current,
+    searchAndFilterRef.current,
+    (fitsWindow) => setMaxHeight(fitsWindow.fromBottom.spaceBelow - 16),
+    0,
+    !filterPanelHidden
+  );
+
   // Add search prompt value to search on Enter key
   const searchPromptKeyDown = (e) => {
     if (e.key === "Enter") {
@@ -283,6 +293,8 @@ const SearchAndFilter = ({
         <div
           className="p-search-and-filter__panel"
           aria-hidden={filterPanelHidden}
+          ref={panel}
+          style={{ maxHeight, overflowX: "auto" }}
         >
           <div>
             {searchTerm.length > 0 && (

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -139,15 +139,39 @@ describe("Tooltip", () => {
   describe("adjustForWindow", () => {
     const generateFits = (overrides = {}) => {
       const fits = {
-        fromTop: { fitsAbove: true, fitsBelow: true },
-        fromBottom: { fitsAbove: true, fitsBelow: true },
-        fromLeft: { fitsLeft: true, fitsRight: true },
-        fromRight: { fitsLeft: true, fitsRight: true },
+        fromTop: {
+          fitsAbove: true,
+          fitsBelow: true,
+          spaceAbove: 0,
+          spaceBelow: 768,
+        },
+        fromBottom: {
+          fitsAbove: true,
+          fitsBelow: true,
+          spaceAbove: 0,
+          spaceBelow: 768,
+        },
+        fromLeft: {
+          fitsLeft: true,
+          fitsRight: true,
+          spaceLeft: 0,
+          spaceRight: 1024,
+        },
+        fromRight: {
+          fitsLeft: true,
+          fitsRight: true,
+          spaceLeft: 0,
+          spaceRight: 1024,
+        },
         fromCenter: {
           fitsLeft: true,
           fitsRight: true,
           fitsAbove: true,
           fitsBelow: true,
+          spaceLeft: 0,
+          spaceRight: 1024,
+          spaceAbove: 0,
+          spaceBelow: 768,
           fitsCentered: {
             fitsLeft: true,
             fitsRight: true,

--- a/src/hooks/useWindowFitment.test.ts
+++ b/src/hooks/useWindowFitment.test.ts
@@ -13,15 +13,39 @@ describe("useWindowFitment", () => {
     targetNode = document.createElement("div");
     referenceNode = document.createElement("div");
     fits = {
-      fromTop: { fitsAbove: false, fitsBelow: true },
-      fromBottom: { fitsAbove: false, fitsBelow: true },
-      fromLeft: { fitsLeft: false, fitsRight: true },
-      fromRight: { fitsLeft: false, fitsRight: true },
+      fromTop: {
+        fitsAbove: false,
+        fitsBelow: true,
+        spaceAbove: 0,
+        spaceBelow: 768,
+      },
+      fromBottom: {
+        fitsAbove: false,
+        fitsBelow: true,
+        spaceAbove: 0,
+        spaceBelow: 768,
+      },
+      fromLeft: {
+        fitsLeft: false,
+        fitsRight: true,
+        spaceLeft: 0,
+        spaceRight: 1024,
+      },
+      fromRight: {
+        fitsLeft: false,
+        fitsRight: true,
+        spaceLeft: 0,
+        spaceRight: 1024,
+      },
       fromCenter: {
         fitsLeft: false,
         fitsRight: true,
         fitsAbove: false,
         fitsBelow: true,
+        spaceLeft: 0,
+        spaceRight: 1024,
+        spaceAbove: 0,
+        spaceBelow: 768,
         fitsCentered: {
           fitsLeft: false,
           fitsRight: true,
@@ -54,15 +78,39 @@ describe("useWindowFitment", () => {
       } as DOMRect);
     renderHook(() => useWindowFitment(targetNode, referenceNode, callback));
     expect(callback).toHaveBeenCalledWith({
-      fromTop: { fitsAbove: true, fitsBelow: true },
-      fromBottom: { fitsAbove: true, fitsBelow: true },
-      fromLeft: { fitsLeft: true, fitsRight: true },
-      fromRight: { fitsLeft: true, fitsRight: true },
+      fromTop: {
+        fitsAbove: true,
+        fitsBelow: true,
+        spaceAbove: 20,
+        spaceBelow: 748,
+      },
+      fromBottom: {
+        fitsAbove: true,
+        fitsBelow: true,
+        spaceAbove: 30,
+        spaceBelow: 738,
+      },
+      fromLeft: {
+        fitsLeft: true,
+        fitsRight: true,
+        spaceLeft: 20,
+        spaceRight: 1004,
+      },
+      fromRight: {
+        fitsLeft: true,
+        fitsRight: true,
+        spaceLeft: 30,
+        spaceRight: 994,
+      },
       fromCenter: {
         fitsLeft: true,
         fitsRight: true,
         fitsAbove: true,
         fitsBelow: true,
+        spaceAbove: 25,
+        spaceBelow: 743,
+        spaceLeft: 25,
+        spaceRight: 999,
         fitsCentered: {
           fitsLeft: true,
           fitsRight: true,
@@ -85,15 +133,39 @@ describe("useWindowFitment", () => {
     global.innerWidth = 10;
     renderHook(() => useWindowFitment(targetNode, referenceNode, callback));
     expect(callback).toHaveBeenCalledWith({
-      fromTop: { fitsAbove: false, fitsBelow: false },
-      fromBottom: { fitsAbove: false, fitsBelow: false },
-      fromLeft: { fitsLeft: false, fitsRight: false },
-      fromRight: { fitsLeft: false, fitsRight: false },
+      fromTop: {
+        fitsAbove: false,
+        fitsBelow: false,
+        spaceAbove: 0,
+        spaceBelow: 10,
+      },
+      fromBottom: {
+        fitsAbove: false,
+        fitsBelow: false,
+        spaceAbove: 0,
+        spaceBelow: 10,
+      },
+      fromLeft: {
+        fitsLeft: false,
+        fitsRight: false,
+        spaceLeft: 0,
+        spaceRight: 10,
+      },
+      fromRight: {
+        fitsLeft: false,
+        fitsRight: false,
+        spaceLeft: 0,
+        spaceRight: 10,
+      },
       fromCenter: {
         fitsLeft: false,
         fitsRight: false,
         fitsAbove: false,
         fitsBelow: false,
+        spaceAbove: 0,
+        spaceBelow: 10,
+        spaceLeft: 0,
+        spaceRight: 10,
         fitsCentered: {
           fitsLeft: false,
           fitsRight: false,

--- a/src/hooks/useWindowFitment.ts
+++ b/src/hooks/useWindowFitment.ts
@@ -10,6 +10,12 @@ export type WindowFitment = {
     // Whether the target element fits between the top edge of the reference
     // element and the bottom edge of the window.
     fitsBelow: boolean;
+    // The available space between the top edge of the reference
+    // element and the top edge of the window.
+    spaceAbove: number;
+    // The available space between the top edge of the reference
+    // element and the bottom edge of the window.
+    spaceBelow: number;
   };
   fromBottom: {
     // Whether the target element fits between the bottom edge of the reference
@@ -18,6 +24,12 @@ export type WindowFitment = {
     // Whether the target element fits between the bottom edge of the reference
     // element and the bottom edge of the window.
     fitsBelow: boolean;
+    // The available space between the bottom edge of the reference
+    // element and the top edge of the window.
+    spaceAbove: number;
+    // The available space between the bottom edge of the reference
+    // element and the bottom edge of the window.
+    spaceBelow: number;
   };
   fromLeft: {
     // Whether the target element fits between the left edge of the reference
@@ -26,6 +38,12 @@ export type WindowFitment = {
     // Whether the target element fits between the left edge of the reference
     // element and the right edge of the window.
     fitsRight: boolean;
+    // The available space between the left edge of the reference
+    // element and the left edge of the window.
+    spaceLeft: number;
+    // The available space between the left edge of the reference
+    // element and the right edge of the window.
+    spaceRight: number;
   };
   fromRight: {
     // Whether the target element fits between the right edge of the reference
@@ -34,6 +52,12 @@ export type WindowFitment = {
     // Whether the target element fits between the right edge of the reference
     // element and the right edge of the window.
     fitsRight: boolean;
+    // The available space between the right edge of the reference
+    // element and the left edge of the window.
+    spaceLeft: number;
+    // The available space between the right edge of the reference
+    // element and the right edge of the window.
+    spaceRight: number;
   };
   fromCenter: {
     // Whether the target element fits between the horizontal center of the
@@ -48,6 +72,18 @@ export type WindowFitment = {
     // Whether the target element fits between the vertical center of the
     // reference element and the bottom edge of the window.
     fitsBelow: boolean;
+    // The available space between the horizontal center of the
+    // reference element and the left edge of the window.
+    spaceLeft: number;
+    // The available space between the horizontal center of the
+    // reference element and the right edge of the window.
+    spaceRight: number;
+    // The available space between the vertical center of the
+    // reference element and the top edge of the window.
+    spaceAbove: number;
+    // The available space between the vertical center of the
+    // reference element and the bottom edge of the window.
+    spaceBelow: number;
     fitsCentered: {
       // Whether the top half of the target element fits between the vertical
       // center of the reference element and the top edge of the window.
@@ -134,24 +170,36 @@ export const useWindowFitment = (
           fromTop: {
             fitsAbove: referenceTop - heightIncludingSpace > windowTop,
             fitsBelow: referenceTop + heightIncludingSpace < windowBottom,
+            spaceAbove: Math.abs(windowTop - referenceTop),
+            spaceBelow: windowBottom - referenceTop,
           },
           fromBottom: {
             fitsAbove: referenceBottom - heightIncludingSpace > windowTop,
             fitsBelow: referenceBottom + heightIncludingSpace < windowBottom,
+            spaceAbove: Math.abs(windowTop - referenceBottom),
+            spaceBelow: windowBottom - referenceBottom,
           },
           fromLeft: {
             fitsLeft: referenceLeft - widthIncludingSpace > windowLeft,
             fitsRight: referenceLeft + widthIncludingSpace < windowRight,
+            spaceLeft: Math.abs(windowLeft - referenceLeft),
+            spaceRight: windowRight - referenceLeft,
           },
           fromRight: {
             fitsLeft: referenceRight - widthIncludingSpace > windowLeft,
             fitsRight: referenceRight + widthIncludingSpace < windowRight,
+            spaceLeft: Math.abs(windowLeft - referenceRight),
+            spaceRight: windowRight - referenceRight,
           },
           fromCenter: {
             fitsLeft: referenceCenterX - widthIncludingSpace > windowLeft,
             fitsRight: referenceCenterX + widthIncludingSpace < windowRight,
             fitsAbove: referenceCenterY - heightIncludingSpace > windowTop,
             fitsBelow: referenceCenterY + heightIncludingSpace < windowBottom,
+            spaceAbove: Math.abs(windowTop - referenceCenterY),
+            spaceBelow: windowBottom - referenceCenterY,
+            spaceLeft: Math.abs(windowLeft - referenceCenterX),
+            spaceRight: windowRight - referenceCenterX,
             fitsCentered: {
               fitsLeft: referenceCenterX - widthFromCenter > windowLeft,
               fitsRight: referenceCenterX + widthFromCenter < windowRight,


### PR DESCRIPTION
## Done

- Constrain the search and filter dropdown to stay within the viewport.

## QA

### QA steps

- View the search and filter dropdown [default story in isolation](https://react-components-906.demos.haus/iframe.html?args=&id=search-and-filter--default-story&viewMode=story).
- Click on the input to open the dropdown.
- Resize your window so that the entire dropdown doesn't fit.
- The dropdown should resize so that it doesn't get cut off and the contents should scroll.

## Fixes

Fixes: https://github.com/canonical/jaas-dashboard/issues/707.

## Screenshots

![Screen Recording 2023-03-20 at 4 27 18 pm](https://user-images.githubusercontent.com/361637/226262184-8c78af15-b3dd-411c-b951-0979664d797f.gif)

