### PR TITLE
Add notification provider WD-4256

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",
+    "@types/react-router-dom": "5.3.3",
     "@typescript-eslint/eslint-plugin": "5.60.1",
     "@typescript-eslint/parser": "5.60.1",
     "babel-jest": "27.5.1",
@@ -91,6 +92,7 @@
     "classnames": "2.3.2",
     "nanoid": "3.3.6",
     "prop-types": "15.8.1",
+    "react-router-dom": "6.6.1",
     "react-table": "7.8.0",
     "react-useportal": "1.0.18"
   },

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -89,7 +89,7 @@ export type Props<L> = PropsWithSpread<
     /**
      * The toggle button's label.
      */
-    toggleLabel?: string | React.ReactNode | null;
+    toggleLabel?: React.ReactNode | null;
     /**
      * Whether the toggle lable or icon should appear first.
      */

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -18,6 +18,13 @@ export const NotificationSeverity = {
   POSITIVE: "positive",
 } as const;
 
+export const DefaultTitles = {
+  [NotificationSeverity.CAUTION]: "Warning",
+  [NotificationSeverity.INFORMATION]: "Info",
+  [NotificationSeverity.NEGATIVE]: "Error",
+  [NotificationSeverity.POSITIVE]: "Success",
+};
+
 type NotificationAction = {
   label: string;
   onClick: () => void;

--- a/src/components/NotificationProvider/NotificationProvider.test.tsx
+++ b/src/components/NotificationProvider/NotificationProvider.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  NotificationConsumer,
+  NotificationProvider,
+  useNotify,
+} from "./NotificationProvider";
+import { BrowserRouter } from "react-router-dom";
+import Button from "../Button";
+import { act } from "react-dom/test-utils";
+
+describe("NotificationProvider", () => {
+  it("stores and renders notifications", async () => {
+    const handleRetry = jest.fn();
+
+    const TriggerComponent = () => {
+      const notify = useNotify();
+      const handleSuccess = () => notify.success("My success!");
+      const handleClear = () => notify.clear();
+      const handleInfo = () => notify.info("Some more details", "Test info");
+      const handleError = () =>
+        notify.failure(
+          "Fail title",
+          new Error("error message"),
+          "Button caused a failure",
+          [
+            {
+              label: "Retry",
+              onClick: handleRetry,
+            },
+          ]
+        );
+
+      return (
+        <div>
+          <Button onClick={handleSuccess} data-testid="success-btn" />
+          <Button onClick={handleClear} data-testid="clear-btn" />
+          <Button onClick={handleError} data-testid="error-btn" />
+          <Button onClick={handleInfo} data-testid="info-btn" />
+        </div>
+      );
+    };
+
+    render(
+      <div>
+        <NotificationProvider>
+          <TriggerComponent />
+          <div data-testid="notification-consumer">
+            <NotificationConsumer />
+          </div>
+        </NotificationProvider>
+      </div>,
+      { wrapper: BrowserRouter }
+    );
+
+    const clickBtn = async (testId: string) =>
+      await act(async () => await userEvent.click(screen.getByTestId(testId)));
+
+    expect(screen.getByTestId("notification-consumer")).toBeEmptyDOMElement();
+
+    await clickBtn("success-btn");
+    expect(screen.getByTestId("notification-consumer")).toMatchSnapshot();
+
+    await clickBtn("clear-btn");
+    expect(screen.getByTestId("notification-consumer")).toBeEmptyDOMElement();
+
+    await clickBtn("error-btn");
+    expect(screen.getByTestId("notification-consumer")).toMatchSnapshot();
+
+    expect(handleRetry).not.toHaveBeenCalled();
+    await clickBtn("notification-action");
+    expect(handleRetry).toHaveBeenCalled();
+
+    await clickBtn("info-btn");
+    expect(screen.getByTestId("notification-consumer")).toMatchSnapshot();
+  });
+});

