### PR TITLE
fix: stop click event propagation in Modal

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -55,4 +55,73 @@ describe("ConfirmationModal ", () => {
     await userEvent.click(screen.getByText("Proceed"));
     expect(onConfirm).toHaveBeenCalled();
   });
+
+  it("should stop click event propagation on cancel by default", async () => {
+    const handleExternalClick = jest.fn();
+    render(
+      <div onClick={handleExternalClick}>
+        <ConfirmationModal
+          cancelButtonLabel="Go back"
+          confirmButtonLabel="Proceed"
+          onConfirm={jest.fn()}
+        >
+          Test click propagation
+        </ConfirmationModal>
+      </div>
+    );
+
+    await userEvent.click(screen.getByText("Go back"));
+    expect(handleExternalClick).toHaveBeenCalledTimes(0);
+  });
+
+  it("should propagate click event on cancel", async () => {
+    const handleExternalClick = jest.fn();
+    render(
+      <div onClick={handleExternalClick}>
+        <ConfirmationModal
+          cancelButtonLabel="Go back"
+          confirmButtonLabel="Proceed"
+          onConfirm={jest.fn()}
+          shouldPropagateClickEvent={true}
+        >
+          Test click propagation
+        </ConfirmationModal>
+      </div>
+    );
+
+    await userEvent.click(screen.getByText("Go back"));
+    expect(handleExternalClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop click event propagation on confirm by default", async () => {
+    const handleExternalClick = jest.fn();
+    render(
+      <div onClick={handleExternalClick}>
+        <ConfirmationModal confirmButtonLabel="Proceed" onConfirm={jest.fn()}>
+          Test click propagation
+        </ConfirmationModal>
+      </div>
+    );
+
+    await userEvent.click(screen.getByText("Proceed"));
+    expect(handleExternalClick).toHaveBeenCalledTimes(0);
+  });
+
+  it("should propagate click event on confirm", async () => {
+    const handleExternalClick = jest.fn();
+    render(
+      <div onClick={handleExternalClick}>
+        <ConfirmationModal
+          confirmButtonLabel="Proceed"
+          onConfirm={jest.fn()}
+          shouldPropagateClickEvent={true}
+        >
+          Test click propagation
+        </ConfirmationModal>
+      </div>
+    );
+
+    await userEvent.click(screen.getByText("Proceed"));
+    expect(handleExternalClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -71,7 +71,7 @@ describe("ConfirmationModal ", () => {
     );
 
     await userEvent.click(screen.getByText("Go back"));
-    expect(handleExternalClick).toHaveBeenCalledTimes(0);
+    expect(handleExternalClick).not.toHaveBeenCalled();
   });
 
   it("should propagate click event on cancel", async () => {
@@ -104,7 +104,7 @@ describe("ConfirmationModal ", () => {
     );
 
     await userEvent.click(screen.getByText("Proceed"));
-    expect(handleExternalClick).toHaveBeenCalledTimes(0);
+    expect(handleExternalClick).not.toHaveBeenCalled();
   });
 
   it("should propagate click event on confirm", async () => {

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -29,7 +29,7 @@ export type Props = PropsWithSpread<
     /**
      * Function to perform the action prompted by the modal.
      */
-    onConfirm: (e: MouseEvent<HTMLElement>) => void;
+    onConfirm: (event: MouseEvent<HTMLElement>) => void;
   },
   Omit<ModalProps, "buttonRow">
 >;
@@ -44,13 +44,13 @@ export const ConfirmationModal = ({
   ...props
 }: Props): ReactElement => {
   const handleClick =
-    (action: Function | null | undefined) =>
-    (e: MouseEvent<HTMLButtonElement>) => {
+    <A extends Function>(action: A | null | undefined) =>
+    (event: MouseEvent<HTMLButtonElement>) => {
       if (!props.shouldPropagateClickEvent) {
-        e.stopPropagation();
+        event.stopPropagation();
       }
       if (action) {
-        action(e);
+        action(event);
       }
     };
 

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -43,18 +43,32 @@ export const ConfirmationModal = ({
   onConfirm,
   ...props
 }: Props): ReactElement => {
+  const handleClick =
+    (action: Function | null | undefined) =>
+    (e: MouseEvent<HTMLButtonElement>) => {
+      if (!props.shouldPropagateClickEvent) {
+        e.stopPropagation();
+      }
+      if (action) {
+        action(e);
+      }
+    };
+
   return (
     <Modal
       buttonRow={
         <>
           {confirmExtra}
-          <Button className="u-no-margin--bottom" onClick={props.close}>
+          <Button
+            className="u-no-margin--bottom"
+            onClick={handleClick(props.close)}
+          >
             {cancelButtonLabel}
           </Button>
           <Button
             appearance={confirmButtonAppearance}
             className="u-no-margin--bottom"
-            onClick={onConfirm}
+            onClick={handleClick(onConfirm)}
           >
             {confirmButtonLabel}
           </Button>

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -139,4 +139,36 @@ describe("Modal ", () => {
     expect(mockHandleModalClose).toHaveBeenCalledTimes(1);
     expect(mockHandleEscPress).not.toHaveBeenCalled();
   });
+
+  it("should stop click event propagation on close by default", async () => {
+    const handleExternalClick = jest.fn();
+    const { container } = render(
+      <div onClick={handleExternalClick}>
+        <Modal title="Test" close={jest.fn()}>
+          Bare bones
+        </Modal>
+      </div>
+    );
+
+    const closeButton = container.querySelector("button.p-modal__close");
+    expect(closeButton).not.toBeNull();
+    await userEvent.click(closeButton!);
+    expect(handleExternalClick).toHaveBeenCalledTimes(0);
+  });
+
+  it("should propagate click event on close", async () => {
+    const handleExternalClick = jest.fn();
+    const { container } = render(
+      <div onClick={handleExternalClick}>
+        <Modal title="Test" close={jest.fn()} shouldPropagateClickEvent={true}>
+          Bare bones
+        </Modal>
+      </div>
+    );
+
+    const closeButton = container.querySelector("button.p-modal__close");
+    expect(closeButton).not.toBeNull();
+    await userEvent.click(closeButton!);
+    expect(handleExternalClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -153,7 +153,7 @@ describe("Modal ", () => {
     const closeButton = container.querySelector("button.p-modal__close");
     expect(closeButton).not.toBeNull();
     await userEvent.click(closeButton!);
-    expect(handleExternalClick).toHaveBeenCalledTimes(0);
+    expect(handleExternalClick).not.toHaveBeenCalled();
   });
 
   it("should propagate click event on close", async () => {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -39,7 +39,7 @@ export const Modal = ({
   className,
   close,
   title,
-  shouldPropagateClickEvent,
+  shouldPropagateClickEvent = false,
   ...wrapperProps
 }: Props): ReactElement => {
   // list of focusable selectors is based on this Stack Overflow answer:

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -52,7 +52,7 @@ export const Modal = ({
 
   const modalRef: MutableRefObject<HTMLElement> = useRef(null);
   const focusableModalElements = useRef(null);
-  const handleTabKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleTabKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (focusableModalElements.current.length > 0) {
       const firstElement = focusableModalElements.current[0];
       const lastElement =
@@ -60,27 +60,27 @@ export const Modal = ({
           focusableModalElements.current.length - 1
         ];
 
-      if (!e.shiftKey && document.activeElement === lastElement) {
+      if (!event.shiftKey && document.activeElement === lastElement) {
         (firstElement as HTMLElement).focus();
-        e.preventDefault();
+        event.preventDefault();
       }
 
-      if (e.shiftKey && document.activeElement === firstElement) {
+      if (event.shiftKey && document.activeElement === firstElement) {
         (lastElement as HTMLElement).focus();
-        return e.preventDefault();
+        return event.preventDefault();
       }
     }
   };
 
   const handleEscKey = (
-    e: KeyboardEvent | React.KeyboardEvent<HTMLDivElement>
+    event: KeyboardEvent | React.KeyboardEvent<HTMLDivElement>
   ) => {
-    if ("nativeEvent" in e && e.nativeEvent.stopImmediatePropagation) {
-      e.nativeEvent.stopImmediatePropagation();
-    } else if ("stopImmediatePropagation" in e) {
-      e.stopImmediatePropagation();
-    } else if (e.stopPropagation) {
-      e.stopPropagation();
+    if ("nativeEvent" in event && event.nativeEvent.stopImmediatePropagation) {
+      event.nativeEvent.stopImmediatePropagation();
+    } else if ("stopImmediatePropagation" in event) {
+      event.stopImmediatePropagation();
+    } else if (event.stopPropagation) {
+      event.stopPropagation();
     }
     if (close) {
       close();
@@ -109,9 +109,9 @@ export const Modal = ({
   }, [close]);
 
   useEffect(() => {
-    const keyDown = (e: KeyboardEvent) => {
-      const listener = keyListenersMap.get(e.code);
-      return listener && listener(e);
+    const keyDown = (event: KeyboardEvent) => {
+      const listener = keyListenersMap.get(event.code);
+      return listener && listener(event);
     };
 
     document.addEventListener("keydown", keyDown);
@@ -128,24 +128,26 @@ export const Modal = ({
     shouldClose.current = false;
   };
 
-  const handleOverlayOnMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === modalRef.current) {
+  const handleOverlayOnMouseDown = (
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    if (event.target === modalRef.current) {
       shouldClose.current = true;
     }
   };
 
-  const handleClose = (e: React.MouseEvent) => {
+  const handleClose = (event: React.MouseEvent) => {
     if (!shouldPropagateClickEvent) {
-      e.stopPropagation();
+      event.stopPropagation();
     }
     if (close) {
       close();
     }
   };
 
-  const handleOverlayOnClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleOverlayOnClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (shouldClose.current) {
-      handleClose(e);
+      handleClose(event);
     }
   };
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -25,6 +25,10 @@ export type Props = PropsWithSpread<
      * The title of the modal.
      */
     title?: ReactNode | null;
+    /**
+     * Whether the button click event should propagate.
+     */
+    shouldPropagateClickEvent?: boolean;
   },
   HTMLProps<HTMLDivElement>
 >;
@@ -35,6 +39,7 @@ export const Modal = ({
   className,
   close,
   title,
+  shouldPropagateClickEvent,
   ...wrapperProps
 }: Props): ReactElement => {
   // list of focusable selectors is based on this Stack Overflow answer:
@@ -77,7 +82,9 @@ export const Modal = ({
     } else if (e.stopPropagation) {
       e.stopPropagation();
     }
-    close();
+    if (close) {
+      close();
+    }
   };
 
   const keyListenersMap = new Map([
@@ -102,7 +109,7 @@ export const Modal = ({
   }, [close]);
 
   useEffect(() => {
-    const keyDown = (e) => {
+    const keyDown = (e: KeyboardEvent) => {
       const listener = keyListenersMap.get(e.code);
       return listener && listener(e);
     };
@@ -121,15 +128,24 @@ export const Modal = ({
     shouldClose.current = false;
   };
 
-  const handleOverlayOnMouseDown = (event) => {
-    if (event.target === modalRef.current) {
+  const handleOverlayOnMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === modalRef.current) {
       shouldClose.current = true;
     }
   };
 
-  const handleOverlayOnClick = () => {
-    if (shouldClose.current) {
+  const handleClose = (e: React.MouseEvent) => {
+    if (!shouldPropagateClickEvent) {
+      e.stopPropagation();
+    }
+    if (close) {
       close();
+    }
+  };
+
+  const handleOverlayOnClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (shouldClose.current) {
+      handleClose(e);
     }
   };
 
@@ -159,7 +175,7 @@ export const Modal = ({
               <button
                 className="p-modal__close"
                 aria-label="Close active modal"
-                onClick={close}
+                onClick={handleClose}
               >
                 Close
               </button>


### PR DESCRIPTION
## Done

- Stopped click event propagation when closing `Modal` and when closing or confirming `ConfirmationModal`.

## QA

- Check that `Modal` and `ConfirmationModal` renders as expected in storybook.
- (optional) For example, the stop click event propagation can be tested in Juju Dashboard when opening the charm actions panel of a charm and clicking on an action. A `ConfirmationModal` will be rendered in a `Portal`. Clicking the close button used to close the panel, but, using the changes in this PR, it doesn't.

## Fixes

- Fixes: #1032 
- https://warthogs.atlassian.net/browse/WD-9915
