### PR TITLE
docs: remove cypress badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # React components for Vanilla Framework
-![CI](https://github.com/canonical/react-components/workflows/CI/badge.svg?branch=main) ![Cypress chrome headless](https://github.com/canonical/react-components/workflows/Cypress%20chrome%20headless/badge.svg)
+![CI](https://github.com/canonical/react-components/workflows/CI/badge.svg?branch=main)
 
 This is a collection of components designed to be the way to consume [Vanilla Framework](http://vanillaframework.io) when using React.
 


### PR DESCRIPTION


## Done

Removes separate Cypress badge as cypress is part of a single CI workflow.
- docs: remove cypress badge

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

## Fixes

Fixes: # .