--- a/src/components/NotificationProvider/NotificationProvider.tsx
+++ b/src/components/NotificationProvider/NotificationProvider.tsx
@@ -1,0 +1,103 @@
+import React, {
+  createContext,
+  FC,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  NotificationType,
+  NotificationHelper,
+  QueuedNotification,
+  NotifyProviderProps,
+} from "./types";
+import { useLocation } from "react-router-dom";
+import isEqual from "lodash/isEqual";
+import { info, failure, success, queue } from "./messageBuilder";
+import Notification, { DefaultTitles } from "../Notification/Notification";
+
+const NotifyContext = createContext<NotificationHelper>({
+  notification: null,
+  clear: () => undefined,
+  failure: () => undefined,
+  success: () => undefined,
+  info: () => undefined,
+  queue: () => undefined,
+});
+
+export const NotificationProvider: FC<NotifyProviderProps> = ({ children }) => {
+  const [notification, setNotification] = useState<NotificationType | null>(
+    null
+  );
+  const { state, pathname } = useLocation() as QueuedNotification;
+
+  const clear = () => notification !== null && setNotification(null);
+
+  const setDeduplicated = (value: NotificationType) => {
+    if (!isEqual(value, notification)) {
+      setNotification(value);
+    }
+    return value;
+  };
+
+  useEffect(() => {
+    if (state?.queuedNotification) {
+      setDeduplicated(state.queuedNotification);
+      window.history.replaceState({}, "");
+    } else {
+      clear();
+    }
+  }, [state, pathname]);
+
+  const helper: NotificationHelper = {
+    notification,
+    clear,
+    queue,
+    failure: (title, error, message, actions) =>
+      setDeduplicated(failure(title, error, message, actions)),
+    info: (message, title) => setDeduplicated(info(message, title)),
+    success: (message) => setDeduplicated(success(message)),
+  };
+
+  return (
+    <NotifyContext.Provider value={helper}>{children}</NotifyContext.Provider>
+  );
+};
+
+export function useNotify() {
+  return useContext(NotifyContext);
+}
+
+export const NotificationConsumer: FC = () => {
+  const notify = useNotify();
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (ref.current?.hasAttribute("scrollIntoView")) {
+      ref.current.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+        inline: "start",
+      });
+    }
+  }, [notify.notification]);
+
+  if (!notify.notification) {
+    return null;
+  }
+  const { actions, title, type, message } = notify.notification;
+
+  return (
+    <div ref={ref}>
+      <Notification
+        title={title ?? DefaultTitles[type]}
+        actions={actions}
+        severity={type}
+        onDismiss={notify.clear}
+      >
+        {message}
+      </Notification>
+    </div>
+  );
+};

--- a/src/components/NotificationProvider/__snapshots__/NotificationProvider.test.tsx.snap
+++ b/src/components/NotificationProvider/__snapshots__/NotificationProvider.test.tsx.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationProvider stores and renders notifications 1`] = `
+<div
+  data-testid="notification-consumer"
+>
+  <div>
+    <div
+      class="p-notification--positive"
+    >
+      <div
+        class="p-notification__content"
+      >
+        <h5
+          class="p-notification__title"
+          data-testid="notification-title"
+        >
+          Success
+        </h5>
+        <p
+          class="p-notification__message"
+        >
+          My success!
+        </p>
+        <button
+          class="p-notification__close"
+          data-testid="notification-close-button"
+        >
+          Close notification
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NotificationProvider stores and renders notifications 2`] = `
+<div
+  data-testid="notification-consumer"
+>
+  <div>
+    <div
+      class="p-notification--negative"
+    >
+      <div
+        class="p-notification__content"
+      >
+        <h5
+          class="p-notification__title"
+          data-testid="notification-title"
+        >
+          Fail title
+        </h5>
+        <p
+          class="p-notification__message"
+        >
+          Button caused a failure
+           
+          error message
+        </p>
+        <button
+          class="p-notification__close"
+          data-testid="notification-close-button"
+        >
+          Close notification
+        </button>
+      </div>
+      <div
+        class="p-notification__meta"
+        data-testid="notification-meta"
+      >
+        <div
+          class="p-notification__actions"
+        >
+          <button
+            class="p-button--link p-notification__action"
+            data-testid="notification-action"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NotificationProvider stores and renders notifications 3`] = `
+<div
+  data-testid="notification-consumer"
+>
+  <div>
+    <div
+      class="p-notification--information"
+    >
+      <div
+        class="p-notification__content"
+      >
+        <h5
+          class="p-notification__title"
+          data-testid="notification-title"
+        >
+          Test info
+        </h5>
+        <p
+          class="p-notification__message"
+        >
+          Some more details
+        </p>
+        <button
+          class="p-notification__close"
+          data-testid="notification-close-button"
+        >
+          Close notification
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/NotificationProvider/index.ts
+++ b/src/components/NotificationProvider/index.ts
@@ -1,0 +1,12 @@
+export {
+  NotificationConsumer,
+  NotificationProvider,
+  useNotify,
+} from "./NotificationProvider";
+export { info, success, failure, queue } from "./messageBuilder";
+export type {
+  NotificationAction,
+  NotificationType,
+  QueuedNotification,
+  NotificationHelper,
+} from "./types";

--- a/src/components/NotificationProvider/messageBuilder.tsx
+++ b/src/components/NotificationProvider/messageBuilder.tsx
@@ -1,0 +1,47 @@
+import {
+  NotificationAction,
+  NotificationType,
+  QueuedNotification,
+} from "./types";
+import React, { ReactNode } from "react";
+import { NotificationSeverity } from "../Notification";
+
+export const queue = (notification: NotificationType): QueuedNotification => {
+  return { state: { queuedNotification: notification } };
+};
+
+export const info = (message: ReactNode, title?: string): NotificationType => {
+  return {
+    message,
+    title,
+    type: NotificationSeverity.INFORMATION,
+  };
+};
+
+export const success = (message: ReactNode): NotificationType => {
+  return {
+    message,
+    type: NotificationSeverity.POSITIVE,
+  };
+};
+
+export const failure = (
+  title: string,
+  error: unknown,
+  message?: ReactNode,
+  actions?: NotificationAction[]
+): NotificationType => {
+  return {
+    actions,
+    message:
+      error && error instanceof Error ? (
+        <>
+          {message} {error.message}
+        </>
+      ) : (
+        message
+      ),
+    title,
+    type: NotificationSeverity.NEGATIVE,
+  };
+};

