### PR TITLE
fix(notif-provider): make success notification title customisable

### DIFF
--- a/src/components/NotificationProvider/NotificationProvider.test.tsx
+++ b/src/components/NotificationProvider/NotificationProvider.test.tsx
@@ -16,7 +16,7 @@ describe("NotificationProvider", () => {
 
     const TriggerComponent = () => {
       const notify = useNotify();
-      const handleSuccess = () => notify.success("My success!");
+      const handleSuccess = () => notify.success("My success!", "Test success");
       const handleClear = () => notify.clear();
       const handleInfo = () => notify.info("Some more details", "Test info");
       const handleError = () =>

--- a/src/components/NotificationProvider/NotificationProvider.tsx
+++ b/src/components/NotificationProvider/NotificationProvider.tsx
@@ -59,7 +59,7 @@ export const NotificationProvider: FC<NotifyProviderProps> = ({
     failure: (title, error, message, actions) =>
       setDeduplicated(failure(title, error, message, actions)),
     info: (message, title) => setDeduplicated(info(message, title)),
-    success: (message) => setDeduplicated(success(message)),
+    success: (message, title) => setDeduplicated(success(message, title)),
     setDeduplicated,
   };
 

--- a/src/components/NotificationProvider/__snapshots__/NotificationProvider.test.tsx.snap
+++ b/src/components/NotificationProvider/__snapshots__/NotificationProvider.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`NotificationProvider stores and renders notifications 1`] = `
           class="p-notification__title"
           data-testid="notification-title"
         >
-          Success
+          Test success
         </h5>
         <p
           class="p-notification__message"

--- a/src/components/NotificationProvider/messageBuilder.tsx
+++ b/src/components/NotificationProvider/messageBuilder.tsx
@@ -18,9 +18,13 @@ export const info = (message: ReactNode, title?: string): NotificationType => {
   };
 };
 
-export const success = (message: ReactNode): NotificationType => {
+export const success = (
+  message: ReactNode,
+  title?: string
+): NotificationType => {
   return {
     message,
+    title,
     type: NotificationSeverity.POSITIVE,
   };
 };

--- a/src/components/NotificationProvider/types.ts
+++ b/src/components/NotificationProvider/types.ts
@@ -39,7 +39,7 @@ export interface NotificationHelper {
     actions?: NotificationAction[]
   ) => NotificationType;
   info: (message: ReactNode, title?: string) => NotificationType;
-  success: (message: ReactNode) => NotificationType;
+  success: (message: ReactNode, title?: string) => NotificationType;
   queue: (notification: NotificationType) => QueuedNotification;
   setDeduplicated: (value: NotificationType) => NotificationType;
 }


### PR DESCRIPTION
## Done

- Allow to (optionally) customise the title for a success notification when using the `NotificationProvider`.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Set a custom title for the success notification, and check that it is correctly displayed.