### PR TITLE
fix: Remove conditionally the aria-sort attribute and ability to sort from ModularTable

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -44,7 +44,7 @@ yarn install
 yarn link path_to_react_components
 ```
 
-At this point, you might get errors about miss-matched versions of specific dependencies between `react-components` and your project. To fix these errors, change the versions of those dependencies in `react-components` to match the versions in your project. Once done, rerun the previously mentioned steps.
+At this point, you might get errors about mismatched versions of specific dependencies between `react-components` and your project. To fix these errors, change the versions of those dependencies in `react-components` to match the versions in your project. Once done, rerun the previously mentioned steps.
 
 Finally, in your project, add the resolutions for `react` and `react-dom` to `package.json`. The added bit of code should be:
 
@@ -56,7 +56,7 @@ Finally, in your project, add the resolutions for `react` and `react-dom` to `pa
 }
 ```
 
-_**Note:** Before pushing changes to `@canonical/react-components`, don't forget to change the miss-matched versions of deependencies in `react-components` to the ones before the change._
+_**Note:** Before pushing changes to `@canonical/react-components`, don't forget to change the mismatched versions of dependencies in `react-components` to the ones before the change._
 
 ## Using with another project that runs on an older version of yarn
 

--- a/src/components/ModularTable/ModularTable.test.tsx
+++ b/src/components/ModularTable/ModularTable.test.tsx
@@ -436,12 +436,12 @@ describe("ModularTable", () => {
       {
         status: "Idle",
         nameless: "second",
-        accessor: "two",
+        whitespace: "two",
       },
       {
         status: "Ready",
         nameless: "first",
-        accessor: "one",
+        whitespace: "one",
       },
     ];
     render(<ModularTable columns={columns} data={data} sortable />);
@@ -487,31 +487,23 @@ describe("ModularTable", () => {
     );
   });
 
-  it("should not have aria-sort attribute and should not sort by columns whose header is a deeply nested ReactNode with no text inside", async () => {
+  it("should have aria-sort attribute and should sort by columns whose header is a number", async () => {
     const columns = [
       { accessor: "status", Header: "Status", sortType: "alphanumeric" },
       {
-        accessor: "deeplyNested",
-        Header: (
-          <div>
-            <button></button>
-            <div>
-              <p></p>
-              <span></span>
-            </div>
-          </div>
-        ),
+        accessor: "numeric",
+        Header: 0,
         sort: "alphanumeric",
       },
     ];
     const data: Record<string, unknown>[] = [
       {
         status: "Idle",
-        deeplyNested: "second",
+        numeric: "second",
       },
       {
         status: "Ready",
-        deeplyNested: "first",
+        numeric: "first",
       },
     ];
     render(<ModularTable columns={columns} data={data} sortable />);
@@ -520,8 +512,9 @@ describe("ModularTable", () => {
     expect(
       screen.getByRole("columnheader", { name: "Status" })
     ).toHaveAttribute("aria-sort", "none");
-    expect(screen.getByRole("columnheader", { name: "" })).not.toHaveAttribute(
-      "aria-sort"
+    expect(screen.getByRole("columnheader", { name: "0" })).toHaveAttribute(
+      "aria-sort",
+      "none"
     );
 
     const tableBody = screen.getAllByRole("rowgroup")[1];
@@ -534,43 +527,35 @@ describe("ModularTable", () => {
       "Ready"
     );
 
-    await userEvent.click(screen.getByRole("columnheader", { name: "" }));
+    await userEvent.click(screen.getByRole("columnheader", { name: "0" }));
 
     rowItems = within(tableBody).getAllByRole("row");
     expect(rowItems).toHaveLength(2);
     expect(within(rowItems[0]).queryAllByRole("cell")[0]).toHaveTextContent(
-      "Idle"
+      "Ready"
     );
     expect(within(rowItems[1]).queryAllByRole("cell")[0]).toHaveTextContent(
-      "Ready"
+      "Idle"
     );
   });
 
-  it("should have aria-sort attribute and should sort by columns whose header is a deeply nested ReactNode with text inside", async () => {
+  it("should have aria-sort attribute and should sort by columns whose header is a JSX", async () => {
     const columns = [
       { accessor: "status", Header: "Status", sortType: "alphanumeric" },
       {
-        accessor: "deeplyNested",
-        Header: (
-          <div>
-            <button></button>
-            <div>
-              <p></p>
-              <span>Deeply Nested Text</span>
-            </div>
-          </div>
-        ),
+        accessor: "jsx",
+        Header: <div>JSX</div>,
         sortBy: "alphanumeric",
       },
     ];
     const data: Record<string, unknown>[] = [
       {
         status: "Idle",
-        deeplyNested: "second",
+        jsx: "second",
       },
       {
         status: "Ready",
-        deeplyNested: "first",
+        jsx: "first",
       },
     ];
     render(<ModularTable columns={columns} data={data} sortable />);
@@ -579,9 +564,10 @@ describe("ModularTable", () => {
     expect(
       screen.getByRole("columnheader", { name: "Status" })
     ).toHaveAttribute("aria-sort", "none");
-    expect(
-      screen.getByRole("columnheader", { name: "Deeply Nested Text" })
-    ).toHaveAttribute("aria-sort", "none");
+    expect(screen.getByRole("columnheader", { name: "JSX" })).toHaveAttribute(
+      "aria-sort",
+      "none"
+    );
 
     const tableBody = screen.getAllByRole("rowgroup")[1];
     let rowItems = within(tableBody).getAllByRole("row");
@@ -593,9 +579,7 @@ describe("ModularTable", () => {
       "Ready"
     );
 
-    await userEvent.click(
-      screen.getByRole("columnheader", { name: "Deeply Nested Text" })
-    );
+    await userEvent.click(screen.getByRole("columnheader", { name: "JSX" }));
 
     rowItems = within(tableBody).getAllByRole("row");
     expect(rowItems).toHaveLength(2);

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -13,7 +13,7 @@ import type {
   Row,
   HeaderGroup,
 } from "react-table";
-import { PropsWithSpread } from "types";
+import { PropsWithSpread, SortDirection } from "types";
 import Table from "../Table";
 import TableRow from "../TableRow";
 import TableHeader from "../TableHeader";
@@ -171,6 +171,16 @@ function ModularTable<D extends Record<string, unknown>>({
 
   const showEmpty: boolean = !!emptyMsg && (!rows || rows.length === 0);
 
+  const getColumnSortDirection = (column: HeaderGroup<D>): SortDirection => {
+    if (!column.canSort || column.render("Header") instanceof Object) {
+      return undefined;
+    }
+    if (!column.isSorted) {
+      return "none";
+    }
+    return column.isSortedDesc ? "descending" : "ascending";
+  };
+
   return (
     <Table {...getTableProps()} {...props}>
       <thead>
@@ -178,13 +188,7 @@ function ModularTable<D extends Record<string, unknown>>({
           <TableRow {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map((column) => (
               <TableHeader
-                sort={
-                  column.isSorted
-                    ? column.isSortedDesc
-                      ? "descending"
-                      : "ascending"
-                    : "none"
-                }
+                sort={getColumnSortDirection(column)}
                 {...column.getHeaderProps([
                   {
                     className: column.className,

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, HTMLProps, useMemo } from "react";
+import React, { ReactNode, HTMLProps, useMemo, isValidElement } from "react";
 import {
   TableCellProps,
   TableHeaderProps,
@@ -176,7 +176,7 @@ function ModularTable<D extends Record<string, unknown>>({
     // Function returns whether an instance of ReactNode has text within it.
     // Recursively goes over all children from the node and searches for text.
     const hasText = (node: ReactNode): boolean => {
-      if (!React.isValidElement(node)) {
+      if (!isValidElement(node)) {
         return (
           (typeof node === "string" || typeof node === "number") &&
           !!String(node).trim()

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -173,33 +173,13 @@ function ModularTable<D extends Record<string, unknown>>({
 
   // Function returns whether table can be sorted by a specific column.
   // Returns true if sorting is enabled for the column and there is text
-  // being rendered within the column header, otherwise returns false.
-  const isColumnSortable = (column: HeaderGroup<D>) => {
-    if (!column.canSort) {
-      return false;
-    }
-
-    const headerNodesQueue: ReactNode[] = [column.render("Header")];
-    // Go through all header child nodes and search for text.
-    while (headerNodesQueue.length) {
-      const frontNode = headerNodesQueue.shift();
-      if (isValidElement(frontNode)) {
-        headerNodesQueue.push(frontNode.props.children);
-      }
-      if (
-        !isValidElement(frontNode) &&
-        (typeof frontNode === "string" || typeof frontNode === "number") &&
-        !!String(frontNode).trim()
-      ) {
-        return true;
-      }
-      if (!isValidElement(frontNode) && Array.isArray(frontNode)) {
-        frontNode.forEach((childNode) => headerNodesQueue.push(childNode));
-      }
-    }
-
-    return false;
-  };
+  // or JSX provided for the header, otherwise returns false.
+  const isColumnSortable = (column: HeaderGroup<D>) =>
+    column.canSort &&
+    (isValidElement(column.Header) ||
+      ((typeof column.Header === "string" ||
+        typeof column.Header === "number") &&
+        !!String(column.Header).trim()));
 
   const getColumnSortDirection = (column: HeaderGroup<D>): SortDirection => {
     if (!isColumnSortable(column)) {

--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -171,8 +171,29 @@ function ModularTable<D extends Record<string, unknown>>({
 
   const showEmpty: boolean = !!emptyMsg && (!rows || rows.length === 0);
 
+  // Fuction returns whether table can be sorted by a specific column.
+  const isColumnSortable = (column: HeaderGroup<D>) => {
+    // Function returns whether an instance of ReactNode has text within it.
+    // Recursively goes over all children from the node and searches for text.
+    const hasText = (node: ReactNode): boolean => {
+      if (!React.isValidElement(node)) {
+        return (
+          (typeof node === "string" || typeof node === "number") &&
+          !!String(node).trim()
+        );
+      }
+      const children = node.props.children;
+      if (Array.isArray(children)) {
+        return children.some((child: ReactNode) => hasText(child));
+      }
+      return hasText(children);
+    };
+
+    return column.canSort && hasText(column.render("Header"));
+  };
+
   const getColumnSortDirection = (column: HeaderGroup<D>): SortDirection => {
-    if (!column.canSort || column.render("Header") instanceof Object) {
+    if (!isColumnSortable(column)) {
       return undefined;
     }
     if (!column.isSorted) {
@@ -200,7 +221,7 @@ function ModularTable<D extends Record<string, unknown>>({
                   },
                   { ...getHeaderProps?.(column) },
                   // Only call this if we want it to be sortable too.
-                  sortable
+                  sortable && isColumnSortable(column)
                     ? column.getSortByToggleProps({ title: undefined })
                     : {},
                 ])}


### PR DESCRIPTION
## Done

- When sorting is disabled for a specific column and/or there is no text being rendered within the column header, the column shouldn't have an aria-sort attribute and clicking on the respective column header won't trigger any sorting action.

## Details

- Fixes: #946 