### PR TITLE
Add ConfirmationModal and ConfirmationButton components [WD-4255]

### DIFF
--- a/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
+++ b/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
@@ -27,8 +27,8 @@ export const doNothing = () => {};
         onConfirm: doNothing,
         children:
           <p>
-            Are you sure you want to delete user "Simon"?<br/>
-            This action is permanent and can not be undone.
+            This will permanently delete the user "Simon".<br/>
+            You cannot undo this action.
           </p>,
       }}
     >
@@ -55,8 +55,8 @@ export const doNothing = () => {};
             onConfirm: brieflyLoad,
             children:
               <p>
-                Are you sure you want to delete user "Simon"?<br/>
-                This action is permanent and can not be undone.
+                This will permanently delete the user "Simon".<br/>
+                You cannot undo this action.
               </p>,
           }}
           className="has-icon"
@@ -91,8 +91,8 @@ export const doNothing = () => {};
             onConfirm: brieflyLoad,
             children:
               <p>
-                Are you sure you want to delete user "Simon"?<br/>
-                This action is permanent and can not be undone.
+                This will permanently delete the user "Simon".<br/>
+                You cannot undo this action.
               </p>,
           }}
           className="has-icon"
@@ -127,8 +127,8 @@ export const doNothing = () => {};
             onConfirm: brieflyLoad,
             children:
               <p>
-                Are you sure you want to delete user "Simon"?<br/>
-                This action is permanent and can not be undone.
+                This will permanently delete the user "Simon".<br/>
+                You cannot undo this action.
               </p>,
           }}
           className="has-icon"

--- a/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
+++ b/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
@@ -1,0 +1,52 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { useState } from "react";
+
+import ConfirmationButton from "./ConfirmationButton";
+import Input from "../Input";
+
+<Meta title="ConfirmationButton" component={ConfirmationButton} />
+
+### ConfirmationButton
+
+`ConfirmationButton` is a specialised version of the Vanilla [Button](https://docs.vanillaframework.io/patterns/buttons/) that prompts a confirmation from the user before executing some action.
+
+### Props
+
+<ArgsTable of={ConfirmationButton} />
+
+<Canvas>
+  <Story name="Default">
+    {() => {
+      const [isLoading, setLoading] = useState(false);
+      const brieflyLoad = () => {
+        setLoading(true);
+        setTimeout(() => setLoading(false), 2000);
+      };
+      return (
+        <ConfirmationButton
+          title="Confirm delete"
+          buttonLabel="Delete"
+          confirmButtonLabel="Delete"
+          confirmExtra={
+            <span className="u-float-left">
+              <Input
+                type="checkbox"
+                id="extraCheckbox"
+                label="Do not ask again"
+                tabIndex={-1}
+              />
+            </span>
+          }
+          icon="delete"
+          isLoading={isLoading}
+          onConfirm={brieflyLoad}
+          shiftClickEnabled
+          hasShiftClickHint
+        >
+          Are you sure you want to delete user "Simon"? This action is
+          permanent and can not be undone.
+        </ConfirmationButton>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
+++ b/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
@@ -2,13 +2,13 @@ import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
 import { useState } from "react";
 
 import ConfirmationButton from "./ConfirmationButton";
-import Input from "../Input";
+import Icon, { ICONS } from "../Icon";
 
 <Meta title="ConfirmationButton" component={ConfirmationButton} />
 
 ### ConfirmationButton
 
-`ConfirmationButton` is a specialised version of the Vanilla [Button](https://docs.vanillaframework.io/patterns/buttons/) that prompts a confirmation from the user before executing some action.
+`ConfirmationButton` is a specialised version of the [ActionButton](?path=/docs/actionbutton--default-story) component that uses a [ConfirmationModal](?path=/docs/confirmationmodal--default-story) to prompt a confirmation from the user before executing an action.
 
 ### Props
 
@@ -21,15 +21,18 @@ export const doNothing = () => {};
 <Canvas>
   <Story name="Default">
     <ConfirmationButton
-      title="Confirm delete"
-      buttonLabel="Delete"
-      confirmButtonLabel="Delete"
-      onConfirm={doNothing}
+      confirmationModalProps={{
+        title: "Confirm delete",
+        confirmButtonLabel: "Delete",
+        onConfirm: doNothing,
+        children:
+          <p>
+            Are you sure you want to delete user "Simon"?<br/>
+            This action is permanent and can not be undone.
+          </p>,
+      }}
     >
-      <p>
-        Are you sure you want to delete user "Simon"?<br/>
-        This action is permanent and can not be undone.
-      </p>
+      Delete
     </ConfirmationButton>
   </Story>
 </Canvas>
@@ -46,19 +49,24 @@ export const doNothing = () => {};
       };
       return (
         <ConfirmationButton
-          title="Confirm delete"
-          buttonLabel="Delete"
-          confirmButtonLabel="Delete"
-          icon="delete"
-          isLoading={isLoading}
-          onConfirm={brieflyLoad}
+          confirmationModalProps={{
+            title: "Confirm delete",
+            confirmButtonLabel: "Delete",
+            onConfirm: brieflyLoad,
+            children:
+              <p>
+                Are you sure you want to delete user "Simon"?<br/>
+                This action is permanent and can not be undone.
+              </p>,
+          }}
+          className="has-icon"
+          disabled={isLoading}
+          loading={isLoading}
           shiftClickEnabled
           showShiftClickHint
         >
-          <p>
-            Are you sure you want to delete user "Simon"?<br/>
-            This action is permanent and can not be undone.
-          </p>
+          <Icon name={ICONS.delete} />
+          <span>Delete</span>
         </ConfirmationButton>
       );
     }}
@@ -77,18 +85,23 @@ export const doNothing = () => {};
       };
       return (
         <ConfirmationButton
-          title="Confirm delete"
-          confirmButtonLabel="Delete"
-          icon="delete"
-          isLoading={isLoading}
-          onConfirm={brieflyLoad}
+          confirmationModalProps={{
+            title: "Confirm delete",
+            confirmButtonLabel: "Delete",
+            onConfirm: brieflyLoad,
+            children:
+              <p>
+                Are you sure you want to delete user "Simon"?<br/>
+                This action is permanent and can not be undone.
+              </p>,
+          }}
+          className="has-icon"
+          disabled={isLoading}
+          loading={isLoading}
           shiftClickEnabled
           showShiftClickHint
         >
-          <p>
-            Are you sure you want to delete user "Simon"?<br/>
-            This action is permanent and can not be undone.
-          </p>
+          <Icon name={ICONS.delete} />
         </ConfirmationButton>
       );
     }}
