### PR TITLE
ci: Require the review of Percy visual tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,6 @@ Maintenance 🔨:
   - any-glob-to-any-file:
     - package.json
     - .gitignore
+"Review: Percy needed":
+- changed-files:
+  - any-glob-to-any-file: src/**

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,23 @@
+name: PR Percy Review Label Required
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "Review: Percy +1"
+          add_comment: true
+          message: |
+            This PR is being prevented from merging because it needs to be reviewed on Percy.
+
+            Go to [Percy](https://percy.io/bb49709b/react-components), find the build relevant to this PR and check if it looks as expected.
+
+            Once it's approved, add the label `Review: Percy +1` to this PR.


### PR DESCRIPTION
## Done

- Adds a CI check that enforces Percy review and adding `Review: Percy +1` label.
- Adds a `Review: Percy needed` automatically if any files in `src` are changed.

## QA

- Check that there is no `Review: Percy +1` label on the PR.
- Check that CI is failing on "PR Percy Review Label Required" job
- Find a bot comment describing why merging is blocked that describes what to do
- Follow the comment instructions
- After reviewing Percy, add `Review: Percy +1` label
- Make sure CI passes 