### PR TITLE
fix: revert change for table pagination text adjustment on small screen

### DIFF
--- a/src/components/TablePagination/utils.tsx
+++ b/src/components/TablePagination/utils.tsx
@@ -8,6 +8,18 @@ import {
 } from "react";
 
 /**
+ * Determine if we are working with a small screen.
+ * 'small screen' in this case is relative to the width of the description div
+ */
+export const figureSmallScreen = () => {
+  const descriptionElement = document.getElementById("pagination-description");
+  if (!descriptionElement) {
+    return true;
+  }
+  return descriptionElement.getBoundingClientRect().width < 230;
+};
+
+/**
  * Iterate direct react child components and override the value of the prop specified by @param dataForwardProp
  * for those child components.
  * @param children - react node children to iterate
@@ -67,7 +79,7 @@ export const useFigureSmallScreen = () => {
   const [isSmallScreen, setSmallScreen] = useState(false);
   useEffect(() => {
     const handleResize = () => {
-      setSmallScreen(window.innerWidth < 620);
+      setSmallScreen(figureSmallScreen());
     };
     window.addEventListener("resize", handleResize);
     return () => {


### PR DESCRIPTION
## Done

- Table pagination description should shrink based on its container width and not screen width. This was implemented before but was removed from a previous commit. This PR added the code back which implements the aforementioned logic.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to `TablePagination` component in Storybook and inspect that the pagination description to show `X out of Y` before small screen breakpoint (~830px)
