### PR TITLE
Fix table sorting

### DIFF
--- a/src/components/MainTable/MainTable.stories.mdx
+++ b/src/components/MainTable/MainTable.stories.mdx
@@ -86,6 +86,7 @@ This is a [React](https://reactjs.org/) component to support many table use case
         { content: "Cores", sortKey: "cores", className: "u-align--right" },
         { content: "RAM", sortKey: "ram", className: "u-align--right" },
         { content: "Disks", sortKey: "disks", className: "u-align--right" },
+        { content: "Networks", className: "u-align--right" },
       ]}
       rows={[
         {
@@ -94,6 +95,7 @@ This is a [React](https://reactjs.org/) component to support many table use case
             { content: 1, className: "u-align--right" },
             { content: "1 GiB", className: "u-align--right" },
             { content: 2, className: "u-align--right" },
+            { content: 42, className: "u-align--right" },
           ],
           sortData: {
             status: "ready",
@@ -108,6 +110,7 @@ This is a [React](https://reactjs.org/) component to support many table use case
             { content: 1, className: "u-align--right" },
             { content: "1 GiB", className: "u-align--right" },
             { content: 2, className: "u-align--right" },
+            { content: 23, className: "u-align--right" },
           ],
           sortData: {
             status: "idle",
@@ -122,6 +125,7 @@ This is a [React](https://reactjs.org/) component to support many table use case
             { content: 8, className: "u-align--right" },
             { content: "3.9 GiB", className: "u-align--right" },
             { content: 3, className: "u-align--right" },
+            { content: 0, className: "u-align--right" },
           ],
           sortData: {
             status: "waiting",

--- a/src/components/MainTable/MainTable.test.tsx
+++ b/src/components/MainTable/MainTable.test.tsx
@@ -156,21 +156,17 @@ describe("MainTable", () => {
     beforeEach(() => {
       headers[0].sortKey = "status";
       headers[1].sortKey = "cores";
-      headers[2].sortKey = "ram";
       rows[0].sortData = {
         status: "ready",
         cores: 2,
-        ram: 1,
       };
       rows[1].sortData = {
         status: "waiting",
         cores: 1,
-        ram: 1,
       };
       rows[2].sortData = {
         status: "idle",
         cores: 8,
-        ram: 3.9,
       };
     });
 
@@ -249,6 +245,38 @@ describe("MainTable", () => {
       expect(within(rowItems[3]).getByRole("rowheader").textContent).toBe(
         "Idle"
       );
+    });
+
+    it("keeps sorting when clicking a non-sortable header", async () => {
+      render(<MainTable headers={headers} rows={rows} sortable={true} />);
+      const rowItems = screen.getAllByRole("row");
+      await userEvent.click(
+        screen.getByRole("columnheader", { name: "Status" })
+      );
+
+      const expectedOrder = ["Idle", "Ready", "Waiting"];
+      // The status should now be ascending.
+      for (let i = 1; i < 4; i++) {
+        expect(within(rowItems[i]).getByRole("rowheader").textContent).toBe(
+          expectedOrder[i - 1]
+        );
+      }
+
+      await userEvent.click(screen.getByRole("columnheader", { name: "RAM" }));
+      // The status should not change
+      for (let i = 1; i < 4; i++) {
+        expect(within(rowItems[i]).getByRole("rowheader").textContent).toBe(
+          expectedOrder[i - 1]
+        );
+      }
+
+      await userEvent.click(screen.getByRole("columnheader", { name: "RAM" }));
+      // The status should not change
+      for (let i = 1; i < 4; i++) {
+        expect(within(rowItems[i]).getByRole("rowheader").textContent).toBe(
+          expectedOrder[i - 1]
+        );
+      }
     });
 
     it("can set a default sort", () => {

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -168,7 +168,7 @@ const generateHeaders = (
         key={index}
         sort={sortDirection}
         onClick={
-          sortable
+          sortable && sortKey
             ? updateSort.bind(
                 this,
                 setSortKey,


### PR DESCRIPTION
## Done

- When clicking a `MainTable` heading that is not sortable, we used to reset to no sorting. Fixed that.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Try sorting a [main table](https://react-components-913.demos.haus/?path=/story/maintable--sortable) and click on headers that are sortable and not-sortable by. The network columns is not sortable and clicking it should not change the sort direction. This used to be broken before.