@@ -108,18 +121,23 @@ export const doNothing = () => {};
       return (
         <ConfirmationButton
           appearance="base"
-          title="Confirm delete"
-          confirmButtonLabel="Delete"
-          icon="delete"
-          isLoading={isLoading}
-          onConfirm={brieflyLoad}
+          confirmationModalProps={{
+            title: "Confirm delete",
+            confirmButtonLabel: "Delete",
+            onConfirm: brieflyLoad,
+            children:
+              <p>
+                Are you sure you want to delete user "Simon"?<br/>
+                This action is permanent and can not be undone.
+              </p>,
+          }}
+          className="has-icon"
+          disabled={isLoading}
+          loading={isLoading}
           shiftClickEnabled
           showShiftClickHint
         >
-          <p>
-            Are you sure you want to delete user "Simon"?<br/>
-            This action is permanent and can not be undone.
-          </p>
+          <Icon name={ICONS.delete} />
         </ConfirmationButton>
       );
     }}

--- a/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
+++ b/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
@@ -14,8 +14,30 @@ import Input from "../Input";
 
 <ArgsTable of={ConfirmationButton} />
 
+export const doNothing = () => {};
+
+### Default
+
 <Canvas>
   <Story name="Default">
+    <ConfirmationButton
+      title="Confirm delete"
+      buttonLabel="Delete"
+      confirmButtonLabel="Delete"
+      onConfirm={doNothing}
+    >
+      <p>
+        Are you sure you want to delete user "Simon"?<br/>
+        This action is permanent and can not be undone.
+      </p>
+    </ConfirmationButton>
+  </Story>
+</Canvas>
+
+### Icon and label
+
+<Canvas>
+  <Story name="Icon and label">
     {() => {
       const [isLoading, setLoading] = useState(false);
       const brieflyLoad = () => {
@@ -27,16 +49,67 @@ import Input from "../Input";
           title="Confirm delete"
           buttonLabel="Delete"
           confirmButtonLabel="Delete"
-          confirmExtra={
-            <span className="u-float-left">
-              <Input
-                type="checkbox"
-                id="extraCheckbox"
-                label="Do not ask again"
-                tabIndex={-1}
-              />
-            </span>
-          }
+          icon="delete"
+          isLoading={isLoading}
+          onConfirm={brieflyLoad}
+          shiftClickEnabled
+          showShiftClickHint
+        >
+          <p>
+            Are you sure you want to delete user "Simon"?<br/>
+            This action is permanent and can not be undone.
+          </p>
+        </ConfirmationButton>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Icon only
+
+<Canvas>
+  <Story name="Icon only">
+    {() => {
+      const [isLoading, setLoading] = useState(false);
+      const brieflyLoad = () => {
+        setLoading(true);
+        setTimeout(() => setLoading(false), 2000);
+      };
+      return (
+        <ConfirmationButton
+          title="Confirm delete"
+          confirmButtonLabel="Delete"
+          icon="delete"
+          isLoading={isLoading}
+          onConfirm={brieflyLoad}
+          shiftClickEnabled
+          showShiftClickHint
+        >
+          <p>
+            Are you sure you want to delete user "Simon"?<br/>
+            This action is permanent and can not be undone.
+          </p>
+        </ConfirmationButton>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Base appearance
+
+<Canvas>
+  <Story name="Base appearance">
+    {() => {
+      const [isLoading, setLoading] = useState(false);
+      const brieflyLoad = () => {
+        setLoading(true);
+        setTimeout(() => setLoading(false), 2000);
+      };
+      return (
+        <ConfirmationButton
+          appearance="base"
+          title="Confirm delete"
+          confirmButtonLabel="Delete"
           icon="delete"
           isLoading={isLoading}
           onConfirm={brieflyLoad}

--- a/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
+++ b/src/components/ConfirmationButton/ConfirmationButton.stories.mdx
@@ -41,10 +41,12 @@ import Input from "../Input";
           isLoading={isLoading}
           onConfirm={brieflyLoad}
           shiftClickEnabled
-          hasShiftClickHint
+          showShiftClickHint
         >
-          Are you sure you want to delete user "Simon"? This action is
-          permanent and can not be undone.
+          <p>
+            Are you sure you want to delete user "Simon"?<br/>
+            This action is permanent and can not be undone.
+          </p>
         </ConfirmationButton>
       );
     }}

--- a/src/components/ConfirmationButton/ConfirmationButton.test.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.test.tsx
@@ -1,0 +1,99 @@
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+import ConfirmationButton from "./ConfirmationButton";
+import userEvent from "@testing-library/user-event";
+
+describe("ConfirmationButton ", () => {
+  it("shows button label and icon", () => {
+    const { container } = render(
+      <ConfirmationButton
+        buttonLabel="Delete"
+        icon="delete"
+        confirmButtonLabel="Confirm"
+        onConfirm={jest.fn()}
+      >
+        Test button label and icon
+      </ConfirmationButton>
+    );
+    expect(container.innerHTML).toContain("Delete");
+    expect(screen.getByRole("button")).toContainHTML("p-icon--delete");
+  });
+
+  it("shows the loading animation when isLoading is true and an icon is set", () => {
+    render(
+      <ConfirmationButton
+        icon="delete"
+        isLoading
+        confirmButtonLabel="Confirm"
+        onConfirm={jest.fn()}
+      >
+        Test loading animation
+      </ConfirmationButton>
+    );
+    expect(screen.getByRole("button")).toContainHTML(
+      "u-animation--spin p-icon--spinner"
+    );
+  });
+
+  it("shows a customised hover text", () => {
+    render(
+      <ConfirmationButton
+        onHoverText="Delete"
+        confirmButtonLabel="Confirm"
+        onConfirm={jest.fn()}
+      >
+        Test custom hover text
+      </ConfirmationButton>
+    );
+    expect(screen.getByTitle("Delete")).toBeInTheDocument();
+  });
+
+  it("performs the action skipping the confirmation with shift+click when enabled", async () => {
+    const onConfirm = jest.fn();
+    render(
+      <ConfirmationButton
+        shiftClickEnabled
+        confirmButtonLabel="Confirm"
+        onConfirm={onConfirm}
+      >
+        Test shift+click confirm shortcut
+      </ConfirmationButton>
+    );
+    const user = userEvent.setup();
+    await user.keyboard("{Shift>}");
+    await user.click(screen.getByTitle("Confirm"));
+    await user.keyboard("{/Shift}");
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("passes extra classes to the modal wrapper", async () => {
+    render(
+      <ConfirmationButton
+        modalClassName="extra-class"
+        confirmButtonLabel="Confirm"
+        onConfirm={jest.fn()}
+      >
+        Test modal extra class
+      </ConfirmationButton>
+    );
+    const button = screen.getByTitle("Confirm");
+    const clickEvent = createEvent.click(button);
+    fireEvent(button, clickEvent);
+    expect(document.body).toContainHTML("p-modal extra-class");
+  });
+
+  it("passes extra classes to the button", () => {
+    render(
+      <ConfirmationButton
+        className="extra-class"
+        confirmButtonLabel="Confirm"
+        onConfirm={jest.fn()}
+      >
+        Test button extra class
+      </ConfirmationButton>
+    );
+    expect(screen.getByTitle("Confirm")).toHaveClass("extra-class");
+  });
+});

--- a/src/components/ConfirmationButton/ConfirmationButton.test.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.test.tsx
@@ -68,6 +68,24 @@ describe("ConfirmationButton ", () => {
     expect(onConfirm).toHaveBeenCalled();
   });
 
+  it("shows the shift click hint", () => {
+    render(
+      <ConfirmationButton
+        showShiftClickHint
+        confirmButtonLabel="Confirm"
+        onConfirm={jest.fn()}
+      >
+        Test shift click hint
+      </ConfirmationButton>
+    );
+    const button = screen.getByTitle("Confirm");
+    const clickEvent = createEvent.click(button);
+    fireEvent(button, clickEvent);
+    expect(document.body).toContainHTML(
+      "You can skip the confirmation dialog by holding"
+    );
+  });
+
   it("passes extra classes to the modal wrapper", async () => {
     render(
       <ConfirmationButton

--- a/src/components/ConfirmationButton/ConfirmationButton.test.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.test.tsx
@@ -2,34 +2,35 @@ import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 import ConfirmationButton from "./ConfirmationButton";
+import Icon, { ICONS } from "../Icon";
 import userEvent from "@testing-library/user-event";
 
 describe("ConfirmationButton ", () => {
-  it("shows button label and icon", () => {
-    const { container } = render(
-      <ConfirmationButton
-        buttonLabel="Delete"
-        icon="delete"
-        confirmButtonLabel="Confirm"
-        onConfirm={jest.fn()}
-      >
-        Test button label and icon
-      </ConfirmationButton>
-    );
-    expect(container.innerHTML).toContain("Delete");
-    expect(screen.getByRole("button")).toContainHTML("p-icon--delete");
-  });
-
-  it("shows the loading animation when isLoading is true and an icon is set", () => {
+  it("shows button icon and label", () => {
     render(
       <ConfirmationButton
-        icon="delete"
-        isLoading
-        confirmButtonLabel="Confirm"
-        onConfirm={jest.fn()}
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm: jest.fn(),
+        }}
       >
-        Test loading animation
+        <Icon name={ICONS.delete} />
+        <span>Delete</span>
       </ConfirmationButton>
+    );
+    expect(screen.getByRole("button")).toContainHTML("p-icon--delete");
+    expect(screen.getByRole("button")).toContainHTML("<span>Delete</span>");
+  });
+
+  it("shows the loading animation when loading is true", () => {
+    render(
+      <ConfirmationButton
+        loading
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm: jest.fn(),
+        }}
+      />
     );
     expect(screen.getByRole("button")).toContainHTML(
       "u-animation--spin p-icon--spinner"
@@ -40,11 +41,11 @@ describe("ConfirmationButton ", () => {
     render(
       <ConfirmationButton
         onHoverText="Delete"
-        confirmButtonLabel="Confirm"
-        onConfirm={jest.fn()}
-      >
-        Test custom hover text
-      </ConfirmationButton>
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm: jest.fn(),
+        }}
+      />
     );
     expect(screen.getByTitle("Delete")).toBeInTheDocument();
   });
@@ -54,11 +55,11 @@ describe("ConfirmationButton ", () => {
     render(
       <ConfirmationButton
         shiftClickEnabled
-        confirmButtonLabel="Confirm"
-        onConfirm={onConfirm}
-      >
-        Test shift+click confirm shortcut
-      </ConfirmationButton>
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm,
+        }}
+      />
     );
     const user = userEvent.setup();
     await user.keyboard("{Shift>}");
@@ -72,29 +73,27 @@ describe("ConfirmationButton ", () => {
     render(
       <ConfirmationButton
         showShiftClickHint
-        confirmButtonLabel="Confirm"
-        onConfirm={jest.fn()}
-      >
-        Test shift click hint
-      </ConfirmationButton>
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm: jest.fn(),
+        }}
+      />
     );
     const button = screen.getByTitle("Confirm");
     const clickEvent = createEvent.click(button);
     fireEvent(button, clickEvent);
-    expect(document.body).toContainHTML(
-      "You can skip the confirmation dialog by holding"
-    );
+    expect(document.body).toContainHTML("<code>SHIFT</code>");
   });
 
   it("passes extra classes to the modal wrapper", async () => {
     render(
       <ConfirmationButton
-        modalClassName="extra-class"
-        confirmButtonLabel="Confirm"
-        onConfirm={jest.fn()}
-      >
-        Test modal extra class
-      </ConfirmationButton>
+        confirmationModalProps={{
+          className: "extra-class",
+          confirmButtonLabel: "Confirm",
+          onConfirm: jest.fn(),
+        }}
+      />
     );
     const button = screen.getByTitle("Confirm");
     const clickEvent = createEvent.click(button);
@@ -106,11 +105,11 @@ describe("ConfirmationButton ", () => {
     render(
       <ConfirmationButton
         className="extra-class"
-        confirmButtonLabel="Confirm"
-        onConfirm={jest.fn()}
-      >
-        Test button extra class
-      </ConfirmationButton>
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm: jest.fn(),
+        }}
+      />
     );
     expect(screen.getByTitle("Confirm")).toHaveClass("extra-class");
   });

--- a/src/components/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.tsx
@@ -97,7 +97,7 @@ export const ConfirmationButton = ({
           >
             {props.children}
             {showShiftClickHint && (
-              <p className="u-text--muted u-hide--small">
+              <p className="p-modal__shortcut-hint u-text--muted">
                 You can skip the confirmation dialog by holding{" "}
                 <code>SHIFT</code> when clicking on the action.
               </p>

--- a/src/components/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.tsx
@@ -1,0 +1,123 @@
+import React, { MouseEvent, ReactElement, ReactNode } from "react";
+import { PropsWithSpread, ValueOf } from "types";
+import Button, { ButtonProps } from "components/Button";
+import ConfirmationModal, {
+  ConfirmationModalProps,
+} from "../ConfirmationModal";
+import Icon, { ICONS } from "components/Icon";
+import classNames from "classnames";
+import usePortal from "react-useportal";
+
+export type Props = PropsWithSpread<
+  {
+    /**
+     * An optional text to be shown inside the button.
+     */
+    buttonLabel?: string;
+    /**
+     * The content of the confirmation modal.
+     */
+    children: ReactNode;
+    /**
+     * The name of an optional icon to be shown inside the button.
+     */
+    icon?: ValueOf<typeof ICONS> | string;
+    /**
+     * Whether the button is loading.<br/>
+     * It displays an animated spinner only if the `icon` prop is set.
+     */
+    isLoading?: boolean;
+    /**
+     * An optional text to be shown when hovering over the button.<br/>
+     * If not specified, the `confirmButtonLabel` will be shown on hover.
+     */
+    onHoverText?: string;
+    /**
+     * Whether to enable the SHIFT+Click shortcut to skip the confirmation modal and perform the action.
+     */
+    shiftClickEnabled?: boolean;
+    /**
+     * Optional class(es) to apply to the modal wrapper element.
+     */
+    modalClassName?: string;
+  },
+  Omit<ConfirmationModalProps, "className"> & Omit<ButtonProps, "hasIcon">
+>;
+
+export const ConfirmationButton = ({
+  buttonLabel,
+  icon,
+  isLoading = false,
+  onHoverText,
+  shiftClickEnabled = false,
+  modalClassName,
+  ...props
+}: Props): ReactElement => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+
+  const handleCancelModal = () => {
+    closePortal();
+    if (props.close) {
+      props.close();
+    }
+  };
+
+  const handleConfirmModal = (e: MouseEvent<HTMLElement>) => {
+    closePortal();
+    props.onConfirm(e);
+  };
+
+  const handleShiftClick = (e: MouseEvent<HTMLElement>) => {
+    if (e.shiftKey) {
+      props.onConfirm(e);
+    } else {
+      openPortal(e);
+    }
+  };
+
+  const iconName = icon ? (isLoading ? "spinner" : icon) : undefined;
+
+  return (
+    <>
+      {isOpen && (
+        <Portal>
+          <ConfirmationModal
+            className={modalClassName}
+            title={props.title}
+            close={handleCancelModal}
+            confirmExtra={props.confirmExtra}
+            confirmButtonLabel={props.confirmButtonLabel}
+            confirmButtonAppearance={props.confirmButtonAppearance}
+            onConfirm={handleConfirmModal}
+            hasShiftClickHint={props.hasShiftClickHint}
+          >
+            {props.children}
+          </ConfirmationModal>
+        </Portal>
+      )}
+      <Button
+        appearance={props.appearance}
+        hasIcon={!!iconName}
+        className={props.className}
+        dense={props.dense}
+        disabled={props.disabled}
+        onClick={shiftClickEnabled ? handleShiftClick : openPortal}
+        aria-label={props.confirmButtonLabel}
+        title={onHoverText ?? props.confirmButtonLabel}
+        type={props.type ?? "button"}
+      >
+        {iconName && (
+          <Icon
+            className={classNames({ "u-animation--spin": isLoading })}
+            name={iconName}
+          />
+        )}
+        {buttonLabel && (
+          <span className="confirmation-toggle-caption">{buttonLabel}</span>
+        )}
+      </Button>
+    </>
+  );
+};
+
+export default ConfirmationButton;

--- a/src/components/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.tsx
@@ -37,6 +37,10 @@ export type Props = PropsWithSpread<
      */
     shiftClickEnabled?: boolean;
     /**
+     * Whether to show a hint about the SHIFT+Click shortcut to skip the confirmation modal.
+     */
+    showShiftClickHint?: boolean;
+    /**
      * Optional class(es) to apply to the modal wrapper element.
      */
     modalClassName?: string;
@@ -50,6 +54,7 @@ export const ConfirmationButton = ({
   isLoading = false,
   onHoverText,
   shiftClickEnabled = false,
+  showShiftClickHint = false,
   modalClassName,
   ...props
 }: Props): ReactElement => {
@@ -89,9 +94,14 @@ export const ConfirmationButton = ({
             confirmButtonLabel={props.confirmButtonLabel}
             confirmButtonAppearance={props.confirmButtonAppearance}
             onConfirm={handleConfirmModal}
-            hasShiftClickHint={props.hasShiftClickHint}
           >
             {props.children}
+            {showShiftClickHint && (
+              <p className="u-text--muted u-hide--small">
+                You can skip the confirmation dialog by holding{" "}
+                <code>SHIFT</code> when clicking on the action.
+              </p>
+            )}
           </ConfirmationModal>
         </Portal>
       )}

--- a/src/components/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.tsx
@@ -1,35 +1,20 @@
-import React, { MouseEvent, ReactElement, ReactNode } from "react";
-import { PropsWithSpread, ValueOf } from "types";
-import Button, { ButtonProps } from "components/Button";
+import React, { MouseEvent, ReactElement } from "react";
+import { PropsWithSpread, SubComponentProps } from "types";
+import ActionButton, { ActionButtonProps } from "../ActionButton";
 import ConfirmationModal, {
   ConfirmationModalProps,
 } from "../ConfirmationModal";
-import Icon, { ICONS } from "components/Icon";
-import classNames from "classnames";
 import usePortal from "react-useportal";
 
 export type Props = PropsWithSpread<
   {
     /**
-     * An optional text to be shown inside the button.
+     * Additional props to pass to the confirmation modal.
      */
-    buttonLabel?: string;
-    /**
-     * The content of the confirmation modal.
-     */
-    children: ReactNode;
-    /**
-     * The name of an optional icon to be shown inside the button.
-     */
-    icon?: ValueOf<typeof ICONS> | string;
-    /**
-     * Whether the button is loading.<br/>
-     * It displays an animated spinner only if the `icon` prop is set.
-     */
-    isLoading?: boolean;
+    confirmationModalProps: SubComponentProps<ConfirmationModalProps>;
     /**
      * An optional text to be shown when hovering over the button.<br/>
-     * If not specified, the `confirmButtonLabel` will be shown on hover.
+     * Defaults to the label of the confirm button in the modal.
      */
     onHoverText?: string;
     /**
@@ -40,92 +25,66 @@ export type Props = PropsWithSpread<
      * Whether to show a hint about the SHIFT+Click shortcut to skip the confirmation modal.
      */
     showShiftClickHint?: boolean;
-    /**
-     * Optional class(es) to apply to the modal wrapper element.
-     */
-    modalClassName?: string;
   },
-  Omit<ConfirmationModalProps, "className"> & Omit<ButtonProps, "hasIcon">
+  ActionButtonProps
 >;
 
 export const ConfirmationButton = ({
-  buttonLabel,
-  icon,
-  isLoading = false,
+  confirmationModalProps,
   onHoverText,
   shiftClickEnabled = false,
   showShiftClickHint = false,
-  modalClassName,
-  ...props
+  ...actionButtonProps
 }: Props): ReactElement => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
 
   const handleCancelModal = () => {
     closePortal();
-    if (props.close) {
-      props.close();
+    if (confirmationModalProps.close) {
+      confirmationModalProps.close();
     }
   };
 
   const handleConfirmModal = (e: MouseEvent<HTMLElement>) => {
     closePortal();
-    props.onConfirm(e);
+    confirmationModalProps.onConfirm(e);
   };
 
   const handleShiftClick = (e: MouseEvent<HTMLElement>) => {
     if (e.shiftKey) {
-      props.onConfirm(e);
+      confirmationModalProps.onConfirm(e);
     } else {
       openPortal(e);
     }
   };
-
-  const iconName = icon ? (isLoading ? "spinner" : icon) : undefined;
 
   return (
     <>
       {isOpen && (
         <Portal>
           <ConfirmationModal
-            className={modalClassName}
-            title={props.title}
+            {...confirmationModalProps}
             close={handleCancelModal}
-            confirmExtra={props.confirmExtra}
-            confirmButtonLabel={props.confirmButtonLabel}
-            confirmButtonAppearance={props.confirmButtonAppearance}
+            confirmButtonLabel={confirmationModalProps.confirmButtonLabel}
             onConfirm={handleConfirmModal}
           >
-            {props.children}
+            {confirmationModalProps.children}
             {showShiftClickHint && (
-              <p className="p-modal__shortcut-hint u-text--muted">
-                You can skip the confirmation dialog by holding{" "}
-                <code>SHIFT</code> when clicking on the action.
+              <p className="p-text--small u-text--muted u-hide--small">
+                Next time, you can skip this confirmation by holding{" "}
+                <code>SHIFT</code> and clicking the action.
               </p>
             )}
           </ConfirmationModal>
         </Portal>
       )}
-      <Button
-        appearance={props.appearance}
-        hasIcon={!!iconName}
-        className={props.className}
-        dense={props.dense}
-        disabled={props.disabled}
+      <ActionButton
+        {...actionButtonProps}
         onClick={shiftClickEnabled ? handleShiftClick : openPortal}
-        aria-label={props.confirmButtonLabel}
-        title={onHoverText ?? props.confirmButtonLabel}
-        type={props.type ?? "button"}
+        title={onHoverText ?? confirmationModalProps.confirmButtonLabel}
       >
-        {iconName && (
-          <Icon
-            className={classNames({ "u-animation--spin": isLoading })}
-            name={iconName}
-          />
-        )}
-        {buttonLabel && (
-          <span className="confirmation-toggle-caption">{buttonLabel}</span>
-        )}
-      </Button>
+        {actionButtonProps.children}
+      </ActionButton>
     </>
   );
 };

--- a/src/components/ConfirmationButton/index.ts
+++ b/src/components/ConfirmationButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ConfirmationButton";
+export type { Props as ConfirmationButtonProps } from "./ConfirmationButton";

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -34,8 +34,8 @@ export const doNothing = () => {};
               close={closeHandler}
             >
               <p>
-                Are you sure you want to delete user "Simon"?<br/>
-                This action is permanent and can not be undone.
+                This will permanently delete the user "Simon".<br/>
+                You cannot undo this action.
               </p>
             </ConfirmationModal>
           ) : null}
@@ -163,7 +163,7 @@ Extra elements can be added to the button row.
               close={closeHandler}
             >
               <p>
-                Are you sure you want to stop instance <b>whimsical-mouflon</b>?
+                This will stop instance <b>whimsical-mouflon</b>.
               </p>
             </ConfirmationModal>
           ) : null}

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -33,8 +33,10 @@ export const doNothing = () => {};
               onConfirm={doNothing}
               close={closeHandler}
             >
-              Are you sure you want to delete user "Simon"?<br/>
-              This action is permanent and can not be undone.
+              <p>
+                Are you sure you want to delete user "Simon"?<br/>
+                This action is permanent and can not be undone.
+              </p>
             </ConfirmationModal>
           ) : null}
         </>
@@ -115,7 +117,10 @@ The appearance of the confirm button can be any of the `Button`'s appearance val
                   test
                 </pre>
               </div>
-              <div className="p-text--small">
+              <div
+                className="p-text--small"
+                style={{ width: "480px" }}
+              >
                 You can revert back to the applications default settings by clicking
                 the “Reset all values” button; or reset each edited field by
                 clicking “Use default”.
@@ -156,9 +161,10 @@ Extra elements can be added to the button row.
               confirmButtonLabel="Stop"
               onConfirm={doNothing}
               close={closeHandler}
-              hasShiftClickHint
             >
-              Are you sure you want to stop instance <b>whimsical-mouflon</b>?
+              <p>
+                Are you sure you want to stop instance <b>whimsical-mouflon</b>?
+              </p>
             </ConfirmationModal>
           ) : null}
         </>

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -8,7 +8,7 @@ import Input from "../Input";
 
 ### ConfirmationModal
 
-`ConfirmationModal` is a specialised version of the Vanilla [Modal](https://docs.vanillaframework.io/patterns/modal/) that prompts a confirmation from the user before executing some action.
+`ConfirmationModal` is a specialised version of the [Modal](?path=/docs/modal--default-story) component to prompt a confirmation from the user before executing an action.
 
 ### Props
 

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -1,0 +1,53 @@
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { useState } from "react";
+
+import ConfirmationModal from "./ConfirmationModal";
+import Input from "../Input";
+
+<Meta title="ConfirmationModal" component={ConfirmationModal} />
+
+### ConfirmationModal
+
+`ConfirmationModal` is a specialised version of the Vanilla [Modal](https://docs.vanillaframework.io/patterns/modal/) that prompts a confirmation from the user before executing some action.
+
+### Props
+
+<ArgsTable of={ConfirmationModal} />
+
+export const doNothing = () => {};
+
+<Canvas>
+  <Story name="Default">
+    {() => {
+      const [modalOpen, setModalOpen] = useState(true);
+      const closeHandler = () => setModalOpen(false);
+      return (
+        <>
+          <button onClick={() => setModalOpen(true)}>Open confirmation modal</button>
+          {modalOpen ? (
+            <ConfirmationModal
+              close={closeHandler}
+              title="Confirm delete"
+              confirmButtonLabel="Delete"
+              confirmExtra={
+                <span className="u-float-left">
+                  <Input
+                    type="checkbox"
+                    id="extraCheckbox"
+                    label="Do not ask again"
+                    tabIndex={-1}
+                  />
+                </span>
+              }
+              onConfirm={doNothing}
+              hasShiftClickHint
+            >
+              Are you sure you want to delete user "Simon"? This action is
+              permanent and can not be undone.
+            </ConfirmationModal>
+          ) : null}
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.mdx
@@ -16,34 +16,149 @@ import Input from "../Input";
 
 export const doNothing = () => {};
 
+### Default
+
 <Canvas>
   <Story name="Default">
     {() => {
-      const [modalOpen, setModalOpen] = useState(true);
+      const [modalOpen, setModalOpen] = useState(false);
       const closeHandler = () => setModalOpen(false);
       return (
         <>
           <button onClick={() => setModalOpen(true)}>Open confirmation modal</button>
           {modalOpen ? (
             <ConfirmationModal
-              close={closeHandler}
               title="Confirm delete"
               confirmButtonLabel="Delete"
+              onConfirm={doNothing}
+              close={closeHandler}
+            >
+              Are you sure you want to delete user "Simon"?<br/>
+              This action is permanent and can not be undone.
+            </ConfirmationModal>
+          ) : null}
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### No title
+
+The title is optional, and the content is fully customisable.
+
+<Canvas>
+  <Story name="No title">
+    {() => {
+      const [modalOpen, setModalOpen] = useState(false);
+      const closeHandler = () => setModalOpen(false);
+      return (
+        <>
+          <button onClick={() => setModalOpen(true)}>Run</button>
+          {modalOpen ? (
+            <ConfirmationModal
+              close={closeHandler}
+              confirmButtonAppearance="positive"
+              confirmButtonLabel="Confirm"
+              onConfirm={doNothing}
+            >
+              <h4 style={{ margin: "1rem 0" }}>
+                Run list-backups?
+              </h4>
+              <div style={{ width: "480px", marginBottom: "1rem" }}>
+                <div className="u-text--muted">UNIT COUNT</div>
+                <div>1</div>
+              </div>
+              <div style={{ marginBottom: "1.5rem" }}>
+                <div className="u-text--muted">UNIT NAME</div>
+                <div>mysql/0</div>
+              </div>
+            </ConfirmationModal>
+          ) : null}
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Positive
+
+The appearance of the confirm button can be any of the `Button`'s appearance values.
+
+<Canvas>
+  <Story name="Positive">
+    {() => {
+      const [modalOpen, setModalOpen] = useState(false);
+      const closeHandler = () => setModalOpen(false);
+      return (
+        <>
+          <button onClick={() => setModalOpen(true)}>Apply changes</button>
+          {modalOpen ? (
+            <ConfirmationModal
+              close={closeHandler}
+              confirmButtonAppearance="positive"
+              confirmButtonLabel="Yes, apply changes"
+              onConfirm={doNothing}
+            >
+              <h4 style={{ margin: "1rem 0" }}>
+                Are you sure you wish to apply these changes?
+              </h4>
+              <p>
+                You have edited the following values to the mysql configuration:
+              </p>
+              <div>
+                <h5 className="u-no-margin--bottom">cluster-name</h5>
+                <pre
+                  className="u-no-padding"
+                  style={{ backgroundColor: "transparent" }}
+                >
+                  test
+                </pre>
+              </div>
+              <div className="p-text--small">
+                You can revert back to the applications default settings by clicking
+                the “Reset all values” button; or reset each edited field by
+                clicking “Use default”.
+              </div>
+            </ConfirmationModal>
+          ) : null}
+        </>
+      );
+    }}
+  </Story>
+</Canvas>
+
+### Extra
+
+Extra elements can be added to the button row.
+
+<Canvas>
+  <Story name="Extra">
+    {() => {
+      const [modalOpen, setModalOpen] = useState(false);
+      const closeHandler = () => setModalOpen(false);
+      return (
+        <>
+          <button onClick={() => setModalOpen(true)}>Stop</button>
+          {modalOpen ? (
+            <ConfirmationModal
               confirmExtra={
                 <span className="u-float-left">
                   <Input
                     type="checkbox"
                     id="extraCheckbox"
-                    label="Do not ask again"
+                    label="Force stop"
                     tabIndex={-1}
                   />
                 </span>
               }
+              title="Confirm stop"
+              confirmButtonLabel="Stop"
               onConfirm={doNothing}
+              close={closeHandler}
               hasShiftClickHint
             >
-              Are you sure you want to delete user "Simon"? This action is
-              permanent and can not be undone.
+              Are you sure you want to stop instance <b>whimsical-mouflon</b>?
             </ConfirmationModal>
           ) : null}
         </>

--- a/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import ConfirmationModal from "./ConfirmationModal";
+import userEvent from "@testing-library/user-event";
+
+describe("ConfirmationModal ", () => {
+  it("shows a customised cancel button label", () => {
+    const { container } = render(
+      <ConfirmationModal
+        cancelButtonLabel="Go back"
+        confirmButtonLabel="Proceed"
+        onConfirm={jest.fn()}
+      >
+        Test cancel button label
+      </ConfirmationModal>
+    );
+    expect(container.innerHTML).toContain("Go back");
+    expect(container.innerHTML).not.toContain("Cancel");
+  });
+
+  it("shows a customised confirm button appearance", () => {
+    render(
+      <ConfirmationModal
+        confirmButtonAppearance="positive"
+        confirmButtonLabel="Proceed"
+        onConfirm={jest.fn()}
+      >
+        Test confirm button appearance
+      </ConfirmationModal>
+    );
+    expect(screen.getByText("Proceed")).toHaveClass("p-button--positive");
+  });
+
+  it("shows the confirm extra", () => {
+    render(
+      <ConfirmationModal
+        confirmExtra={<div data-testid="extraElement" />}
+        confirmButtonLabel="Proceed"
+        onConfirm={jest.fn()}
+      >
+        Test confirm extra
+      </ConfirmationModal>
+    );
+    expect(screen.getByTestId("extraElement")).toBeInTheDocument();
+  });
+
+  it("shows the shift click hint", () => {
+    const { container } = render(
+      <ConfirmationModal
+        hasShiftClickHint
+        confirmButtonLabel="Proceed"
+        onConfirm={jest.fn()}
+      >
+        Test shift click hint
+      </ConfirmationModal>
+    );
+    expect(container.innerHTML).toContain(
+      "You can skip these confirmation modals by holding"
+    );
+  });
+
+  it("executes the onConfirm callback when confirm button is clicked", async () => {
+    const onConfirm = jest.fn();
+    render(
+      <ConfirmationModal confirmButtonLabel="Proceed" onConfirm={onConfirm}>
+        Test confirm button click
+      </ConfirmationModal>
+    );
+    await userEvent.click(screen.getByText("Proceed"));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -45,21 +45,6 @@ describe("ConfirmationModal ", () => {
     expect(screen.getByTestId("extraElement")).toBeInTheDocument();
   });
 
-  it("shows the shift click hint", () => {
-    const { container } = render(
-      <ConfirmationModal
-        hasShiftClickHint
-        confirmButtonLabel="Proceed"
-        onConfirm={jest.fn()}
-      >
-        Test shift click hint
-      </ConfirmationModal>
-    );
-    expect(container.innerHTML).toContain(
-      "You can skip these confirmation modals by holding"
-    );
-  });
-
   it("executes the onConfirm callback when confirm button is clicked", async () => {
     const onConfirm = jest.fn();
     render(

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,81 @@
+import React, { MouseEvent, ReactElement } from "react";
+import type { ReactNode } from "react";
+import { PropsWithSpread, ValueOf } from "types";
+import Button, { ButtonAppearance } from "components/Button";
+import Modal, { ModalProps } from "components/Modal";
+
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Label for the cancel button.
+     */
+    cancelButtonLabel?: string;
+    /**
+     * The content of the modal.
+     */
+    children: ReactNode;
+    /**
+     * Appearance of the confirm button.
+     */
+    confirmButtonAppearance?: ValueOf<typeof ButtonAppearance> | string;
+    /**
+     * Label for the confirm button.
+     */
+    confirmButtonLabel: string;
+    /**
+     * Extra elements to be placed in the button row of the modal.
+     */
+    confirmExtra?: ReactNode;
+    /**
+     * Show the SHIFT+Click shortcut hint to skip the confirmation.
+     */
+    hasShiftClickHint?: boolean;
+    /**
+     * Function to perform the action prompted by the modal.
+     */
+    onConfirm: (e: MouseEvent<HTMLElement>) => void;
+  },
+  Omit<ModalProps, "buttonRow">
+>;
+
+export const ConfirmationModal = ({
+  cancelButtonLabel = "Cancel",
+  children,
+  confirmButtonAppearance = "negative",
+  confirmButtonLabel,
+  confirmExtra,
+  hasShiftClickHint = false,
+  onConfirm,
+  ...props
+}: Props): ReactElement => {
+  return (
+    <Modal
+      buttonRow={
+        <>
+          {confirmExtra}
+          <Button className="u-no-margin--bottom" onClick={props.close}>
+            {cancelButtonLabel}
+          </Button>
+          <Button
+            appearance={confirmButtonAppearance}
+            className="u-no-margin--bottom"
+            onClick={onConfirm}
+          >
+            {confirmButtonLabel}
+          </Button>
+        </>
+      }
+      {...props}
+    >
+      <p style={{ textAlign: "start", whiteSpace: "pre-line" }}>{children}</p>
+      {hasShiftClickHint && (
+        <p className="u-text--muted u-hide--small">
+          You can skip these confirmation modals by holding <code>SHIFT</code>{" "}
+          when clicking on the action.
+        </p>
+      )}
+    </Modal>
+  );
+};
+
+export default ConfirmationModal;

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -27,10 +27,6 @@ export type Props = PropsWithSpread<
      */
     confirmExtra?: ReactNode;
     /**
-     * Show the SHIFT+Click shortcut hint to skip the confirmation.
-     */
-    hasShiftClickHint?: boolean;
-    /**
      * Function to perform the action prompted by the modal.
      */
     onConfirm: (e: MouseEvent<HTMLElement>) => void;
@@ -44,7 +40,6 @@ export const ConfirmationModal = ({
   confirmButtonAppearance = "negative",
   confirmButtonLabel,
   confirmExtra,
-  hasShiftClickHint = false,
   onConfirm,
   ...props
 }: Props): ReactElement => {
@@ -67,13 +62,7 @@ export const ConfirmationModal = ({
       }
       {...props}
     >
-      <p style={{ textAlign: "start", whiteSpace: "pre-line" }}>{children}</p>
-      {hasShiftClickHint && (
-        <p className="u-text--muted u-hide--small">
-          You can skip these confirmation modals by holding <code>SHIFT</code>{" "}
-          when clicking on the action.
-        </p>
-      )}
+      {children}
     </Modal>
   );
 };

--- a/src/components/ConfirmationModal/index.ts
+++ b/src/components/ConfirmationModal/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ConfirmationModal";
+export type { Props as ConfirmationModalProps } from "./ConfirmationModal";

--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -65,8 +65,8 @@ The modal component can be used to overlay an area of the screen which can conta
               }
             >
               <p>
-                Are you sure you want to delete user "Simon"? This action is
-                permanent and can not be undone.
+                This will permanently delete the user "Simon".<br/>
+                You cannot undo this action.
               </p>
             </Modal>
           ) : null}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   CodeSnippetBlockAppearance,
 } from "./components/CodeSnippet";
 export { default as Col } from "./components/Col";
+export { default as ConfirmationButton } from "./components/ConfirmationButton";
 export { default as ConfirmationModal } from "./components/ConfirmationModal";
 export { default as ContextualMenu } from "./components/ContextualMenu";
 export { default as Field } from "./components/Field";
@@ -69,6 +70,7 @@ export type {
   CodeSnippetDropdownProps,
 } from "./components/CodeSnippet";
 export type { ColProps, ColSize } from "./components/Col";
+export type { ConfirmationButtonProps } from "./components/ConfirmationButton";
 export type { ConfirmationModalProps } from "./components/ConfirmationModal";
 export type {
   ContextualMenuProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   CodeSnippetBlockAppearance,
 } from "./components/CodeSnippet";
 export { default as Col } from "./components/Col";
+export { default as ConfirmationModal } from "./components/ConfirmationModal";
 export { default as ContextualMenu } from "./components/ContextualMenu";
 export { default as Field } from "./components/Field";
 export { default as Form } from "./components/Form";
@@ -68,6 +69,7 @@ export type {
   CodeSnippetDropdownProps,
 } from "./components/CodeSnippet";
 export type { ColProps, ColSize } from "./components/Col";
+export type { ConfirmationModalProps } from "./components/ConfirmationModal";
 export type {
   ContextualMenuProps,
   ContextualMenuDropdownProps,


### PR DESCRIPTION
## Done

- Added ConfirmationModal component
- Added ConfirmationButton component

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check an usage example of the 2 new components in the Storybook

## Fixes

Fixes: [WD-4255](https://warthogs.atlassian.net/browse/WD-4255).

[WD-4255]: https://warthogs.atlassian.net/browse/WD-4255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