### PR TITLE
feat: Add tooltip delay(500ms by default) after mouseover

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "prop-types": "15.8.1",
     "react-router-dom": "6.17.0",
     "react-table": "7.8.0",
-    "react-useportal": "1.0.18"
+    "react-useportal": "1.0.19"
   },
   "resolutions": {
     "@types/react": "18.2.28",

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -211,6 +211,56 @@ describe("Tooltip", () => {
     expect(screen.getByRole("tooltip")).toHaveStyle("z-index: 999");
   });
 
+  it("portal is not opened until the delay time.", async () => {
+    render(
+      <Tooltip message="text" zIndex={999}>
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+    await userEvent.hover(
+      screen.getByRole("button", { name: "open the tooltip" })
+    );
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("should be able to configure delay", async () => {
+    jest.useFakeTimers("modern");
+    render(
+      <Tooltip delay={1} message="text" zIndex={999}>
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await user.hover(screen.getByRole("button"));
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+
+  it("blur before the delay time cancels the timeout.", async () => {
+    jest.useFakeTimers("modern");
+    render(
+      <Tooltip message="text" zIndex={999}>
+        <button>open the tooltip</button>
+      </Tooltip>
+    );
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const button = screen.getByRole("button", { name: "open the tooltip" });
+    await user.hover(button);
+    act(async () => {
+      await user.unhover(button);
+    });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   describe("adjustForWindow", () => {
     const generateFits = (overrides = {}) => {
       const fits = {

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -93,8 +93,8 @@ describe("Tooltip", () => {
       </div>
     );
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await user.hover(screen.getByRole("button"));
-    act(() => {
+    await act(async () => {
+      await user.hover(screen.getByRole("button"));
       jest.runAllTimers();
     });
 
@@ -127,8 +127,8 @@ describe("Tooltip", () => {
       </div>
     );
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await user.hover(screen.getByRole("button"));
-    act(() => {
+    await act(async () => {
+      await user.hover(screen.getByRole("button"));
       jest.runAllTimers();
     });
     await user.click(screen.getByRole("link", { name: "Canonical" }));
@@ -167,8 +167,8 @@ describe("Tooltip", () => {
     );
     global.innerWidth = 20;
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await user.hover(screen.getByRole("button", { name: "Child" }));
-    act(() => {
+    await act(async () => {
+      await user.hover(screen.getByRole("button", { name: "Child" }));
       jest.runAllTimers();
     });
     expect(screen.getByTestId("tooltip-portal")).toHaveClass(
@@ -187,8 +187,10 @@ describe("Tooltip", () => {
       </Tooltip>
     );
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await user.hover(screen.getByRole("button", { name: "open the tooltip" }));
-    act(() => {
+    await act(async () => {
+      await user.hover(
+        screen.getByRole("button", { name: "open the tooltip" })
+      );
       jest.runAllTimers();
     });
     expect(screen.getByTestId("tooltip-portal")).toHaveClass(
@@ -204,8 +206,10 @@ describe("Tooltip", () => {
       </Tooltip>
     );
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await user.hover(screen.getByRole("button", { name: "open the tooltip" }));
-    act(() => {
+    await act(async () => {
+      await user.hover(
+        screen.getByRole("button", { name: "open the tooltip" })
+      );
       jest.runAllTimers();
     });
     expect(screen.getByRole("tooltip")).toHaveStyle("z-index: 999");
@@ -231,9 +235,8 @@ describe("Tooltip", () => {
       </Tooltip>
     );
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    await user.hover(screen.getByRole("button"));
-
-    act(() => {
+    await act(async () => {
+      await user.hover(screen.getByRole("button"));
       jest.advanceTimersByTime(1);
     });
 
@@ -242,20 +245,22 @@ describe("Tooltip", () => {
 
   it("blur before the delay time cancels the timeout.", async () => {
     jest.useFakeTimers("modern");
+
     render(
-      <Tooltip message="text" zIndex={999}>
+      <Tooltip delay={200} message="text" zIndex={999}>
         <button>open the tooltip</button>
       </Tooltip>
     );
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const button = screen.getByRole("button", { name: "open the tooltip" });
-    await user.hover(button);
-    act(async () => {
-      await user.unhover(button);
+    const button = screen.getByRole("button");
+
+    await act(async () => {
+      await user.hover(button);
     });
 
-    act(() => {
-      jest.runAllTimers();
+    await act(async () => {
+      await user.unhover(button);
+      jest.runOnlyPendingTimers();
     });
 
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -238,8 +238,9 @@ describe("Tooltip", () => {
   });
 
   it("portal is not opened until the delay time.", async () => {
+    const delay = 100;
     render(
-      <Tooltip message="text" zIndex={999}>
+      <Tooltip delay={delay} message="text" zIndex={999}>
         <button>open the tooltip</button>
       </Tooltip>
     );
@@ -247,8 +248,13 @@ describe("Tooltip", () => {
       await userEventWithTimers.hover(
         screen.getByRole("button", { name: "open the tooltip" })
       );
+      jest.advanceTimersByTime(delay - 1);
     });
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(delay);
+    });
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
   });
 
   it("should be able to configure delay", async () => {
@@ -266,8 +272,9 @@ describe("Tooltip", () => {
   });
 
   it("blur before the delay time cancels the timeout.", async () => {
+    const delay = 200;
     render(
-      <Tooltip delay={200} message="text" zIndex={999}>
+      <Tooltip delay={delay} message="text" zIndex={999}>
         <button>open the tooltip</button>
       </Tooltip>
     );
@@ -282,6 +289,10 @@ describe("Tooltip", () => {
       jest.runOnlyPendingTimers();
     });
 
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(delay);
+    });
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -74,6 +74,10 @@ export type Props = {
    * The z-index value of the tooltip message element.
    */
   zIndex?: number;
+  /**
+   * Deplay in ms after which Tooltip will appear
+   */
+  delay?: number;
 };
 
 const getPositionStyle = (
@@ -191,6 +195,7 @@ const Tooltip = ({
   positionElementClassName,
   tooltipClassName,
   zIndex,
+  delay = 500,
 }: Props): JSX.Element => {
   const wrapperRef = useRef<HTMLElement>(null);
   const messageRef = useRef<HTMLElement>(null);
@@ -204,6 +209,13 @@ const Tooltip = ({
   });
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const tooltipId = useId();
+  const [timer, setTimer] = useState<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const cancelableClosePortal = useCallback(() => {
+    clearTimeout(timer);
+    closePortal();
+  }, [timer, closePortal]);
 
   useEffect(() => {
     if (isOpen && !followMouse && wrapperRef.current) {
@@ -252,10 +264,10 @@ const Tooltip = ({
   const handleKeyPress = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        closePortal();
+        cancelableClosePortal();
       }
     },
-    [closePortal]
+    [cancelableClosePortal]
   );
 
   useEffect(() => {
@@ -276,7 +288,7 @@ const Tooltip = ({
         ? !messageRef.current?.contains(e.relatedTarget)
         : e.target !== messageRef.current
     ) {
-      closePortal();
+      cancelableClosePortal();
     }
   };
 
@@ -289,6 +301,11 @@ const Tooltip = ({
     openPortal();
   };
 
+  const deplayedOpenPortal = useCallback(() => {
+    const timeout = setTimeout(openPortal, delay);
+    setTimer(timeout);
+  }, [delay, openPortal]);
+
   return (
     <>
       {message ? (
@@ -298,7 +315,7 @@ const Tooltip = ({
           onClick={handleClick}
           onFocus={openPortal}
           onMouseOut={handleBlur}
-          onMouseOver={openPortal}
+          onMouseOver={deplayedOpenPortal}
         >
           <span
             className={positionElementClassName}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { MouseEventHandler, ReactNode } from "react";
 import usePortal from "react-useportal";
 
 import { useWindowFitment, useListener, useId } from "hooks";
@@ -75,7 +75,7 @@ export type Props = {
    */
   zIndex?: number;
   /**
-   * Deplay in ms after which Tooltip will appear
+   * Delay in ms after which Tooltip will appear (defaults to 350ms).
    */
   delay?: number;
 };
@@ -195,7 +195,7 @@ const Tooltip = ({
   positionElementClassName,
   tooltipClassName,
   zIndex,
-  delay = 500,
+  delay = 350,
 }: Props): JSX.Element => {
   const wrapperRef = useRef<HTMLElement>(null);
   const messageRef = useRef<HTMLElement>(null);
@@ -301,10 +301,13 @@ const Tooltip = ({
     openPortal();
   };
 
-  const deplayedOpenPortal = useCallback(() => {
-    const timeout = setTimeout(openPortal, delay);
-    setTimer(timeout);
-  }, [delay, openPortal]);
+  const deplayedOpenPortal: MouseEventHandler = useCallback(
+    (event) => {
+      const timeout = setTimeout(() => openPortal(event), delay);
+      setTimer(timeout);
+    },
+    [delay, openPortal]
+  );
 
   return (
     <>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -301,7 +301,7 @@ const Tooltip = ({
     openPortal();
   };
 
-  const deplayedOpenPortal: MouseEventHandler = useCallback(
+  const delayedOpenPortal: MouseEventHandler = useCallback(
     (event) => {
       const timeout = setTimeout(() => openPortal(event), delay);
       setTimer(timeout);
@@ -318,7 +318,7 @@ const Tooltip = ({
           onClick={handleClick}
           onFocus={openPortal}
           onMouseOut={handleBlur}
-          onMouseOver={deplayedOpenPortal}
+          onMouseOver={delayedOpenPortal}
         >
           <span
             className={positionElementClassName}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -207,7 +207,9 @@ const Tooltip = ({
     left: -9999999,
     top: -9999999,
   });
-  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { openPortal, closePortal, isOpen, Portal } = usePortal({
+    programmaticallyOpen: true,
+  });
   const tooltipId = useId();
   const [timer, setTimer] = useState<ReturnType<typeof setTimeout> | null>(
     null
@@ -298,12 +300,13 @@ const Tooltip = ({
       return;
     }
     e.target.focus();
-    openPortal();
+    openPortal(e);
   };
 
   const delayedOpenPortal: MouseEventHandler = useCallback(
     (event) => {
-      const timeout = setTimeout(() => openPortal(event), delay);
+      console.log({ event });
+      const timeout = setTimeout(() => openPortal(), delay);
       setTimer(timeout);
     },
     [delay, openPortal]

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -303,14 +303,10 @@ const Tooltip = ({
     openPortal(e);
   };
 
-  const delayedOpenPortal: MouseEventHandler = useCallback(
-    (event) => {
-      console.log({ event });
-      const timeout = setTimeout(() => openPortal(), delay);
-      setTimer(timeout);
-    },
-    [delay, openPortal]
-  );
+  const delayedOpenPortal: MouseEventHandler = useCallback(() => {
+    const timeout = setTimeout(() => openPortal(), delay);
+    setTimer(timeout);
+  }, [delay, openPortal]);
 
   return (
     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12091,10 +12091,10 @@ react-table@7.8.0:
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.8.0.tgz#07858c01c1718c09f7f1aed7034fcfd7bda907d2"
   integrity sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==
 
-react-useportal@1.0.18:
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/react-useportal/-/react-useportal-1.0.18.tgz#b3baf14962f44402b2d0d6152acc2035c5342bd8"
-  integrity sha512-dGuT/yyE2T9RtUxRZJYkIX8tLHC7KxAxbMw/Ufjiwo8ixoDYzkk9LFKGnARtCtFz6Yd5AoP7fVymrN3eT04jiA==
+react-useportal@1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/react-useportal/-/react-useportal-1.0.19.tgz#473168f1a1c4009833d49a46b05d974a5850a166"
+  integrity sha512-gXXxBu/j+gQrghUh5l0/GJxy3MoRxQRX0P3jpNI8c+4v/ey1ZGW3Tqh/wTYgBs8NdumvaYe+IiKGMYntEv07CA==
   dependencies:
     use-ssr "^1.0.25"
 


### PR DESCRIPTION
## Done

- Add delay of 500ms before showing tooltip after mouseover
- Delay is configurable from Props

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: #975  .
