### PR TITLE
fix(ConfirmationModal): Use base appearance for cancel btn in ConfirmationModal

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -48,7 +48,11 @@ export const ConfirmationModal = ({
       buttonRow={
         <>
           {confirmExtra}
-          <Button className="u-no-margin--bottom" onClick={props.close}>
+          <Button
+            appearance="base"
+            className="u-no-margin--bottom"
+            onClick={props.close}
+          >
             {cancelButtonLabel}
           </Button>
           <Button


### PR DESCRIPTION
## Done

- use base appearance for cancel button in `ConfirmationModal`

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open the [confirmation modal](https://react-components-989.demos.haus/?path=/story/confirmationmodal--default-story) and ensure the cancel button has a base appearance without border.
