### PR TITLE
fix: tooltip open

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -287,7 +287,8 @@ const Tooltip = ({
 
     if (
       e.relatedTarget
-        ? !messageRef.current?.contains(e.relatedTarget)
+        ? !messageRef.current?.contains(e.relatedTarget) &&
+          !wrapperRef.current?.contains(e.relatedTarget)
         : e.target !== messageRef.current
     ) {
       cancelableClosePortal();


### PR DESCRIPTION
## Done

- Fix tooltip open/close: When tooltip wraps multiple children, and we change which child is hovered, the tooltip should stay open.

see description video in https://github.com/canonical/anbox-cloud-dashboard/pull/732#pullrequestreview-1976424478
