### PR TITLE
fix(tooltip) avoid broken reference to tooltip when not mounted

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -308,7 +308,7 @@ const Tooltip = ({
             {React.Children.map(children, (child) =>
               child && React.isValidElement(child)
                 ? React.cloneElement(child, {
-                    "aria-describedby": tooltipId,
+                    "aria-describedby": isOpen ? tooltipId : undefined,
                   } as React.HTMLAttributes<HTMLElement>)
                 : child
             )}

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -6,9 +6,7 @@ exports[`Tooltip renders and matches the snapshot 1`] = `
     <span
       style="display: inline-block;"
     >
-      <button
-        aria-describedby="mock-nanoid-1"
-      >
+      <button>
         button text
       </button>
     </span>


### PR DESCRIPTION
## Done

- avoid setting aria ref from tooltip anchor when the tooltip is not rendered
