### PR TITLE
fix: slider input field has wrong width #1041

### DIFF
--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 
+// stylelint-disable-next-line scss/load-no-partial-leading-underscore
 @import "~vanilla-framework/scss/_base_forms";
 @import "~vanilla-framework/scss/base_placeholders";
 @import "~vanilla-framework/scss/base_icon-definitions";

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -1,9 +1,79 @@
 @use "sass:map";
-@import "vanilla-framework";
-@include vf-base;
-@include vf-p-lists;
+
+@import "~vanilla-framework/scss/_base_forms";
+@import "~vanilla-framework/scss/base_placeholders";
+@import "~vanilla-framework/scss/base_icon-definitions";
+
+@include vf-b-placeholders;
 
 $dropdown-max-height: 20rem;
+
+/**
+ Including base vanilla input elements declaration from:
+https://github.com/canonical/vanilla-framework/blob/b4378c920f8bcb804db2ead64566ce3fa54636ae/scss/_base_forms.scss#L14
+
+Workaround for: https: //github.com/canonical/react-components/issues/1041
+*/
+
+%vf-readonly-element {
+  color: $color-mid-light;
+  cursor: default;
+
+  &:hover,
+  &:active {
+    border-color: $color-mid-dark;
+    outline: none;
+  }
+}
+%vf-disabled-element {
+  cursor: not-allowed;
+  opacity: $disabled-element-opacity;
+}
+%bordered-text-vertical-padding {
+  padding-bottom: $input-vertical-padding;
+  padding-top: $input-vertical-padding;
+}
+%vf-input-elements {
+  @extend %bordered-text-vertical-padding;
+  @include vf-focus($color-focus, $bar-thickness, true);
+  @include vf-animation(#{background-color}, fast);
+
+  // stylelint-disable property-no-vendor-prefix
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  appearance: textfield;
+  // stylelint-enable property-no-vendor-prefix
+  background-color: $colors--light-theme--background-inputs;
+  border: 0 solid transparent;
+  border-bottom: $input-border-thickness solid
+    $colors--light-theme--text-default;
+  border-radius: 0;
+  color: $colors--light-theme--text-default;
+  font-family: unquote($font-base-family);
+  font-size: 1rem;
+  font-weight: $font-weight-regular-text;
+  line-height: map-get($line-heights, default-text);
+  margin-bottom: $input-margin-bottom;
+  min-width: 8em;
+  padding-left: $sph--small;
+  padding-right: $sph--small;
+  vertical-align: baseline;
+  width: 100%;
+
+  &:hover {
+    background-color: $colors--light-theme--background-hover;
+  }
+
+  &:active,
+  &:focus {
+    background-color: $colors--light-theme--background-active;
+  }
+
+  &[disabled],
+  &[disabled="disabled"] {
+    @extend %vf-disabled-element;
+  }
+}
 
 .multi-select {
   position: relative;


### PR DESCRIPTION
## Done

- fix: Slider input field has wrong width #1041

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Verify that bug in the linked issue has been fixed.

## Fixes

Fixes: # .
