### PR TITLE
[SearchAndFilter] add onPanelToggle and onExpandChange event handlers

### DIFF
--- a/src/components/SearchAndFilter/SearchAndFilter.test.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.tsx
@@ -396,7 +396,7 @@ describe("Search and filter", () => {
     expect(onPanelToggle).toHaveBeenCalled();
   });
 
-  it("calls onHeightChange function when provided and the counter is clicked", async () => {
+  it("calls onExpandChange function when provided and the counter is clicked", async () => {
     // Jest is unaware of layout so we must mock the offsetTop and offsetHeight
     // of the chips
     Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
@@ -408,12 +408,12 @@ describe("Search and filter", () => {
       value: 100,
     });
     const returnSearchData = jest.fn();
-    const onHeightChange = jest.fn();
+    const onExpandChange = jest.fn();
     render(
       <SearchAndFilter
         filterPanelData={sampleData}
         returnSearchData={returnSearchData}
-        onHeightChange={onHeightChange}
+        onExpandChange={onExpandChange}
       />
     );
     await waitFor(async () => {
@@ -427,6 +427,6 @@ describe("Search and filter", () => {
     await waitFor(async () => {
       await userEvent.click(screen.getByRole("button", { name: "+1" }));
     });
-    expect(onHeightChange).toHaveBeenCalled();
+    expect(onExpandChange).toHaveBeenCalled();
   });
 });

--- a/src/components/SearchAndFilter/SearchAndFilter.test.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.tsx
@@ -377,4 +377,38 @@ describe("Search and filter", () => {
     )?.textContent;
     expect(chip2Value).toEqual("eu-west-1");
   });
+
+  it("calls onHeightChange function when provided and the counter is clicked", async () => {
+    // Jest is unaware of layout so we must mock the offsetTop and offsetHeight
+    // of the chips
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 40,
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetTop", {
+      configurable: true,
+      value: 100,
+    });
+    const returnSearchData = jest.fn();
+    const onHeightChange = jest.fn();
+    render(
+      <SearchAndFilter
+        filterPanelData={sampleData}
+        returnSearchData={returnSearchData}
+        onHeightChange={onHeightChange}
+      />
+    );
+    await waitFor(async () => {
+      await userEvent.click(
+        screen.getByRole("searchbox", { name: Label.SearchAndFilter })
+      );
+    });
+    await waitFor(async () => {
+      await userEvent.click(screen.getByRole("button", { name: "us-east1" }));
+    });
+    await waitFor(async () => {
+      await userEvent.click(screen.getByRole("button", { name: "+1" }));
+    });
+    expect(onHeightChange).toHaveBeenCalled();
+  });
 });

--- a/src/components/SearchAndFilter/SearchAndFilter.test.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.tsx
@@ -378,6 +378,24 @@ describe("Search and filter", () => {
     expect(chip2Value).toEqual("eu-west-1");
   });
 
+  it("calls onPanelToggle function when provided and the searchbox is clicked", async () => {
+    const returnSearchData = jest.fn();
+    const onPanelToggle = jest.fn();
+    render(
+      <SearchAndFilter
+        filterPanelData={sampleData}
+        returnSearchData={returnSearchData}
+        onPanelToggle={onPanelToggle}
+      />
+    );
+    await waitFor(async () => {
+      await userEvent.click(
+        screen.getByRole("searchbox", { name: Label.SearchAndFilter })
+      );
+    });
+    expect(onPanelToggle).toHaveBeenCalled();
+  });
+
   it("calls onHeightChange function when provided and the counter is clicked", async () => {
     // Jest is unaware of layout so we must mock the offsetTop and offsetHeight
     // of the chips

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -26,6 +26,10 @@ export type Props = {
    */
   returnSearchData: (searchData: SearchAndFilterChip[]) => void;
   /**
+   * A function that is called when the filter panel is shown/hidden.
+   */
+  onPanelToggle?: () => void;
+  /**
    * A function that is called when the height of the search container changes.
    */
   onHeightChange?: () => void;
@@ -35,6 +39,7 @@ const SearchAndFilter = ({
   existingSearchData = [],
   filterPanelData,
   returnSearchData,
+  onPanelToggle = () => {},
   onHeightChange = () => {},
   ...props
 }: Props): JSX.Element => {
@@ -50,6 +55,9 @@ const SearchAndFilter = ({
   const searchContainerRef = useRef(null);
   const searchBoxRef = useRef(null);
   const panel = useRef();
+
+  // Call onPanelToggle when the filterPanelHidden state changes
+  useEffect(onPanelToggle, [onPanelToggle, filterPanelHidden]);
 
   // Call onHeightChange when the search box is expanded or collapsed
   useEffect(onHeightChange, [onHeightChange, searchBoxExpanded]);

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -32,7 +32,7 @@ export type Props = {
   /**
    * A function that is called when the height of the search container changes.
    */
-  onHeightChange?: () => void;
+  onExpandChange?: () => void;
 };
 
 const SearchAndFilter = ({
@@ -40,7 +40,7 @@ const SearchAndFilter = ({
   filterPanelData,
   returnSearchData,
   onPanelToggle = () => {},
-  onHeightChange = () => {},
+  onExpandChange = () => {},
   ...props
 }: Props): JSX.Element => {
   const [searchData, setSearchData] = useState(existingSearchData);
@@ -59,8 +59,8 @@ const SearchAndFilter = ({
   // Call onPanelToggle when the filterPanelHidden state changes
   useEffect(onPanelToggle, [onPanelToggle, filterPanelHidden]);
 
-  // Call onHeightChange when the search box is expanded or collapsed
-  useEffect(onHeightChange, [onHeightChange, searchBoxExpanded]);
+  // Call onExpandChange when the search box is expanded or collapsed
+  useEffect(onExpandChange, [onExpandChange, searchBoxExpanded]);
 
   // Return searchData to parent component
   useEffect(() => {

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -25,12 +25,17 @@ export type Props = {
    * A function that is called when the search data changes.
    */
   returnSearchData: (searchData: SearchAndFilterChip[]) => void;
+  /**
+   * A function that is called when the height of the search container changes.
+   */
+  onHeightChange?: () => void;
 };
 
 const SearchAndFilter = ({
   existingSearchData = [],
   filterPanelData,
   returnSearchData,
+  onHeightChange = () => {},
   ...props
 }: Props): JSX.Element => {
   const [searchData, setSearchData] = useState(existingSearchData);
@@ -45,6 +50,9 @@ const SearchAndFilter = ({
   const searchContainerRef = useRef(null);
   const searchBoxRef = useRef(null);
   const panel = useRef();
+
+  // Call onHeightChange when the search box is expanded or collapsed
+  useEffect(onHeightChange, [onHeightChange, searchBoxExpanded]);
 
   // Return searchData to parent component
   useEffect(() => {


### PR DESCRIPTION
## Done

- Added the following 2 optional callback props to the `SearchAndFilter` component:
1. `onPanelToggle`: triggered when the filter panel is shown/hidden.
2. `onExpandChange`: triggered when the search box has overflowing chips (= chips going new-line) and is expanded/collapsed.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Add a `SearchAndFilter` component with the `onPanelToggle` prop set.
- Check that when clicking on the search box to show the filter panel and when clicking outside to hide it, the `onPanelToggle` function is called.
- Add a `SearchAndFilter` component with the `onExpandChange` prop set.
- Add many chips so that they overflow in the search box.
- Check that when expanding/collapsing the search box, the `onExpandChange` function is called.