### PR TITLE
Avoid duplicate first or last page button, when total pages is one above truncateThreshold

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -407,4 +407,72 @@ describe("<Pagination />", () => {
     );
     expect(mockHandleBack).toHaveBeenCalledTimes(1);
   });
+
+  it("renders all pages on page 1 without duplicating first or last page", async () => {
+    render(
+      <Pagination
+        itemsPerPage={2}
+        totalItems={8}
+        paginate={jest.fn()}
+        currentPage={1}
+        truncateThreshold={3}
+      />
+    );
+
+    expect(await screen.findAllByRole("button", { name: "1" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+  });
+
+  it("renders all pages on page 2 without duplicating first or last page", async () => {
+    render(
+      <Pagination
+        itemsPerPage={2}
+        totalItems={8}
+        paginate={jest.fn()}
+        currentPage={2}
+        truncateThreshold={3}
+      />
+    );
+
+    expect(await screen.findAllByRole("button", { name: "1" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+  });
+
+  it("renders all pages on page 3 without duplicating first or last page", async () => {
+    render(
+      <Pagination
+        itemsPerPage={2}
+        totalItems={8}
+        paginate={jest.fn()}
+        currentPage={3}
+        truncateThreshold={3}
+      />
+    );
+
+    expect(await screen.findAllByRole("button", { name: "1" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+  });
+
+  it("renders all pages on page 4 without duplicating first or last page", async () => {
+    render(
+      <Pagination
+        itemsPerPage={2}
+        totalItems={8}
+        paginate={jest.fn()}
+        currentPage={4}
+        truncateThreshold={3}
+      />
+    );
+
+    expect(await screen.findAllByRole("button", { name: "1" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+  });
 });

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -423,6 +423,7 @@ describe("<Pagination />", () => {
     expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+    expect(screen.queryByText("…")).not.toBeInTheDocument();
   });
 
   it("renders all pages on page 2 without duplicating first or last page", async () => {
@@ -440,6 +441,7 @@ describe("<Pagination />", () => {
     expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+    expect(screen.queryByText("…")).not.toBeInTheDocument();
   });
 
   it("renders all pages on page 3 without duplicating first or last page", async () => {
@@ -457,6 +459,7 @@ describe("<Pagination />", () => {
     expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+    expect(screen.queryByText("…")).not.toBeInTheDocument();
   });
 
   it("renders all pages on page 4 without duplicating first or last page", async () => {
@@ -474,5 +477,27 @@ describe("<Pagination />", () => {
     expect(await screen.findAllByRole("button", { name: "2" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
     expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+    expect(screen.queryByText("…")).not.toBeInTheDocument();
+  });
+
+  it("renders all pages on page 4 without duplicating first or last page", async () => {
+    render(
+      <Pagination
+        itemsPerPage={2}
+        totalItems={20}
+        paginate={jest.fn()}
+        currentPage={4}
+        truncateThreshold={3}
+      />
+    );
+
+    expect(await screen.findAllByRole("button", { name: "1" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "3" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "4" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "5" })).toHaveLength(1);
+    expect(await screen.findAllByRole("button", { name: "10" })).toHaveLength(
+      1
+    );
+    expect(screen.queryAllByText("…")).toHaveLength(2);
   });
 });

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -55,7 +55,7 @@ const generatePaginationItems = (
         onClick={() => changePage(1)}
       />
     );
-    if (![1, 2, 3].includes(currentPage)) {
+    if (!visiblePages.includes(2)) {
       items.push(<PaginationItemSeparator key="sep1" />);
     }
   }
@@ -73,7 +73,7 @@ const generatePaginationItems = (
 
   if (truncated) {
     // render last in sequence
-    if (![lastPage, lastPage - 1, lastPage - 2].includes(currentPage)) {
+    if (!visiblePages.includes(lastPage - 1)) {
       items.push(<PaginationItemSeparator key="sep2" />);
     }
     items.push(

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -27,16 +27,16 @@ const generatePaginationItems = (
     // on page 1, also show pages 2, 3 and 4
     if (currentPage === 1) {
       start = 1;
-      end = currentPage + 3;
+      end = Math.min(lastPage - 1, currentPage + 3);
     }
     // on page 2, show page 1, and also pages 3, and 4
     if (currentPage === 2) {
       start = 1;
-      end = currentPage + 2;
+      end = Math.min(lastPage - 1, currentPage + 3);
     }
     // on the last page and page before last, also show the 3 previous pages
     if (currentPage === lastPage || currentPage === lastPage - 1) {
-      start = lastPage - 4;
+      start = Math.max(1, lastPage - 4);
       end = lastPage - 1;
     }
     visiblePages = pageNumbers.slice(start, end);


### PR DESCRIPTION
## Done

- fixed pagination edge case for when the `totalPages +1 = truncateThreshold` to avoid duplicating the button for the first or last page

## QA

### QA steps

- See tests are valid and passing