### PR TITLE
fix(MultiSelect): Apply a temporary fix for Vanilla includes in MultiSelect component

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ts-jest": "29.1.2",
     "tsc-alias": "1.8.8",
     "typescript": "5.3.3",
-    "vanilla-framework": "4.6.0",
+    "vanilla-framework": "4.9.0",
     "wait-on": "7.2.0",
     "webpack": "5.89.0"
   },

--- a/src/components/Icon/Icon.stories.scss
+++ b/src/components/Icon/Icon.stories.scss
@@ -1,7 +1,4 @@
-@import "~vanilla-framework/scss/settings";
-@import "~vanilla-framework/scss/base_placeholders";
-@import "~vanilla-framework/scss/base_icon-definitions";
-@import "~vanilla-framework/scss/patterns_icons";
+@import "vanilla-framework";
 
 @include vf-b-placeholders;
 @include vf-p-icons-common;

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -1,138 +1,15 @@
 @use "sass:map";
 @import "vanilla-framework";
+@include vf-b-placeholders; // Vanilla base placeholders to extend from
 
 $dropdown-max-height: 20rem;
 
-// XXX: Temporarly we are duplicating some of the placeholders defined in Vanilla
-// to avoid conflict of including the duplicate of base Vanilla in React components.
-// This is a temporary solution until we have a better way to handle this.
-
-// as in Vanilla _base_placeholders.scss
-%vf-hide-text {
-  overflow: hidden;
-  text-indent: 110vw;
-  white-space: nowrap;
-}
-
-// as in Vanilla _base_placeholders.scss
-%icon {
-  $vertical-offset: 0.5px;
-  @extend %vf-hide-text;
-  @include vf-icon-size($default-icon-size);
-  background: {
-    position: center;
-    repeat: no-repeat;
-  }
-
-  display: inline-block;
-  font-size: inherit; // allow icons to match size of parent text element, when set in em
-  margin: 0;
-  padding: 0;
-  position: relative;
-  vertical-align: calc(
-    $vertical-offset + 0.5 * $cap-height - 0.5 * $default-icon-size
-  );
-}
-
-// as in Vanilla _base_forms.scss
-%vf-disabled-element {
-  cursor: not-allowed;
-  opacity: $disabled-element-opacity;
-}
-
-// as in Vanilla _base_forms.scss
-%vf-readonly-element {
-  color: $color-mid-light;
-  cursor: default;
-
-  &:hover,
-  &:active {
-    border-color: $color-mid-dark;
-    outline: none;
-  }
-}
-
-// as in Vanilla _base_forms.scss
-%bordered-text-vertical-padding {
-  padding-bottom: $input-vertical-padding;
-  padding-top: $input-vertical-padding;
-}
-
-// as in Vanilla _base_forms.scss
-%vf-input-elements {
-  @extend %bordered-text-vertical-padding;
-  @include vf-focus($color-focus, $bar-thickness, true);
-  @include vf-animation(#{background-color}, fast);
-
-  // stylelint-disable property-no-vendor-prefix
-  -webkit-appearance: textfield;
-  -moz-appearance: textfield;
-  appearance: textfield;
-  // stylelint-enable property-no-vendor-prefix
-  background-color: $colors--theme--background-inputs;
-  border: 0 solid transparent;
-  border-bottom: $input-border-thickness solid
-    $colors--theme--border-high-contrast;
-  border-radius: 0;
-  color: $colors--theme--text-default;
-  font-family: unquote($font-base-family);
-  font-size: 1rem;
-  font-weight: $font-weight-regular-text;
-  line-height: map-get($line-heights, default-text);
-  margin-bottom: $input-margin-bottom;
-  min-width: 8em;
-  padding-left: $sph--small;
-  padding-right: $sph--small;
-  vertical-align: baseline;
-  width: 100%;
-
-  &:hover {
-    background-color: $colors--theme--background-hover;
-  }
-
-  &:active,
-  &:focus {
-    background-color: $colors--theme--background-active;
-  }
-
-  option,
-  option:checked {
-    background-color: $colors--theme--background-alt;
-    color: $colors--theme--text-default;
-  }
-
-  option:checked:not(:disabled) {
-    background-color: $colors--theme--background-active;
-  }
-
-  &::placeholder {
-    color: $colors--theme--text-muted;
-  }
-
-  &.is-dense {
-    margin: 0 0 $spv-nudge-compensation 0;
-    padding-bottom: calc($spv-nudge - $spv--x-small - $input-border-thickness);
-    padding-top: calc($spv-nudge - $spv--x-small - $input-border-thickness);
-  }
-
-  &[disabled],
-  &[disabled="disabled"] {
-    @extend %vf-disabled-element;
-  }
-
-  &[readonly],
-  &[readonly="readonly"] {
-    @extend %vf-readonly-element;
-  }
-
-  @each $state, $color in $states {
-    &.has-#{$state} {
-      border: $input-border-thickness solid $color;
-    }
-  }
-}
-
 .multi-select {
+  // Scope Vanilla form includes to multi select component only
+  // to avoid overriding any Vanilla base styles
+  // XXX: This is a workaround for https://github.com/canonical/vanilla-framework/issues/5030
+  @include vf-b-forms;
+
   position: relative;
 }
 

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -1,9 +1,136 @@
 @use "sass:map";
 @import "vanilla-framework";
