### PR TITLE
Add permissions for deploying to pages.

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -29,6 +29,10 @@ jobs:
       url: ${{steps.deployment.outputs.page_url}}
     runs-on: ubuntu-latest
     needs: build-docs
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Done

- Add token permissions (as per the [docs](https://github.com/actions/deploy-pages)) for deploying to pages, as the previous job [failed](https://github.com/canonical/react-components/actions/runs/6034670898/job/16373781625).