### PR TITLE
feat: Buttons-only Pagination

### DIFF
--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -12,7 +12,8 @@ This is a [React](https://reactjs.org/) component for the Vanilla [Pagination](h
 
 The pagination component should be used to navigate between pages of content. There are two types of pagination being provided:
 
-- **Numbered Pagination:** used when the total number of items is known. Depending on the length provided, the pagination component will automatically scale.<br/>
+- **Numbered Pagination:** used when the total number of items is known.<br/>
+  Depending on the length provided, the pagination component will automatically scale.<br/>
   **Required props:** itemsPerPage, totalItems, paginate, currentPage.
 
 - **Buttons-only Pagination:** used when the total number of items is unknown.<br/>
@@ -78,7 +79,7 @@ The pagination component should be used to navigate between pages of content. Th
   </Story>
 </Canvas>
 
-### Disabled pagination items (Numbered Pagination)
+### Hidden pagination items (Numbered Pagination)
 
 <Canvas>
   <Story name="Disabled pagination items (Numbered Pagination)">
@@ -92,10 +93,18 @@ The pagination component should be used to navigate between pages of content. Th
   </Story>
 </Canvas>
 
-### Custom button names (Buttons-only pagination)
+### Default (Buttons-only pagination)
 
 <Canvas>
   <Story name="Default (Buttons-only Pagination)">
+    <Pagination onForward={() => {}} onBack={() => {}} />
+  </Story>
+</Canvas>
+
+### Custom button names (Buttons-only pagination)
+
+<Canvas>
+  <Story name="Custom buttons (Buttons-only Pagination)">
     <Pagination
       onForward={() => {}}
       onBack={() => {}}

--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -101,10 +101,18 @@ The pagination component should be used to navigate between pages of content. Th
   </Story>
 </Canvas>
 
-### Custom button names (Buttons-only pagination)
+### Default button labels (Buttons-only pagination)
 
 <Canvas>
-  <Story name="Custom buttons (Buttons-only Pagination)">
+  <Story name="Default button labels (Buttons-only Pagination)">
+    <Pagination onForward={() => {}} onBack={() => {}} showLabels />
+  </Story>
+</Canvas>
+
+### Custom button labels (Buttons-only pagination)
+
+<Canvas>
+  <Story name="Custom button labels (Buttons-only Pagination)">
     <Pagination
       onForward={() => {}}
       onBack={() => {}}
@@ -112,5 +120,13 @@ The pagination component should be used to navigate between pages of content. Th
       forwardLabel="Custom forward label"
       backLabel="Custom back label"
     />
+  </Story>
+</Canvas>
+
+### Centered (Buttons-only pagination)
+
+<Canvas>
+  <Story name="Centered (Buttons-only Pagination)">
+    <Pagination onForward={() => {}} onBack={() => {}} centered />
   </Story>
 </Canvas>

--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -10,13 +10,19 @@ export const Template = (args) => <Pagination {...args} />;
 
 This is a [React](https://reactjs.org/) component for the Vanilla [Pagination](https://docs.vanillaframework.io/patterns/pagination/).
 
-The pagination component should be used to navigate between pages of content. Depending on the length provided, the pagination component will automatically scale.
+The pagination component should be used to navigate between pages of content. There are two types of pagination being provided:
+
+- **Numbered Pagination:** used when the total number of items is known. Depending on the length provided, the pagination component will automatically scale.<br/>
+  **Required props:** itemsPerPage, totalItems, paginate, currentPage.
+
+- **Buttons-only Pagination:** used when the total number of items is unknown.<br/>
+  **Required props:** onForward, onBack.
 
 ### Props
 
 <ArgsTable of={Pagination} />
 
-### Default
+### Default (Numbered Pagination)
 
 <Canvas>
   <Story
@@ -32,10 +38,10 @@ The pagination component should be used to navigate between pages of content. De
   </Story>
 </Canvas>
 
-### Truncated
+### Truncated (Numbered Pagination)
 
 <Canvas>
-  <Story name="Truncated">
+  <Story name="Truncated (Numbered Pagination)">
     <Pagination
       itemsPerPage={10}
       totalItems={1000}
@@ -45,10 +51,10 @@ The pagination component should be used to navigate between pages of content. De
   </Story>
 </Canvas>
 
-### Disabled controls
+### Disabled controls (Numbered Pagination)
 
 <Canvas>
-  <Story name="Disabled controls">
+  <Story name="Disabled controls (Numbered Pagination)">
     <Pagination
       itemsPerPage={20}
       totalItems={100}
@@ -58,16 +64,44 @@ The pagination component should be used to navigate between pages of content. De
   </Story>
 </Canvas>
 
-### Centered
+### Centered (Numbered Pagination)
 
 <Canvas>
-  <Story name="Centered">
+  <Story name="Centered (Numbered Pagination)">
     <Pagination
       itemsPerPage={10}
       totalItems={50}
       paginate={() => {}}
       currentPage={1}
       centered
+    />
+  </Story>
+</Canvas>
+
+### Disabled pagination items (Numbered Pagination)
+
+<Canvas>
+  <Story name="Disabled pagination items (Numbered Pagination)">
+    <Pagination
+      itemsPerPage={10}
+      totalItems={50}
+      paginate={() => {}}
+      currentPage={1}
+      hideNumbers
+    />
+  </Story>
+</Canvas>
+
+### Custom button names (Buttons-only pagination)
+
+<Canvas>
+  <Story name="Default (Buttons-only Pagination)">
+    <Pagination
+      onForward={() => {}}
+      onBack={() => {}}
+      showLabels
+      forwardLabel="Custom forward label"
+      backLabel="Custom back label"
     />
   </Story>
 </Canvas>

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -7,7 +7,7 @@ import { Label as PaginationButtonLabel } from "./PaginationButton/PaginationBut
 
 describe("<Pagination />", () => {
   // snapshot tests
-  it("renders and matches the snapshot", () => {
+  it("renders numbered pagination and matches the snapshot", () => {
     render(
       <Pagination
         itemsPerPage={10}
@@ -21,7 +21,7 @@ describe("<Pagination />", () => {
   });
 
   // unit tests
-  it("renders no pagination with only a single page", () => {
+  it("renders no numbered pagination with only a single page", () => {
     render(
       <Pagination
         itemsPerPage={10}
@@ -34,7 +34,7 @@ describe("<Pagination />", () => {
     expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
   });
 
-  it("renders a simple paginator with back and forward arrows if only five pages or less", () => {
+  it("renders a simple numbered paginator with back and forward arrows if only five pages or less", () => {
     render(
       <Pagination
         itemsPerPage={10}
@@ -60,7 +60,7 @@ describe("<Pagination />", () => {
     expect(screen.getByRole("button", { name: "5" })).toBeInTheDocument();
   });
 
-  it("renders a complex paginator with truncation if more than five pages", () => {
+  it("renders a complex numbered paginator with truncation if more than five pages", () => {
     render(
       <Pagination
         itemsPerPage={10}
@@ -112,7 +112,7 @@ describe("<Pagination />", () => {
     expect(screen.getAllByText("…")).toHaveLength(1);
   });
 
-  it("does not trigger form submission on pagination button click by default", async () => {
+  it("does not trigger form submission on numbered pagination button click by default", async () => {
     const handleOnSubmit = jest.fn();
     render(
       <form onSubmit={handleOnSubmit}>
@@ -130,7 +130,7 @@ describe("<Pagination />", () => {
     expect(handleOnSubmit).not.toHaveBeenCalled();
   });
 
-  it("can be centered", () => {
+  it("should center the numbered pagination", () => {
     render(
       <Pagination
         itemsPerPage={10}
@@ -144,5 +144,50 @@ describe("<Pagination />", () => {
     expect(document.querySelector(".p-pagination__items")).toHaveClass(
       "u-align--center"
     );
+  });
+
+  it("should render default buttons-only pagination and match the snapshot", () => {
+    render(<Pagination onForward={() => {}} onBack={() => {}} />);
+    expect(screen.getByRole("navigation")).toMatchSnapshot();
+  });
+
+  it("should show default labels for buttons-only pagination", () => {
+    render(<Pagination onForward={() => {}} onBack={() => {}} showLabels />);
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+    expect(
+      screen
+        .getByRole("button", { name: /Previous page/ })
+        // eslint-disable-next-line testing-library/no-node-access
+        .querySelector("span")
+    ).toHaveTextContent("Previous page");
+    expect(
+      // eslint-disable-next-line testing-library/no-node-access
+      screen.getByRole("button", { name: /Next page/ }).querySelector("span")
+    ).toHaveTextContent("Next page");
+  });
+
+  it("should show custom labels for buttons-only pagination", () => {
+    render(
+      <Pagination
+        onForward={() => {}}
+        onBack={() => {}}
+        showLabels
+        forwardLabel="Custom forward label"
+        backLabel="Custom back label"
+      />
+    );
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+    expect(
+      screen
+        .getByRole("button", { name: /Custom forward label/ })
+        // eslint-disable-next-line testing-library/no-node-access
+        .querySelector("span")
+    ).toHaveTextContent("Custom forward label");
+    expect(
+      screen
+        .getByRole("button", { name: /Custom back label/ })
+        // eslint-disable-next-line testing-library/no-node-access
+        .querySelector("span")
+    ).toHaveTextContent("Custom back label");
   });
 });

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,9 +1,11 @@
+/* eslint-disable testing-library/no-node-access */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Pagination from "./Pagination";
 import { Label as PaginationButtonLabel } from "./PaginationButton/PaginationButton";
+import { CustomLabel as CustomButtonLabel } from "./PaginationButton/PaginationButton.test";
 
 describe("<Pagination />", () => {
   // snapshot tests
@@ -84,7 +86,7 @@ describe("<Pagination />", () => {
     expect(screen.getByRole("button", { name: "100" })).toBeInTheDocument();
   });
 
-  it("does not render a truncation separator if currentPage is contiguous at start", () => {
+  it("does not render a truncation separator for numbered pagination if currentPage is contiguous at start", () => {
     render(
       <Pagination
         itemsPerPage={10}
@@ -98,7 +100,7 @@ describe("<Pagination />", () => {
     expect(screen.getAllByText("…")).toHaveLength(1);
   });
 
-  it("does not render a truncation separator if currentPage is contiguous at end", () => {
+  it("does not render a truncation separator for numbered pagination if currentPage is contiguous at end", () => {
     render(
       <Pagination
         itemsPerPage={10}
@@ -140,54 +142,269 @@ describe("<Pagination />", () => {
         centered
       />
     );
-    // eslint-disable-next-line testing-library/no-node-access
     expect(document.querySelector(".p-pagination__items")).toHaveClass(
       "u-align--center"
     );
   });
 
-  it("should render default buttons-only pagination and match the snapshot", () => {
-    render(<Pagination onForward={() => {}} onBack={() => {}} />);
-    expect(screen.getByRole("navigation")).toMatchSnapshot();
-  });
-
-  it("should show default labels for buttons-only pagination", () => {
-    render(<Pagination onForward={() => {}} onBack={() => {}} showLabels />);
-    expect(screen.getAllByRole("button")).toHaveLength(2);
-    expect(
-      screen
-        .getByRole("button", { name: /Previous page/ })
-        // eslint-disable-next-line testing-library/no-node-access
-        .querySelector("span")
-    ).toHaveTextContent("Previous page");
-    expect(
-      // eslint-disable-next-line testing-library/no-node-access
-      screen.getByRole("button", { name: /Next page/ }).querySelector("span")
-    ).toHaveTextContent("Next page");
-  });
-
-  it("should show custom labels for buttons-only pagination", () => {
+  it("should show default labels in correct order for numbered pagination", () => {
     render(
       <Pagination
-        onForward={() => {}}
-        onBack={() => {}}
+        itemsPerPage={10}
+        totalItems={50}
+        paginate={jest.fn()}
+        currentPage={1}
         showLabels
-        forwardLabel="Custom forward label"
-        backLabel="Custom back label"
+      />
+    );
+    const previousButton = screen.getByRole("button", {
+      name: new RegExp(PaginationButtonLabel.Previous),
+    });
+    expect(previousButton.querySelector("span")).toHaveTextContent(
+      PaginationButtonLabel.Previous
+    );
+    const nextButton = screen.getByRole("button", {
+      name: new RegExp(PaginationButtonLabel.Next),
+    });
+    expect(nextButton.querySelector("span")).toHaveTextContent(
+      PaginationButtonLabel.Next
+    );
+    expect(
+      previousButton &&
+        nextButton &&
+        previousButton.compareDocumentPosition(nextButton) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("should show custom labels in correct order for numbered pagination", () => {
+    render(
+      <Pagination
+        itemsPerPage={10}
+        totalItems={50}
+        paginate={jest.fn()}
+        currentPage={1}
+        showLabels
+        forwardLabel={CustomButtonLabel.Next}
+        backLabel={CustomButtonLabel.Previous}
+      />
+    );
+    const previousButton = screen.getByRole("button", {
+      name: new RegExp(CustomButtonLabel.Previous),
+    });
+    expect(previousButton.querySelector("span")).toHaveTextContent(
+      CustomButtonLabel.Previous
+    );
+    const nextButton = screen.getByRole("button", {
+      name: new RegExp(CustomButtonLabel.Next),
+    });
+    expect(nextButton.querySelector("span")).toHaveTextContent(
+      CustomButtonLabel.Next
+    );
+    expect(
+      previousButton &&
+        nextButton &&
+        previousButton.compareDocumentPosition(nextButton) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("should have forward and back buttons disabled for numbered pagination", () => {
+    render(
+      <Pagination
+        itemsPerPage={10}
+        totalItems={50}
+        paginate={jest.fn()}
+        currentPage={1}
+        forwardDisabled
+        backDisabled
+      />
+    );
+    expect(
+      screen.getByRole("button", {
+        name: PaginationButtonLabel.Next,
+      })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: PaginationButtonLabel.Previous,
+      })
+    ).toBeDisabled();
+  });
+
+  it("should call paginate and onForward for numbered pagination when pressing forward button", async () => {
+    const mockHandlePaginate = jest.fn();
+    const mockHandleForward = jest.fn();
+    render(
+      <Pagination
+        itemsPerPage={10}
+        totalItems={50}
+        paginate={mockHandlePaginate}
+        currentPage={1}
+        onForward={mockHandleForward}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: new RegExp(PaginationButtonLabel.Next),
+      })
+    );
+    expect(mockHandlePaginate).toHaveBeenCalledTimes(1);
+    expect(mockHandlePaginate).toHaveBeenCalledWith(2);
+    expect(mockHandleForward).toHaveBeenCalledTimes(1);
+    expect(mockHandleForward).toHaveBeenCalledWith(2);
+  });
+
+  it("should call paginate and onBack for numbered pagination when pressing back button", async () => {
+    const mockHandlePaginate = jest.fn();
+    const mockHandleBack = jest.fn();
+    render(
+      <Pagination
+        itemsPerPage={10}
+        totalItems={50}
+        paginate={mockHandlePaginate}
+        currentPage={2}
+        onBack={mockHandleBack}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: new RegExp(PaginationButtonLabel.Previous),
+      })
+    );
+    expect(mockHandlePaginate).toHaveBeenCalledTimes(1);
+    expect(mockHandlePaginate).toHaveBeenCalledWith(1);
+    expect(mockHandleBack).toHaveBeenCalledTimes(1);
+    expect(mockHandleBack).toHaveBeenCalledWith(1);
+  });
+
+  it("should hide numbers for numbered pagination", () => {
+    render(
+      <Pagination
+        itemsPerPage={10}
+        totalItems={50}
+        paginate={jest.fn()}
+        currentPage={2}
+        hideNumbers
       />
     );
     expect(screen.getAllByRole("button")).toHaveLength(2);
     expect(
-      screen
-        .getByRole("button", { name: /Custom forward label/ })
-        // eslint-disable-next-line testing-library/no-node-access
-        .querySelector("span")
-    ).toHaveTextContent("Custom forward label");
+      screen.getByRole("button", {
+        name: new RegExp(PaginationButtonLabel.Next),
+      })
+    ).toBeVisible();
     expect(
-      screen
-        .getByRole("button", { name: /Custom back label/ })
-        // eslint-disable-next-line testing-library/no-node-access
-        .querySelector("span")
-    ).toHaveTextContent("Custom back label");
+      screen.getByRole("button", {
+        name: new RegExp(PaginationButtonLabel.Previous),
+      })
+    ).toBeVisible();
+  });
+
+  it("should render default buttons-only pagination and match the snapshot", () => {
+    render(<Pagination onForward={jest.fn()} onBack={jest.fn()} />);
+    expect(screen.getByRole("navigation")).toMatchSnapshot();
+  });
+
+  it("should center the buttons-only pagination", () => {
+    render(<Pagination onForward={jest.fn()} onBack={jest.fn()} centered />);
+    expect(document.querySelector(".p-pagination__items")).toHaveClass(
+      "u-align--center"
+    );
+  });
+
+  it("should show default labels for buttons-only pagination", () => {
+    render(<Pagination onForward={jest.fn()} onBack={jest.fn()} showLabels />);
+    const previousButton = screen.getByRole("button", {
+      name: new RegExp(PaginationButtonLabel.Previous),
+    });
+    expect(previousButton.querySelector("span")).toHaveTextContent(
+      PaginationButtonLabel.Previous
+    );
+    const nextButton = screen.getByRole("button", {
+      name: new RegExp(PaginationButtonLabel.Next),
+    });
+    expect(nextButton.querySelector("span")).toHaveTextContent(
+      PaginationButtonLabel.Next
+    );
+    expect(
+      previousButton &&
+        nextButton &&
+        previousButton.compareDocumentPosition(nextButton) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("should show custom labels in correct order for buttons-only pagination", () => {
+    render(
+      <Pagination
+        onForward={jest.fn()}
+        onBack={jest.fn()}
+        showLabels
+        forwardLabel={CustomButtonLabel.Next}
+        backLabel={CustomButtonLabel.Previous}
+      />
+    );
+    const previousButton = screen.getByRole("button", {
+      name: new RegExp(CustomButtonLabel.Previous),
+    });
+    expect(previousButton.querySelector("span")).toHaveTextContent(
+      CustomButtonLabel.Previous
+    );
+    const nextButton = screen.getByRole("button", {
+      name: new RegExp(CustomButtonLabel.Next),
+    });
+    expect(nextButton.querySelector("span")).toHaveTextContent(
+      CustomButtonLabel.Next
+    );
+    expect(
+      previousButton &&
+        nextButton &&
+        previousButton.compareDocumentPosition(nextButton) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("should have forward and back buttons disabled for buttons-only pagination", () => {
+    render(
+      <Pagination
+        onForward={jest.fn()}
+        onBack={jest.fn()}
+        backDisabled
+        forwardDisabled
+      />
+    );
+    expect(
+      screen.getByRole("button", {
+        name: PaginationButtonLabel.Next,
+      })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: PaginationButtonLabel.Previous,
+      })
+    ).toBeDisabled();
+  });
+
+  it("should call onForward for buttons-only pagination when pressing forward button", async () => {
+    const mockHandleForward = jest.fn();
+    render(<Pagination onForward={mockHandleForward} onBack={jest.fn()} />);
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: new RegExp(PaginationButtonLabel.Next),
+      })
+    );
+    expect(mockHandleForward).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onBack for buttons-only pagination when pressing back button", async () => {
+    const mockHandleBack = jest.fn();
+    render(<Pagination onForward={jest.fn()} onBack={mockHandleBack} />);
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: new RegExp(PaginationButtonLabel.Previous),
+      })
+    );
+    expect(mockHandleBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -132,7 +132,7 @@ type BaseProps = {
 
 // Used when number of items per page, number of total items,
 // current page and paginate function is defined. Pagination
-// ishandled by paginate function and optional onForward and
+// is handled by paginate function and optional onForward and
 // onBack functions.
 type NumberedPagination = BaseProps & {
   /**
@@ -156,23 +156,29 @@ type NumberedPagination = BaseProps & {
    */
   totalItems: number;
   /**
-   * Whever to hide the pagination items.
+   * Whether to hide the pagination items.
    */
   hideNumbers?: boolean;
   /**
-   * Function to handle page transition to a higher-numbered page.<br>
+   * Function to handle page transition to a higher-numbered page for
+   * numbered pagination and to next page for buttons-only pagination.<br>
+   * _Called with page parameter for numbered pagination and_
+   * _with no parameter for buttons-only pagination._<br>
    * **Required for buttons-only pagination.**
    */
   onForward?: (page: number) => void;
   /**
-   * Function to handle on page transition to a lower-numbered page.<br>
+   * Function to handle page transition to a lower-numbered page for
+   * numbered pagination and to next page for buttons-only pagination.<br>
+   * _Called with page parameter for numbered pagination and_
+   * _with no parameter for buttons-only pagination._<br>
    * **Required for buttons-only pagination.**
    */
   onBack?: (page: number) => void;
 };
 
-// Used when at least one of number of items per page, number of
-// total items, current page or paginate function is undefined.
+// Used when number of items per page, number of total items,
+// current page or paginate function are undefined.
 // Pagination is handled by onForward and onBack function.
 type ButtonsOnlyPagination = BaseProps & {
   itemsPerPage?: never;

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -178,7 +178,7 @@ type NumberedPagination = BaseProps & {
 };
 
 // Used when number of items per page, number of total items,
-// current page or paginate function are undefined.
+// current page and paginate function are undefined.
 // Pagination is handled by onForward and onBack function.
 type ButtonsOnlyPagination = BaseProps & {
   itemsPerPage?: never;

--- a/src/components/Pagination/PaginationButton/PaginationButton.test.tsx
+++ b/src/components/Pagination/PaginationButton/PaginationButton.test.tsx
@@ -1,7 +1,14 @@
+/* eslint-disable testing-library/no-node-access */
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-import PaginationButton from "./PaginationButton";
+import PaginationButton, { Label } from "./PaginationButton";
+
+export enum CustomLabel {
+  Next = "Custom forward label",
+  Previous = "Custom back label",
+}
 
 describe("PaginationButton", () => {
   it("should render correctly and match snapshot", () => {
@@ -9,19 +16,34 @@ describe("PaginationButton", () => {
     expect(screen.getByRole("button")).toMatchSnapshot();
   });
 
+  it("should contain default label before the forward icon", () => {
+    render(
+      <PaginationButton direction="forward" onClick={() => {}} showLabel />
+    );
+    const defaultLabel = screen
+      .getByRole("button", { name: new RegExp(Label.Next) })
+      .querySelector("span");
+    const icon = document.querySelector(".p-icon--chevron-down");
+    expect(defaultLabel).toHaveTextContent(Label.Next);
+    expect(
+      defaultLabel &&
+        icon &&
+        defaultLabel.compareDocumentPosition(icon) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("should contain default label after the back icon", () => {
     render(<PaginationButton direction="back" onClick={() => {}} showLabel />);
-    const customLabel = screen
-      .getByRole("button", { name: /Previous page/ })
-      // eslint-disable-next-line testing-library/no-node-access
+    const defaultLabel = screen
+      .getByRole("button", { name: new RegExp(Label.Previous) })
       .querySelector("span");
-    // eslint-disable-next-line testing-library/no-node-access
     const icon = document.querySelector(".p-icon--chevron-down");
-    expect(customLabel).toHaveTextContent("Previous page");
+    expect(defaultLabel).toHaveTextContent(Label.Previous);
     expect(
-      customLabel &&
+      defaultLabel &&
         icon &&
-        customLabel.compareDocumentPosition(icon) &
+        defaultLabel.compareDocumentPosition(icon) &
           Node.DOCUMENT_POSITION_PRECEDING
     ).toBeTruthy();
   });
@@ -32,21 +54,81 @@ describe("PaginationButton", () => {
         direction="forward"
         onClick={() => {}}
         showLabel
-        label="Custom label"
+        label={CustomLabel.Next}
       />
     );
     const customLabel = screen
-      .getByRole("button", { name: /Custom label/ })
-      // eslint-disable-next-line testing-library/no-node-access
+      .getByRole("button", { name: new RegExp(CustomLabel.Next) })
       .querySelector("span");
-    // eslint-disable-next-line testing-library/no-node-access
     const icon = document.querySelector(".p-icon--chevron-down");
-    expect(customLabel).toHaveTextContent("Custom label");
+    expect(customLabel).toHaveTextContent(CustomLabel.Next);
     expect(
       customLabel &&
         icon &&
         customLabel.compareDocumentPosition(icon) &
           Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it("should contain custom label before the forward icon", () => {
+    render(
+      <PaginationButton
+        direction="back"
+        onClick={() => {}}
+        showLabel
+        label={CustomLabel.Previous}
+      />
+    );
+    const customLabel = screen
+      .getByRole("button", { name: new RegExp(CustomLabel.Previous) })
+      .querySelector("span");
+    const icon = document.querySelector(".p-icon--chevron-down");
+    expect(customLabel).toHaveTextContent(CustomLabel.Previous);
+    expect(
+      customLabel &&
+        icon &&
+        customLabel.compareDocumentPosition(icon) &
+          Node.DOCUMENT_POSITION_PRECEDING
+    ).toBeTruthy();
+  });
+
+  it("should call onClick when clicking the forward button", async () => {
+    const mockHandleClick = jest.fn();
+    render(<PaginationButton direction="forward" onClick={mockHandleClick} />);
+    await userEvent.click(screen.getByRole("button", { name: Label.Next }));
+    expect(mockHandleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onClick when clicking the back button", async () => {
+    const mockHandleClick = jest.fn();
+    render(<PaginationButton direction="back" onClick={mockHandleClick} />);
+    await userEvent.click(screen.getByRole("button", { name: Label.Previous }));
+    expect(mockHandleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should be diabled and onClick will not be called when clicking the forward button", async () => {
+    const mockHandleClick = jest.fn();
+    render(
+      <PaginationButton
+        direction="forward"
+        onClick={mockHandleClick}
+        disabled
+      />
+    );
+    const disabledButton = screen.getByRole("button", { name: Label.Next });
+    expect(disabledButton).toBeDisabled();
+    await userEvent.click(disabledButton);
+    expect(mockHandleClick).not.toHaveBeenCalled();
+  });
+
+  it("should be diabled and onClick will not be called when clicking the back button", async () => {
+    const mockHandleClick = jest.fn();
+    render(
+      <PaginationButton direction="back" onClick={mockHandleClick} disabled />
+    );
+    const disabledButton = screen.getByRole("button", { name: Label.Previous });
+    expect(disabledButton).toBeDisabled();
+    await userEvent.click(disabledButton);
+    expect(mockHandleClick).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Pagination/PaginationButton/PaginationButton.test.tsx
+++ b/src/components/Pagination/PaginationButton/PaginationButton.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import PaginationButton from "./PaginationButton";
+
+describe("PaginationButton", () => {
+  it("should render correctly and match snapshot", () => {
+    render(<PaginationButton direction="back" onClick={() => {}} />);
+    expect(screen.getByRole("button")).toMatchSnapshot();
+  });
+
+  it("should contain default label after the back icon", () => {
+    render(<PaginationButton direction="back" onClick={() => {}} showLabel />);
+    const customLabel = screen
+      .getByRole("button", { name: /Previous page/ })
+      // eslint-disable-next-line testing-library/no-node-access
+      .querySelector("span");
+    // eslint-disable-next-line testing-library/no-node-access
+    const icon = document.querySelector(".p-icon--chevron-down");
+    expect(customLabel).toHaveTextContent("Previous page");
+    expect(
+      customLabel &&
+        icon &&
+        customLabel.compareDocumentPosition(icon) &
+          Node.DOCUMENT_POSITION_PRECEDING
+    ).toBeTruthy();
+  });
+
+  it("should contain custom label before the forward icon", () => {
+    render(
+      <PaginationButton
+        direction="forward"
+        onClick={() => {}}
+        showLabel
+        label="Custom label"
+      />
+    );
+    const customLabel = screen
+      .getByRole("button", { name: /Custom label/ })
+      // eslint-disable-next-line testing-library/no-node-access
+      .querySelector("span");
+    // eslint-disable-next-line testing-library/no-node-access
+    const icon = document.querySelector(".p-icon--chevron-down");
+    expect(customLabel).toHaveTextContent("Custom label");
+    expect(
+      customLabel &&
+        icon &&
+        customLabel.compareDocumentPosition(icon) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+});

--- a/src/components/Pagination/PaginationButton/PaginationButton.tsx
+++ b/src/components/Pagination/PaginationButton/PaginationButton.tsx
@@ -21,14 +21,25 @@ export type Props = {
    * Function to handle clicking the pagination button.
    */
   onClick: MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Whether to show the label for button.
+   */
+  showLabel?: boolean;
+  /**
+   * Custom label for button.
+   */
+  label?: string;
 };
 
 const PaginationButton = ({
   direction,
   onClick,
   disabled = false,
+  showLabel,
+  label,
 }: Props): JSX.Element => {
-  const label = direction === "back" ? Label.Previous : Label.Next;
+  const buttonLabel =
+    label || (direction === "back" ? Label.Previous : Label.Next);
   return (
     <li className="p-pagination__item">
       <button
@@ -40,7 +51,9 @@ const PaginationButton = ({
         onClick={onClick}
         type="button"
       >
-        <i className="p-icon--chevron-down">{label}</i>
+        {direction === "forward" && showLabel && <span>{buttonLabel}</span>}
+        <i className="p-icon--chevron-down">{buttonLabel}</i>
+        {direction === "back" && showLabel && <span>{buttonLabel}</span>}
       </button>
     </li>
   );

--- a/src/components/Pagination/PaginationButton/__snapshots__/PaginationButton.test.tsx.snap
+++ b/src/components/Pagination/PaginationButton/__snapshots__/PaginationButton.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PaginationButton should render correctly and match snapshot 1`] = `
+<button
+  class="p-pagination__link--previous"
+  type="button"
+>
+  <i
+    class="p-icon--chevron-down"
+  >
+    Previous page
+  </i>
+</button>
+`;

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -131,3 +131,16 @@ exports[`<Pagination /> should render default buttons-only pagination and match 
   </ol>
 </nav>
 `;
+
+exports[`PaginationButton should render correctly and match snapshot 1`] = `
+<button
+  class="p-pagination__link--previous"
+  type="button"
+>
+  <i
+    class="p-icon--chevron-down"
+  >
+    Previous page
+  </i>
+</button>
+`;

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Pagination /> renders and matches the snapshot 1`] = `
+exports[`<Pagination /> renders numbered pagination and matches the snapshot 1`] = `
 <nav
   aria-label="Pagination"
   class="p-pagination"
@@ -72,6 +72,46 @@ exports[`<Pagination /> renders and matches the snapshot 1`] = `
         type="button"
       >
         5
+      </button>
+    </li>
+    <li
+      class="p-pagination__item"
+    >
+      <button
+        class="p-pagination__link--next"
+        type="button"
+      >
+        <i
+          class="p-icon--chevron-down"
+        >
+          Next page
+        </i>
+      </button>
+    </li>
+  </ol>
+</nav>
+`;
+
+exports[`<Pagination /> should render default buttons-only pagination and match the snapshot 1`] = `
+<nav
+  aria-label="Pagination"
+  class="p-pagination"
+>
+  <ol
+    class="p-pagination__items"
+  >
+    <li
+      class="p-pagination__item"
+    >
+      <button
+        class="p-pagination__link--previous"
+        type="button"
+      >
+        <i
+          class="p-icon--chevron-down"
+        >
+          Previous page
+        </i>
       </button>
     </li>
     <li


### PR DESCRIPTION
## Done

- Added Buttons-only Pagination for the case when total number of items is unknown. This use-case is required for the Audit logs feature in Juju Dashboard.
- Fully backwards compatible with all previous uses of Pagination component.

## QA

- Open storybook locally and navigate to the Pagination docs.