### PR TITLE
fix: table pagination description adjustments for all screen sizes

### DIFF
--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
@@ -2,7 +2,7 @@ import Button from "components/Button";
 import Icon from "components/Icon";
 import Input from "components/Input";
 import Select from "components/Select";
-import React, { ChangeEvent, HTMLAttributes, useRef } from "react";
+import React, { ChangeEvent, HTMLAttributes } from "react";
 import classnames from "classnames";
 import {
   generatePagingOptions,
@@ -38,8 +38,7 @@ const TablePaginationControls = ({
   onPageSizeChange,
   ...divProps
 }: Props): JSX.Element => {
-  const descriptionRef = useRef<HTMLDivElement>(null);
-  const isSmallScreen = useFigureSmallScreen({ descriptionRef });
+  const isSmallScreen = useFigureSmallScreen();
 
   const totalPages = Math.ceil(totalItems / pageSize);
   const descriptionDisplay = getDescription({
@@ -77,7 +76,7 @@ const TablePaginationControls = ({
       {...divProps}
       role="navigation"
     >
-      <div className="description" ref={descriptionRef}>
+      <div className="description" id="pagination-description">
         {descriptionDisplay}
       </div>
       <Button
@@ -111,7 +110,7 @@ const TablePaginationControls = ({
         <Icon name="chevron-down" />
       </Button>
       <Select
-        className="items-per-page"
+        className="u-no-margin--bottom"
         label="Items per page"
         labelClassName="u-off-screen"
         id="itemsPerPage"

--- a/src/components/TablePagination/__snapshots__/TablePagination.test.tsx.snap
+++ b/src/components/TablePagination/__snapshots__/TablePagination.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<TablePagination /> renders table pagination and matches the snapshot 1
 >
   <div
     class="description"
+    id="pagination-description"
   >
     Showing all 5 items
   </div>
@@ -72,7 +73,7 @@ exports[`<TablePagination /> renders table pagination and matches the snapshot 1
         <select
           aria-describedby=""
           aria-invalid="false"
-          class="p-form-validation__input items-per-page"
+          class="p-form-validation__input u-no-margin--bottom"
           id="itemsPerPage"
         >
           <option

--- a/src/components/TablePagination/utils.tsx
+++ b/src/components/TablePagination/utils.tsx
@@ -2,25 +2,10 @@ import {
   Children,
   ReactElement,
   ReactNode,
-  RefObject,
   cloneElement,
   useEffect,
   useState,
 } from "react";
-
-/**
- * Determine if we are working with a small screen.
- * 'small screen' in this case is relative to the width of the description div
- */
-export const figureSmallScreen = (
-  descriptionRef: RefObject<HTMLDivElement>
-) => {
-  const descriptionElement = descriptionRef.current;
-  if (!descriptionElement) {
-    return true;
-  }
-  return descriptionElement.getBoundingClientRect().width < 230;
-};
 
 /**
  * Iterate direct react child components and override the value of the prop specified by @param dataForwardProp
@@ -78,20 +63,17 @@ export const getDescription = ({
   }`;
 };
 
-export const useFigureSmallScreen = (args: {
-  descriptionRef: RefObject<HTMLDivElement>;
-}) => {
-  const { descriptionRef } = args;
+export const useFigureSmallScreen = () => {
   const [isSmallScreen, setSmallScreen] = useState(false);
   useEffect(() => {
     const handleResize = () => {
-      setSmallScreen(figureSmallScreen(descriptionRef));
+      setSmallScreen(window.innerWidth < 620);
     };
     window.addEventListener("resize", handleResize);
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, [isSmallScreen, descriptionRef]);
+  }, []);
 
   return isSmallScreen;
 };


### PR DESCRIPTION
## Done

- Fixed description text adjustment for small screen sizes. removed unnecessary `useEffect` dependencies that was previously causing weird render cycle issues.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- On story book, try vary the screen size while looking at the `TablePagination` component. The pagination description (left of controls) should show `X out of Y` for small screen sizes consistently.

[Screencast from 07-02-2024 15:27:57.webm](https://github.com/canonical/react-components/assets/151511568/f398a660-aa87-4623-ba1a-6ba3a15e7c92)
