### PR TITLE
ci: Extend from a default config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>canonical/vanilla-framework"]
+  "extends": ["github>canonical/renovate-apps"]
 }


### PR DESCRIPTION
## Done

Renovate has [deprecated](https://docs.renovatebot.com/config-presets/) extending `renovate.json` and now requires extending a `default.json`.

I've changed this repo to use the apps default.json (which is pretty much the same as the vanilla config) as the Vanilla repo only has a renovate.json.
