### PR TITLE
fix: hide description when width is below the small breakpoint

### DIFF
--- a/src/components/TablePagination/TablePagination.scss
+++ b/src/components/TablePagination/TablePagination.scss
@@ -3,10 +3,18 @@
 .pagination {
   align-items: baseline;
   display: flex;
-  margin-top: 1.2rem;
+  margin: $spv--large 0;
+
+  @media screen and (max-width: $breakpoint-small) {
+    justify-content: flex-end;
+  }
 
   .description {
     flex-grow: 1;
+
+    @media screen and (max-width: $breakpoint-small) {
+      display: none;
+    }
   }
 
   .back {


### PR DESCRIPTION
## Done

Even in its shortened version, the description for the table pagination goes new line multiple times on small widths:

![image](https://github.com/canonical/react-components/assets/56583786/ce4ba257-01ab-45aa-9110-f20d78712ed0)

To solve this, the description element is now hidden when width is below the small breakpoint.

![image](https://github.com/canonical/react-components/assets/56583786/5b709d14-2299-4b7d-9213-20d6ee89fd49)

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- On any storybook example for the table pagination, resize the window so that the width is lower than 620px (small breakpoint).
- Check that the description is hidden.