### PR TITLE
Fix ConfirmationModal to focus on positive confirm button#945

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,5 +1,5 @@
-import React, { MouseEvent, ReactElement } from "react";
-import type { ReactNode } from "react";
+import React, { MouseEvent, ReactElement, useRef, useEffect } from "react";
+import type { ReactNode, MutableRefObject, RefObject } from "react";
 import { PropsWithSpread, ValueOf } from "types";
 import Button, { ButtonAppearance } from "components/Button";
 import Modal, { ModalProps } from "components/Modal";
@@ -43,27 +43,50 @@ export const ConfirmationModal = ({
   onConfirm,
   ...props
 }: Props): ReactElement => {
-  return (
-    <Modal
-      buttonRow={
-        <>
-          {confirmExtra}
-          <Button className="u-no-margin--bottom" onClick={props.close}>
-            {cancelButtonLabel}
-          </Button>
-          <Button
-            appearance={confirmButtonAppearance}
-            className="u-no-margin--bottom"
-            onClick={onConfirm}
-          >
-            {confirmButtonLabel}
-          </Button>
-        </>
+  const modalRef: MutableRefObject<HTMLElement> = useRef(null);
+
+  useEffect(() => {
+    if (modalRef.current) {
+      const positiveButton: HTMLButtonElement | null =
+        modalRef?.current?.querySelector("button.p-button--positive");
+      // If the modal has a positive button then focus on that after opening
+      // to make a better keyboard navigation experience.
+      if (positiveButton) {
+        console.log("positive button focus");
+        positiveButton.focus();
+      } else {
+        // If there is no button then focus on the modal wrapper.
+        modalRef.current.focus();
       }
-      {...props}
+    }
+  }, []);
+
+  return (
+    <div
+      className="p-confirmation-modal"
+      ref={modalRef as RefObject<HTMLDivElement>}
     >
-      {children}
-    </Modal>
+      <Modal
+        buttonRow={
+          <>
+            {confirmExtra}
+            <Button className="u-no-margin--bottom" onClick={props.close}>
+              {cancelButtonLabel}
+            </Button>
+            <Button
+              appearance={confirmButtonAppearance}
+              className="u-no-margin--bottom"
+              onClick={onConfirm}
+            >
+              {confirmButtonLabel}
+            </Button>
+          </>
+        }
+        {...props}
+      >
+        {children}
+      </Modal>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Done

* Allow ConfirmationModal to focus on the positive confirm button when opening the modal, letting users press enter to confirm
* If confirm button is not positive, modal focus will be on the cancel button

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

* Use ConfirmationModal component and change`confirmButtonAppearance`  to `positive/negative/neutral`. Click enter to verify which buttons are clicked.

## Fixes

Fixes: #945
