### PR TITLE
fix: move useLocation within useNotify hook to cater for latest react-router-dom limitations

### DIFF
--- a/src/components/NotificationProvider/types.ts
+++ b/src/components/NotificationProvider/types.ts
@@ -37,4 +37,5 @@ export interface NotificationHelper {
   info: (message: ReactNode, title?: string) => NotificationType;
   success: (message: ReactNode) => NotificationType;
   queue: (notification: NotificationType) => QueuedNotification;
+  setDeduplicated: (value: NotificationType) => NotificationType;
 }


### PR DESCRIPTION
## Done

- moved `useLocation` call from the `NotificationProvider` component into the `useNotify` hook. This circumvents the issue where react router no longer accepts usage of `useLocation` outside of the Router context.

## QA
-  I checked this by copying the change over to the lxd-ui repo, then QA'd there.