-@include vf-base;
-@include vf-p-lists;
 
 $dropdown-max-height: 20rem;
+
+// XXX: Temporarly we are duplicating some of the placeholders defined in Vanilla
+// to avoid conflict of including the duplicate of base Vanilla in React components.
+// This is a temporary solution until we have a better way to handle this.
+
+// as in Vanilla _base_placeholders.scss
+%vf-hide-text {
+  overflow: hidden;
+  text-indent: 110vw;
+  white-space: nowrap;
+}
+
+// as in Vanilla _base_placeholders.scss
+%icon {
+  $vertical-offset: 0.5px;
+  @extend %vf-hide-text;
+  @include vf-icon-size($default-icon-size);
+  background: {
+    position: center;
+    repeat: no-repeat;
+  }
+
+  display: inline-block;
+  font-size: inherit; // allow icons to match size of parent text element, when set in em
+  margin: 0;
+  padding: 0;
+  position: relative;
+  vertical-align: calc(
+    $vertical-offset + 0.5 * $cap-height - 0.5 * $default-icon-size
+  );
+}
+
+// as in Vanilla _base_forms.scss
+%vf-disabled-element {
+  cursor: not-allowed;
+  opacity: $disabled-element-opacity;
+}
+
+// as in Vanilla _base_forms.scss
+%vf-readonly-element {
+  color: $color-mid-light;
+  cursor: default;
+
+  &:hover,
+  &:active {
+    border-color: $color-mid-dark;
+    outline: none;
+  }
+}
+
+// as in Vanilla _base_forms.scss
+%bordered-text-vertical-padding {
+  padding-bottom: $input-vertical-padding;
+  padding-top: $input-vertical-padding;
+}
+
+// as in Vanilla _base_forms.scss
+%vf-input-elements {
+  @extend %bordered-text-vertical-padding;
+  @include vf-focus($color-focus, $bar-thickness, true);
+  @include vf-animation(#{background-color}, fast);
+
+  // stylelint-disable property-no-vendor-prefix
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  appearance: textfield;
+  // stylelint-enable property-no-vendor-prefix
+  background-color: $colors--theme--background-inputs;
+  border: 0 solid transparent;
+  border-bottom: $input-border-thickness solid
+    $colors--theme--border-high-contrast;
+  border-radius: 0;
+  color: $colors--theme--text-default;
+  font-family: unquote($font-base-family);
+  font-size: 1rem;
+  font-weight: $font-weight-regular-text;
+  line-height: map-get($line-heights, default-text);
+  margin-bottom: $input-margin-bottom;
+  min-width: 8em;
+  padding-left: $sph--small;
+  padding-right: $sph--small;
+  vertical-align: baseline;
+  width: 100%;
+
+  &:hover {
+    background-color: $colors--theme--background-hover;
+  }
+
+  &:active,
+  &:focus {
+    background-color: $colors--theme--background-active;
+  }
+
+  option,
+  option:checked {
+    background-color: $colors--theme--background-alt;
+    color: $colors--theme--text-default;
+  }
+
+  option:checked:not(:disabled) {
+    background-color: $colors--theme--background-active;
+  }
+
+  &::placeholder {
+    color: $colors--theme--text-muted;
+  }
+
+  &.is-dense {
+    margin: 0 0 $spv-nudge-compensation 0;
+    padding-bottom: calc($spv-nudge - $spv--x-small - $input-border-thickness);
+    padding-top: calc($spv-nudge - $spv--x-small - $input-border-thickness);
+  }
+
+  &[disabled],
+  &[disabled="disabled"] {
+    @extend %vf-disabled-element;
+  }
+
+  &[readonly],
+  &[readonly="readonly"] {
+    @extend %vf-readonly-element;
+  }
+
+  @each $state, $color in $states {
+    &.has-#{$state} {
+      border: $input-border-thickness solid $color;
+    }
+  }
+}
 
 .multi-select {
   position: relative;
@@ -37,12 +164,12 @@ $dropdown-max-height: 20rem;
 }
 
 .multi-select__dropdown {
-  @extend %vf-bg--x-light;
-  @extend %vf-has-box-shadow;
+  background-color: $colors--theme--background-default;
+  box-shadow: $box-shadow;
+  color: $colors--theme--text-default;
   left: 0;
   max-height: $dropdown-max-height;
   overflow: auto;
-
   padding-top: $spv--small;
   position: absolute;
   right: 0;
@@ -59,14 +186,15 @@ $dropdown-max-height: 20rem;
 }
 
 .multi-select__dropdown-list {
-  @extend %vf-list;
-
+  list-style: none;
   margin-bottom: $sph--x-small;
+  margin-left: 0;
+  padding-left: 0;
 }
 
 .multi-select__footer {
-  background: white;
-  border-top: 1px solid $color-mid-light;
+  background: $colors--theme--background-default;
+  border-top: 1px solid $colors--theme--border-default;
   bottom: 0;
   display: flex;
   flex-wrap: wrap;
@@ -97,12 +225,6 @@ $dropdown-max-height: 20rem;
   }
 }
 
