### PR TITLE
Add sub-rows to ModularTable

### DIFF
--- a/src/components/ModularTable/ModularTable.stories.mdx
+++ b/src/components/ModularTable/ModularTable.stories.mdx
@@ -205,24 +205,24 @@ columns = {
           {
             Header: "ID",
             accessor: "buildId",
-            sortType: 'basic',
+            sortType: "basic",
             Cell: ({ value }) => <a href="#">#{value}</a>,
           },
           {
             Header: "Architecture",
             accessor: "arch",
-            sortType: 'basic',
+            sortType: "basic",
           },
           {
             Header: "Build Duration",
             accessor: "duration",
             className: "u-hide--small",
-            sortType: 'basic',
+            sortType: "basic",
           },
           {
             Header: "Result",
             accessor: "result",
-            sortType: 'basic',
+            sortType: "basic",
             Cell: ({ value }) => {
               switch (value) {
                 case "released":
@@ -248,7 +248,7 @@ columns = {
             Header: "Build Finished",
             accessor: "finished",
             className: "u-align-text--right",
-            sortType: 'basic',
+            sortType: "basic",
           },
         ],
         []
@@ -275,6 +275,90 @@ columns = {
             duration: "1 minute",
             result: "other",
             finished: "ages ago",
+          },
+        ],
+        []
+      )}
+    />
+  </Story>
+</Preview>
+
+### Subrows
+
+Subrows can be used to group table rows under a heading that needs to appear
+at the start of the group. In the following example sorting the columns will
+sort the group rows, then sort the sub-rows, but the group header always comes first.
+
+<Preview>
+  <Story name="Subrows">
+    <ModularTable
+      sortable
+      columns={React.useMemo(
+        () => [
+          {
+            Header: "Flavour",
+            accessor: "flavour",
+            sortType: "basic",
+            Cell: (props) =>
+              props.row.depth === 0 ? (
+                <strong>{props.value}</strong>
+              ) : (
+                <>
+                  <input type="checkbox" /> {props.value}
+                </>
+              ),
+          },
+          {
+            Header: "Scoops",
+            accessor: "scoops",
+            sortType: "basic",
+            Cell: (props) =>
+              props.row.depth === 0 ? (
+                <span className="u-text--muted">{props.value}</span>
+              ) : (
+                props.value
+              ),
+          },
+        ],
+        []
+      )}
+      data={React.useMemo(
+        () => [
+          {
+            flavour: "Sorbet",
+            scoops: "1-2",
+            subRows: [
+              {
+                flavour: "Lemon",
+                scoops: 2,
+              },
+              {
+                flavour: "Mango",
+                scoops: 1,
+              },
+              {
+                flavour: "Raspberry",
+                scoops: 2,
+              },
+            ],
+          },
+          {
+            flavour: "Ice-cream",
+            scoops: "1-3",
+            subRows: [
+              {
+                flavour: "Chocolate",
+                scoops: 1,
+              },
+              {
+                flavour: "Vanilla",
+                scoops: 3,
+              },
+              {
+                flavour: "Caramel",
+                scoops: 2,
+              },
+            ],
           },
         ],
         []

--- a/src/components/ModularTable/ModularTable.test.tsx
+++ b/src/components/ModularTable/ModularTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import ModularTable from "./ModularTable";
@@ -10,6 +11,7 @@ const columns = [
     Header: "Cores",
     className: "u-align--right",
     sortType: "alphanumeric",
+    title: "Cores",
   },
   {
     accessor: "ram",
@@ -24,7 +26,7 @@ const columns = [
     sortType: "alphanumeric",
   },
 ];
-const data = [
+const data: Record<string, unknown>[] = [
   {
     status: "Ready",
     cores: 1,
@@ -78,6 +80,104 @@ it("renders all cells with a correct content", async () => {
       expect(cell.textContent).toEqual(`${rowData[columnAccessor]}`);
     });
   });
+});
+
+it("renders subrows", async () => {
+  const data: Record<string, unknown>[] = [
+    {
+      status: "Ready",
+      cores: 1,
+      ram: "1 GiB",
+      disks: 2,
+      subRows: [
+        {
+          status: "Waiting",
+          cores: 1,
+          ram: "1 GiB",
+          disks: 2,
+        },
+      ],
+    },
+    {
+      status: "Idle",
+      cores: 8,
+      ram: "3.9 GiB",
+      disks: 3,
+    },
+  ];
+  render(<ModularTable columns={columns} data={data} />);
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+  const rowItems = within(tableBody).getAllByRole("row");
+  expect(rowItems).toHaveLength(3);
+  expect(within(rowItems[0]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Ready"
+  );
+  expect(within(rowItems[1]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Waiting"
+  );
+  expect(within(rowItems[2]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Idle"
+  );
+});
+
+it("sorts group headers then sub-rows", async () => {
+  const data: Record<string, unknown>[] = [
+    {
+      status: "Ready",
+      cores: 3,
+      ram: "1 GiB",
+      disks: 2,
+      subRows: [
+        {
+          status: "Waiting",
+          cores: 4,
+          ram: "1 GiB",
+          disks: 2,
+        },
+        {
+          status: "Error",
+          cores: 2,
+          ram: "1 GiB",
+          disks: 2,
+        },
+      ],
+    },
+    {
+      status: "Idle",
+      cores: 1,
+      ram: "3.9 GiB",
+      disks: 3,
+    },
+  ];
+  render(<ModularTable columns={columns} data={data} sortable />);
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+  let rowItems = within(tableBody).getAllByRole("row");
+  expect(within(rowItems[0]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Ready"
+  );
+  expect(within(rowItems[1]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Waiting"
+  );
+  expect(within(rowItems[2]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Error"
+  );
+  expect(within(rowItems[3]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Idle"
+  );
+  await userEvent.click(screen.getByRole("columnheader", { name: "Cores" }));
+  rowItems = within(tableBody).getAllByRole("row");
+  expect(within(rowItems[0]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Idle"
+  );
+  expect(within(rowItems[1]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Ready"
+  );
+  expect(within(rowItems[2]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Error"
+  );
+  expect(within(rowItems[3]).queryAllByRole("cell")[0]).toHaveTextContent(
+    "Waiting"
+  );
 });
 
 it("renders no rows when data is empty", () => {


### PR DESCRIPTION
## Done

- Added support for the React Table [subRows prop](https://react-table-v7.tanstack.com/docs/api/useTable#row-properties). It was previously possible to pass in this prop, but it didn't do anything.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to the new [subrows example in Storyboard](/?path=/docs/modulartable--subrows).
- Check that you can sort the rows and that the subrows sort within the groups.

## Fixes

This will be used to support sorting the grouped action log rows in Juju Dashboard: https://github.com/canonical/jaas-dashboard/issues/1033.
