### PR TITLE
ci: fix config structure change with labeler v5 update

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
 Maintenance 🔨:
-  - package.json
-  - .gitignore
+- changed-files:
+  - any-glob-to-any-file:
+    - package.json
+    - .gitignore

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,10 @@ on:
   - pull_request_target
 
 jobs:
-  triage:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5


### PR DESCRIPTION
## Done

- The labeler action v5 update had config structure change which is breaking ci for forked PRs since it runs on pull_request_target. This PR adjusts the labeler action setup based on its official [documentation](https://github.com/actions/labeler/tree/main#pull-request-labeler)

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```
