### PR TITLE
fix: Confirmation modal can be very narrow #976

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -62,7 +62,9 @@ export const ConfirmationModal = ({
       }
       {...props}
     >
-      {children}
+      <div style={{ minWidth: '480px' }}>
+        {children}
+      </div>
     </Modal>
   );
 };


### PR DESCRIPTION
## Done

- Given a minimum width to the confirmation modal so that width doesn't become narrow when there isn't a lot of content.


## Fixes

Fixes: #976 .


https://github.com/canonical/react-components/assets/90577359/50d41671-a028-4b71-8b90-f7f3e205c738

