### PR TITLE
Separate docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,36 @@
+name: Publish docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    name: Build Storybook docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Install dependencies
+        run: yarn install
+      - name: Build Storybook
+        run: yarn build-docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: "./docs"
+  publish-docs:
+    name: Publish to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,8 +1,7 @@
 name: Publish docs
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,9 +1,8 @@
-name: Publish to NPM and GitHub Pages
+name: Publish to NPM
 
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   publish-npm:
@@ -24,29 +23,3 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-  build-docs:
-    runs-on: publish-npm
-    needs: build-docs
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v3
-      - name: Build Storybook
-        run: yarn build-docs
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
-        with:
-          path: "./docs"
-  publish-docs:
-    name: Publish to GitHub Pages
-    environment:
-      name: github-pages
-      url: ${{steps.deployment.outputs.page_url}}
-    runs-on: ubuntu-latest
-    needs: build-docs
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -23,3 +23,6 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+  publish-docs:
+    needs: publish-npm
+    uses: ./.github/workflows/publish-docs.yml

--- a/PUBLISH-NPM-PACKAGE.md
+++ b/PUBLISH-NPM-PACKAGE.md
@@ -3,7 +3,8 @@
 To publish a new react-components release you will need to [update the version](#update-package-version) in package.json and [create a new
 release](#publish-the-release). Once the release has been created in GitHub the
 package will automatically get built and published to NPM and the docs will get
-redeployed (see [publish-on-release.yml](./.github/workflows/publish-on-release.yml)).
+redeployed (see
+[publish-on-release.yml](./.github/workflows/publish-on-release.yml) and [publish-docs.yml](./.github/workflows/publish-docs.yml)).
 
 If needed, you can also [manually trigger the action](#manually-update-docs) to build the docs if you need this to happen without doing a release.
 
@@ -56,8 +57,7 @@ You should now see the new version on [NPM](https://www.npmjs.com/package/@canon
 To rebuild the docs you need to manually trigger the publish action. More
 details in the [GitHub docs](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).
 
-1. Go to the [Publish to NPM and GitHub
-   Pages](https://github.com/canonical/react-components/actions/workflows/publish-on-release.yml) action.
+1. Go to the [Publish docs](https://github.com/canonical/react-components/actions/workflows/publish-docs.yml) action.
 2. Click the 'Run workflow' button.
 3. Select the `main`` branch.
 4. Click 'Run workflow'.


### PR DESCRIPTION
## Done

- Separate the workflow for publishing the docs on release, so that when it is manually run it doesn't also publish the package to NPM.
