### PR TITLE
fix(modal): do not scroll content when opened

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -99,7 +99,7 @@ export const Modal = ({
     if (close && focusableModalElements.current.length > 1) {
       focusIndex = 1;
     }
-    focusableModalElements.current[focusIndex]?.focus();
+    focusableModalElements.current[focusIndex]?.focus({ preventScroll: true });
   }, [close]);
 
   useEffect(() => {


### PR DESCRIPTION
## Done

### Problem
The modal opens with the content scrolled (when there's enough content to be scrollable), so the user can't read from the beginning. It seems like this behaviour was introduced in [this commit](https://github.com/canonical/react-components/commit/6633f75a53f04114ec64435259c2017f2c435358), where the focus is moved to one of the buttons on the footer.

### Solution
Focus without scrolling into view. 

## QA

### QA steps

- `dotrun`
- Go to the `Modal` component in storybook
- Resize window till the modal becomes scrollable (or add some text to make it more obvious)
- Check that when the modal is opened the scrollbar is on top 

## Fixes

Fixes: #958 