-.multi-select__dropdown-item-description {
-  @extend %small-text;
-
-  color: $color-mid-dark;
-}
-
 .multi-select__dropdown-button {
   border: 0;
   margin-bottom: 0;
@@ -113,7 +235,7 @@ $dropdown-max-height: 20rem;
 }
 
 .multi-select__selected-list {
-  background-color: $colors--light-theme--background-inputs;
+  background-color: $colors--theme--background-inputs;
   border-bottom: 0;
   margin: 0;
   overflow: hidden;
@@ -142,12 +264,12 @@ $dropdown-max-height: 20rem;
     transform: translateY(-50%) rotate(-180deg);
 
     @extend %icon;
-    @include vf-icon-chevron($color-mid-dark);
+    @include vf-icon-chevron-themed;
     @include vf-transition($property: transform, $duration: fast);
   }
 
   &[aria-expanded="true"] {
-    background-color: $colors--light-theme--background-hover;
+    background-color: $colors--theme--background-hover;
   }
 
   &[aria-expanded="false"] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14500,10 +14500,10 @@ validate-npm-package-name@^5.0.0:
   dependencies:
     builtins "^5.0.0"
 
-vanilla-framework@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.6.0.tgz#61b93a2197eed0d869f85e1014dd9e67bacc355e"
-  integrity sha512-pRjJknqsL4CLA+ovLMlg7MhVh9nIcu7Ev81Z62gh3hAzUDIiZOUI2W9+B16XWv4QFmFxEOgQcfVi2cezLun9SQ==
+vanilla-framework@4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.0.tgz#7566b42a22c2394ea1d7ea843d24ec305446cb3e"
+  integrity sha512-iTmvqWlsX0ic69VZ1sR9NPQtYRR9+iM679HZCl7SDQhMQSsEeJEQ6Ejjen3JN5a7YxiYmeIhxaLlmC4rExRT1w==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Done

- Updates Vanilla to 4.9.0
- Removes problematic `@includes` (`vf-base` and `vf-b-forms`) and`@extend` uses from `MultiSelect.scss` and replaces them with copies of relevant parts of Vanilla.

This is a temporary solution until we find better ways to reuse bigger parts of Vanilla styling. `@extend` usage by itself is not huge issue, but it does silently create a duplicate of Vanilla styling.
Bigger problem was including `vf-base` and `vf-lists` (which contain required placeholders to extend) as they duplicate big chunks of Vanilla styling creating source order conflicts of old and new styles and breaking the styling of some other components.

### QA steps

- Check if MultiSelect renders and works as expected:
  - https://react-components-1052.demos.haus/?path=/docs/multiselect--docs
- Check if previously broken slider component renders as expected:
  - https://react-components-1052.demos.haus/?path=/story/slider--with-input

## Fixes

Fixes: #1041
