### PR TITLE
Add default sort to ModularTable

### DIFF
--- a/src/components/ModularTable/ModularTable.stories.mdx
+++ b/src/components/ModularTable/ModularTable.stories.mdx
@@ -197,6 +197,8 @@ columns = {
   <Story name="Sortable">
     <ModularTable
       sortable
+      initialSortColumn="duration"
+      initialSortDirection="ascending"
       getCellProps={({ value }) => ({
         className: value === "1 minute" ? "p-heading--5" : "",
       })}

--- a/src/components/ModularTable/ModularTable.test.tsx
+++ b/src/components/ModularTable/ModularTable.test.tsx
@@ -82,6 +82,24 @@ it("renders all cells with a correct content", async () => {
   });
 });
 
+it("can set a default sort", async () => {
+  render(
+    <ModularTable
+      columns={columns}
+      data={data}
+      initialSortColumn="disks"
+      initialSortDirection="descending"
+      sortable
+    />
+  );
+  const tableBody = screen.getAllByRole("rowgroup")[1];
+  const rowItems = within(tableBody).getAllByRole("row");
+  expect(rowItems).toHaveLength(3);
+  expect(within(rowItems[0]).queryAllByRole("cell")[3]).toHaveTextContent("3");
+  expect(within(rowItems[1]).queryAllByRole("cell")[3]).toHaveTextContent("2");
+  expect(within(rowItems[2]).queryAllByRole("cell")[3]).toHaveTextContent("2");
+});
+
 it("renders subrows", async () => {
   const data: Record<string, unknown>[] = [
     {

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, HTMLProps } from "react";
+import React, { ReactNode, HTMLProps, useMemo } from "react";
 import {
   TableCellProps,
   TableHeaderProps,
@@ -61,6 +61,8 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
       cell: Cell<D>
     ) => Partial<TableCellProps & HTMLProps<HTMLTableCellElement>>;
     getRowId?: UseTableOptions<D>["getRowId"];
+    initialSortColumn?: string;
+    initialSortDirection?: "ascending" | "descending";
   },
   HTMLProps<HTMLTableElement>
 >;
@@ -126,14 +128,31 @@ function ModularTable<D extends Record<string, unknown>>({
   getRowProps,
   getCellProps,
   getRowId,
+  initialSortColumn,
+  initialSortDirection,
   ...props
 }: Props<D>): JSX.Element {
+  const sortBy = useMemo(
+    () =>
+      initialSortColumn
+        ? [
+            {
+              id: initialSortColumn,
+              desc: initialSortDirection === "descending",
+            },
+          ]
+        : [],
+    [initialSortColumn, initialSortDirection]
+  );
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable<D>(
       {
         columns,
         data,
         getRowId: getRowId || undefined,
+        initialState: {
+          sortBy,
+        },
       },
       sortable ? useSortBy : undefined
     );

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -61,7 +61,13 @@ export type Props<D extends Record<string, unknown>> = PropsWithSpread<
       cell: Cell<D>
     ) => Partial<TableCellProps & HTMLProps<HTMLTableCellElement>>;
     getRowId?: UseTableOptions<D>["getRowId"];
+    /**
+     * The column that the table will be sorted by (this should match a cell selector).
+     */
     initialSortColumn?: string;
+    /**
+     * The direction of the initial sort.
+     */
     initialSortDirection?: "ascending" | "descending";
   },
   HTMLProps<HTMLTableElement>

--- a/src/types/react-table-config.d.ts
+++ b/src/types/react-table-config.d.ts
@@ -1,9 +1,21 @@
 // check @types/react-table README for details on this config file:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-table/Readme.md
 
-import { UseSortByColumnProps } from "react-table";
+import {
+  UseSortByColumnProps,
+  UseSortByOptions,
+  UseFiltersColumnProps,
+  UseSortByState,
+} from "react-table";
 
 declare module "react-table" {
+  export interface TableOptions<D extends Record<string, unknown>>
+    extends UseSortByOptions<D> {}
+
+  export interface TableState<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseSortByState<D> {}
+
   export interface UseTableColumnOptions<D extends Record<string, unknown>>
     extends UseTableColumnOptions<D> {
     className?: string;


### PR DESCRIPTION
## Done

- Update ModularTable to support default sorting.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to the modular table in storybook.
- Scroll down to the 'Sortable' example.
- Check that it is sorted by 'Build duration' by default.

