### PR TITLE
Fix tooltip click propagation

### DIFF
--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -78,6 +78,48 @@ describe("Tooltip", () => {
     expect(clickHandler).toHaveBeenCalled();
   });
 
+  it("does not propogate clicks on the tooltip message to the parent", async () => {
+    const parentClick = jest.fn();
+    render(
+      <div onClick={parentClick}>
+        <Tooltip message="a message">
+          <button>open the tooltip</button>
+        </Tooltip>
+      </div>
+    );
+    await userEvent.hover(screen.getByRole("button"));
+    await userEvent.click(screen.getByRole("tooltip"));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it("does not propogate clicks in the tooltip's children to the parent", async () => {
+    const parentClick = jest.fn();
+    render(
+      <div onClick={parentClick}>
+        <Tooltip
+          message={
+            <>
+              Additional information{" "}
+              <a
+                href="example.com"
+                onClick={(event) => {
+                  event.preventDefault();
+                }}
+              >
+                Canonical
+              </a>
+            </>
+          }
+        >
+          <button>open the tooltip</button>
+        </Tooltip>
+      </div>
+    );
+    await userEvent.hover(screen.getByRole("button"));
+    await userEvent.click(screen.getByRole("link", { name: "Canonical" }));
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
   it("does not show tooltip message by default", () => {
     render(<Tooltip message="tooltip text">Child</Tooltip>);
     expect(screen.queryByText("tooltip text")).not.toBeInTheDocument();

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -327,6 +327,11 @@ const Tooltip = ({
                 <span
                   role="tooltip"
                   className="p-tooltip__message"
+                  onClick={(event) => {
+                    // Prevent clicks inside the message from bubbling to parent
+                    // click handlers.
+                    event.stopPropagation();
+                  }}
                   ref={messageRef}
                   id={tooltipId}
                   style={{ zIndex: zIndex }}


### PR DESCRIPTION
## Done

- Prevent clicks on the tooltip message from propagating to parent click handlers.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to the tooltip stories and add `onClick={() => console.log("parent clicked")}` to the wrapping template div: https://github.com/canonical/react-components/blob/main/src/components/Tooltip/Tooltip.stories.mdx?plain=1#L20.
- Open storybook and go to the tooltip story.
- Hover the button and then click the tooltip or the link inside the tooltip.
- The "parent clicked" message should not get logged.

## Fixes

Fixes: #911.