--- a/src/components/NotificationProvider/types.ts
+++ b/src/components/NotificationProvider/types.ts
@@ -1,0 +1,40 @@
+import { ReactNode } from "react";
+import { ValueOf } from "types";
+import { NotificationSeverity } from "../Notification";
+
+export interface NotifyProviderProps {
+  children: ReactNode;
+}
+
+export interface NotificationAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface NotificationType {
+  actions?: NotificationAction[];
+  message: ReactNode;
+  title?: string;
+  type: ValueOf<typeof NotificationSeverity>;
+}
+
+export interface QueuedNotification {
+  state?: {
+    queuedNotification: NotificationType | null;
+  };
+  pathname?: string;
+}
+
+export interface NotificationHelper {
+  notification: NotificationType | null;
+  clear: () => void;
+  failure: (
+    title: string,
+    error: unknown,
+    message?: ReactNode,
+    actions?: NotificationAction[]
+  ) => NotificationType;
+  info: (message: ReactNode, title?: string) => NotificationType;
+  success: (message: ReactNode) => NotificationType;
+  queue: (notification: NotificationType) => QueuedNotification;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,15 @@ export {
   default as Notification,
   NotificationSeverity,
 } from "./components/Notification";
+export {
+  NotificationConsumer,
+  NotificationProvider,
+  useNotify,
+  info,
+  success,
+  failure,
+  queue,
+} from "./components/NotificationProvider";
 export { default as Pagination } from "./components/Pagination";
 export { default as PasswordToggle } from "./components/PasswordToggle";
 export { default as RadioInput } from "./components/RadioInput";
@@ -101,6 +110,12 @@ export type {
   NavLinkButton,
 } from "./components/Navigation";
 export type { NotificationProps } from "./components/Notification";
+export type {
+  NotificationAction,
+  NotificationType,
+  QueuedNotification,
+  NotificationHelper,
+} from "./components/NotificationProvider";
 export type { PaginationProps } from "./components/Pagination";
 export type { RadioInputProps } from "./components/RadioInput";
 export type { RowProps } from "./components/Row";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,6 +2240,11 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@remix-run/router@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.2.1.tgz#812edd4104a15a493dda1ccac0b352270d7a188c"
+  integrity sha512-XiY0IsyHR+DXYS5vBxpoBe/8veTeoRpMHP+vDosLZxL5bnpetzI0igkxkLZS235ldLzyfkxF+2divEwWHP3vMQ==
+
 "@rushstack/eslint-patch@^1.1.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.3.0.tgz#f5635b36fc0dad96ef1e542a302cd914230188c0"
@@ -3219,6 +3224,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -3374,6 +3384,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.6.tgz#ad621fa71a8db29af7c31b41b2ea3d8a6f4144d1"
   integrity sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.20"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.20.tgz#88eccaa122a82405ef3efbcaaa5dcdd9f021387c"
+  integrity sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==
+  dependencies:
+    "@types/history" "^4.7.11"
     "@types/react" "*"
 
 "@types/react-table@7.7.14":
@@ -11560,6 +11587,21 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-dom@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.6.1.tgz#1b96ec0b2cefa7319f1251383ea5b41295ee260d"
+  integrity sha512-u+8BKUtelStKbZD5UcY0NY90WOzktrkJJhyhNg7L0APn9t1qJNLowzrM9CHdpB6+rcPt6qQrlkIXsTvhuXP68g==
+  dependencies:
+    "@remix-run/router" "1.2.1"
+    react-router "6.6.1"
+
+react-router@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.6.1.tgz#17de6cf285f2d1c9721a3afca999c984e5558854"
+  integrity sha512-YkvlYRusnI/IN0kDtosUCgxqHeulN5je+ew8W+iA1VvFhf86kA+JEI/X/8NqYcr11hCDDp906S+SGMpBheNeYQ==
+  dependencies:
+    "@remix-run/router" "1.2.1"
 
 react-sizeme@^3.0.1:
   version "3.0.2"


### PR DESCRIPTION
## Done

- Added NotificationProvider.
- Allows to trigger messages with the `const notify = useNotify();` hook easily, like  `notify.success("The thing finished` or `notify.failure("the thing failed", exception)`.
- Added a convenient `<NotifyConsumer>`, that can be placed anywhere and will render any triggered notification. This can be placed flexibly on top of a form, in a modal or used in an overlay.

Fixes: [WD-4256](https://warthogs.atlassian.net/browse/WD-4256)


[WD-4256]: https://warthogs.atlassian.net/browse/WD-4256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