### PR TITLE
Contextual menu scrolling

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -23,7 +23,7 @@ export enum Label {
 export type Props<L> = PropsWithSpread<
   {
     /**
-     * Whether the menu should adjust to fit in the screen.
+     * Whether the menu should adjust its horizontal position to fit on the screen.
      */
     autoAdjust?: boolean;
     /**
@@ -67,13 +67,17 @@ export type Props<L> = PropsWithSpread<
      */
     onToggleMenu?: (isOpen: boolean) => void | null;
     /**
-     * The position of the menu.
+     * The horizontal position of the menu.
      */
     position?: Position | null;
     /**
      * An element to make the menu relative to.
      */
     positionNode?: HTMLElement | null;
+    /**
+     * Whether the dropdown should scroll if it is too long to fit on the screen.
+     */
+    scrollOverflow?: boolean;
     /**
      * The appearance of the toggle button.
      */
@@ -173,6 +177,7 @@ const ContextualMenu = <L,>({
   onToggleMenu,
   position = "right",
   positionNode,
+  scrollOverflow,
   toggleAppearance,
   toggleClassName,
   toggleDisabled,
@@ -337,6 +342,7 @@ const ContextualMenu = <L,>({
             position={position}
             positionCoords={positionCoords}
             positionNode={getPositionNode(wrapper.current, positionNode)}
+            scrollOverflow={scrollOverflow}
             setAdjustedPosition={setAdjustedPosition}
             wrapperClass={wrapperClass}
             {...dropdownProps}

--- a/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import merge from "deepmerge";
 import React from "react";
 
@@ -12,6 +12,52 @@ describe("ContextualMenuDropdown ", () => {
   it("renders", () => {
     render(<ContextualMenuDropdown links={["Link1"]} data-testid="dropdown" />);
     expect(screen.getByTestId("dropdown")).toMatchSnapshot();
+  });
+
+  it("doesn't change height if scrollOverflow not set", () => {
+    render(
+      <ContextualMenuDropdown
+        isOpen
+        links={Array.from({ length: 10 }).map((_, i) => i)}
+      />
+    );
+    expect(
+      document.querySelector(".p-contextual-menu__dropdown")
+    ).not.toHaveAttribute("style");
+  });
+
+  it("changes height if scrollOverflow is set", async () => {
+    global.innerHeight = 116;
+    const positionNode = document.createElement("div");
+    document.body.appendChild(positionNode);
+    const links = Array.from({ length: 10 }).map((_, i) => i);
+    const { rerender } = render(
+      <ContextualMenuDropdown
+        isOpen
+        links={links}
+        positionNode={positionNode}
+        scrollOverflow
+      />
+    );
+    // Rerender the component so that the hooks run again once the elements have
+    // been created in the DOM.
+    rerender(
+      <ContextualMenuDropdown
+        isOpen
+        links={links}
+        positionNode={positionNode}
+        scrollOverflow
+      />
+    );
+    await waitFor(() => {
+      expect(
+        document.querySelector(".p-contextual-menu__dropdown")
+      ).toHaveAttribute(
+        "style",
+        "min-height: 2rem; overflow-x: auto; max-height: 100px;"
+      );
+    });
+    positionNode.remove();
   });
 
   describe("adjustForWindow", () => {


### PR DESCRIPTION
## Done

- Add a prop to handle scrolling the contextual menu if it doesn't fit on the screen (handled in the same way as the search and filter dropdown: https://github.com/canonical/react-components/pull/906).

## QA

- Open `src/components/ContextualMenu/ContextualMenu.stories.mdx`.
- Scroll down to the "Toggle" story and duplicate the links objects so that there are quite a few links.
- add `scrollOverflow: true,` to the args.
- Run Storybook (`yarn start`).
- Open `<storybook-url>/iframe.html?id=contextualmenu--toggle&viewMode=story`
- Click on the button to open the menu.
- Resize your window so that the menu doesn't fit on the screen.
- The menu should resize so that it doesn't get cut off, and the content should scroll.

## Screenshots

<img width="820" alt="Screenshot 2023-08-29 at 12 31 09 pm" src="https://github.com/canonical/react-components/assets/361637/59ff4deb-5271-42fd-b90b-39afa9361fcb">

