### PR TITLE
fix: remove invalid syntax for style imports

### DIFF
--- a/src/components/TablePagination/TablePagination.scss
+++ b/src/components/TablePagination/TablePagination.scss
@@ -1,4 +1,4 @@
-@import "~vanilla-framework/scss/settings";
+@import "vanilla-framework/scss/settings";
 
 .pagination {
   align-items: baseline;


### PR DESCRIPTION
## Done

- fix issue with style imports with the `~` prefix not working with projects built with vite.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check that styling for the table pagination component still looks okay in storybook
