### PR TITLE
fix(theme) use default colors for the custom theme WD-4880

### DIFF
--- a/.storybook/vanillaish.js
+++ b/.storybook/vanillaish.js
@@ -3,13 +3,7 @@ import { create } from "@storybook/theming/create";
 export default create({
   base: "light",
 
-  colorPrimary: "#fff",
-  colorSecondary: "rgba(0,0,0,0.05)",
-
   // UI
-  appBg: "#fff",
-  appContentBg: "#fff",
-  appBorderColor: "#cdcdcd",
   appBorderRadius: ".125rem",
 
   // Typography
@@ -17,19 +11,7 @@ export default create({
     '"Ubuntu", -apple-system, "Segoe UI", "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
   fontCode: '"Ubuntu Mono", Consolas, Monaco, Courier, monospace',
 
-  // Text colors
-  textColor: "#111",
-  textInverseColor: "#111",
-
-  // Toolbar default and active colors
-  barTextColor: "#111",
-  barSelectedColor: "#666",
-  barBg: "#fff",
-
   // Form colors
-  inputBg: "#fff",
-  inputBorder: "#cdcdcd",
-  inputTextColor: "#111",
   inputBorderRadius: ".125rem",
 
   brandTitle: "Vanilla React Library",


### PR DESCRIPTION
## Done

- use default colors for the custom theme
- fixes the contrast for the navigation font

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA steps

- check storybook navigation colours

## Fixes

Fixes: WD-4880
