### PR TITLE
fix(ActionButton) reset height and width after loading finished

### DIFF
--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -88,6 +88,11 @@ const ActionButton = ({
       }, LOADER_MIN_DURATION);
     }
 
+    if (!loading && !showLoader) {
+      setHeight(null);
+      setWidth(null);
+    }
+
     return () => window.clearTimeout(loaderTimeout);
   }, [loading, showLoader, success]);
 


### PR DESCRIPTION
## Done

- reset height and width after loading finished on the ActionButton
- it used to leak setting height and width on load and keeping it set in the dom