### PR TITLE
Support ReactNode in the CodeSnippet component.

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.stories.mdx
+++ b/src/components/CodeSnippet/CodeSnippet.stories.mdx
@@ -310,3 +310,42 @@ Custom elements can be passed to a CodeBlock via the `content` prop. In these ca
     />
   </Story>
 </Canvas>
+
+### JSX code elements
+
+It's possible to pass JSX instead of strings to the `code` parameter, either
+as a single element or an array (e.g. if you want to display line numbers).
+
+<Canvas>
+  <Story name="JSX code elements">
+    <CodeSnippet
+      blocks={[
+        {
+          code: (
+            <>
+              <strong>snap</strong> install <a href="">toto</a>
+              <br />
+              <strong>apt</strong> install <a href="">toto</a>
+            </>
+          ),
+        },
+      ]}
+    />
+    <CodeSnippet
+      blocks={[
+        {
+          appearance: CodeSnippetBlockAppearance.NUMBERED,
+          code: [
+            `#!/bin/bash`,
+            `set -eu . $CONJURE_UP_SPELLSDIR/sdk/common.sh`,
+            `if [[ "$JUJU_PROVIDERTYPE" == "lxd" ]]; then`,
+            `  debug "Running pre-deploy for $CONJURE_UP_SPELL"`,
+            `  sed "s/##MODEL##/$JUJU_MODEL/" $(scriptPath)/lxd-profile.yaml | lxc profile edit "juju-$JUJU_MODEL" || exposeResult "Failed to set profile" $? "false"`,
+            `fi`,
+            `exposeResult "Successful pre-deploy." 0 "true"`,
+          ],
+        },
+      ]}
+    />
+  </Story>
+</Canvas>

--- a/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -54,6 +54,56 @@ describe("CodeSnippet ", () => {
     expect(screen.getByText("Test line 3;")).toBeInTheDocument();
   });
 
+  it("renders line numbers when an array is passed in", () => {
+    const multilineCode = [
+      "Test line 1;",
+      <strong>Test line 2;</strong>,
+      "Test line 3;",
+    ];
+
+    render(
+      <CodeSnippet
+        blocks={[
+          {
+            appearance: CodeSnippetBlockAppearance.NUMBERED,
+            code: multilineCode,
+          },
+        ]}
+      />
+    );
+    expect(
+      // eslint-disable-next-line testing-library/no-node-access
+      document.querySelector(".p-code-snippet__block--numbered")
+    ).toBeInTheDocument();
+    expect(
+      // eslint-disable-next-line testing-library/no-node-access
+      document.querySelectorAll(".p-code-snippet__line")
+    ).toHaveLength(3);
+    expect(screen.getByText("Test line 1;")).toBeInTheDocument();
+    expect(screen.getByText("Test line 2;")).toBeInTheDocument();
+    expect(screen.getByText("Test line 3;")).toBeInTheDocument();
+  });
+
+  it("renders JSX code", () => {
+    render(
+      <CodeSnippet
+        blocks={[
+          {
+            code: (
+              <div data-testid="jsx-content">
+                <a href="example.com/docs/function">functionCall()</a>
+              </div>
+            ),
+          },
+        ]}
+      />
+    );
+    expect(screen.getByTestId("jsx-content")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "functionCall()" })
+    ).toBeInTheDocument();
+  });
+
   it("renders default linux prompt icon", () => {
     render(
       <CodeSnippet

--- a/src/components/CodeSnippet/CodeSnippetBlock.tsx
+++ b/src/components/CodeSnippet/CodeSnippetBlock.tsx
@@ -21,7 +21,7 @@ export type Props = {
   /**
    * The code snippet to display.
    */
-  code: string;
+  code: ReactNode;
   /**
    * Content to show below the code snippet.
    */
@@ -59,13 +59,22 @@ export default function CodeSnippetBlock({
     appearance === CodeSnippetBlockAppearance.LINUX_PROMPT ||
     appearance === CodeSnippetBlockAppearance.WINDOWS_PROMPT ||
     appearance === CodeSnippetBlockAppearance.URL;
-  let numberedCode: JSX.Element[];
+  let numberedCode: ReactNode;
 
   if (isNumbered) {
     className += "--numbered";
 
     // wrap code lines in spans (and preserve the whitespace)
-    const lines = code.split(/\r?\n/);
+    let lines: ReactNode[];
+    if (Array.isArray(code)) {
+      lines = code;
+    } else if (typeof code === "string") {
+      lines = code.split(/\r?\n/);
+    } else {
+      // If the code is not able to be split over multiple lines, then display
+      // a single line number.
+      lines = [code];
+    }
     numberedCode = lines.map((line, i) => (
       <React.Fragment key={`p-code-snippet__line-${i}`}>
         <span className="p-code-snippet__line">{line}</span>


### PR DESCRIPTION
## Done

- Support a `ReactNode` as the value of the code to display in CodeSnippet.

## Fixes

https://warthogs.atlassian.net/browse/WD-5870
