### PR TITLE
fix(field): remove bold prefix for error/caution/success validation

### DIFF
--- a/src/components/Field/Field.test.tsx
+++ b/src/components/Field/Field.test.tsx
@@ -27,7 +27,7 @@ describe("Field ", () => {
       </Field>
     );
     expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
-      "Caution: Are you sure?"
+      "Are you sure?"
     );
     expect(screen.getByTestId("field")).toHaveClass("is-caution");
   });
@@ -43,7 +43,7 @@ describe("Field ", () => {
       </Field>
     );
     expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
-      "Caution: Are you sure?"
+      "Are you sure?"
     );
     expect(screen.getByTestId("field")).toHaveClass("is-caution");
   });
@@ -55,7 +55,7 @@ describe("Field ", () => {
       </Field>
     );
     expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
-      "Error: You can't do that"
+      "You can't do that"
     );
     expect(screen.getByTestId("field")).toHaveClass("is-error");
   });
@@ -71,7 +71,7 @@ describe("Field ", () => {
       </Field>
     );
     expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
-      "Error: You can't do that"
+      "You can't do that"
     );
     expect(screen.getByTestId("field")).toHaveClass("is-error");
   });
@@ -83,7 +83,7 @@ describe("Field ", () => {
       </Field>
     );
     expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
-      "Success: You did it!"
+      "You did it!"
     );
     expect(screen.getByTestId("field")).toHaveClass("is-success");
   });
@@ -99,7 +99,7 @@ describe("Field ", () => {
       </Field>
     );
     expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
-      "Success: You did it!"
+      "You did it!"
     );
     expect(screen.getByTestId("field")).toHaveClass("is-success");
   });

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -107,11 +107,9 @@ const generateError = (
   if (!error && !caution && !success) {
     return null;
   }
-  const messageType =
-    (error && "Error") || (caution && "Caution") || (success && "Success");
   return (
     <p className="p-form-validation__message" id={validationId}>
-      <strong>{messageType}:</strong> {error || caution || success}
+      {error || caution || success}
     </p>
   );
 };

--- a/src/components/FormikField/FormikField.test.tsx
+++ b/src/components/FormikField/FormikField.test.tsx
@@ -29,9 +29,7 @@ describe("FormikField", () => {
       </Formik>
     );
 
-    expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
-    );
+    expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage("Uh oh!");
   });
 
   it("can hide the errors", () => {

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -103,23 +103,17 @@ describe("Input", () => {
 
   it("can display an error for a text input", async () => {
     render(<Input error="Uh oh!" type="text" />);
-    expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
-    );
+    expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage("Uh oh!");
   });
 
   it("can display an error for a radiobutton", async () => {
     render(<Input error="Uh oh!" type="radio" />);
-    expect(screen.getByRole("radio")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
-    );
+    expect(screen.getByRole("radio")).toHaveAccessibleErrorMessage("Uh oh!");
   });
 
   it("can display an error for a checkbox", async () => {
     render(<Input error="Uh oh!" type="checkbox" />);
-    expect(screen.getByRole("checkbox")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
-    );
+    expect(screen.getByRole("checkbox")).toHaveAccessibleErrorMessage("Uh oh!");
   });
 
   it("can display help for a text input", async () => {

--- a/src/components/PasswordToggle/PasswordToggle.test.tsx
+++ b/src/components/PasswordToggle/PasswordToggle.test.tsx
@@ -50,7 +50,7 @@ describe("PasswordToggle", () => {
   it("can display an error", async () => {
     render(<PasswordToggle error="Uh oh!" id="test-id" label="password" />);
     expect(screen.getByLabelText("password")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
+      "Uh oh!"
     );
   });
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -55,9 +55,7 @@ describe("Select", () => {
 
   it("can display an error", async () => {
     render(<Select error="Uh oh!" />);
-    expect(screen.getByRole("combobox")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
-    );
+    expect(screen.getByRole("combobox")).toHaveAccessibleErrorMessage("Uh oh!");
   });
 
   it("can display help", async () => {

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -35,9 +35,7 @@ describe("Slider", () => {
         error="Uh oh!"
       />
     );
-    expect(screen.getByRole("slider")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
-    );
+    expect(screen.getByRole("slider")).toHaveAccessibleErrorMessage("Uh oh!");
   });
 
   it("can display help", async () => {

--- a/src/components/Textarea/Textarea.test.tsx
+++ b/src/components/Textarea/Textarea.test.tsx
@@ -32,9 +32,7 @@ describe("Textarea ", () => {
 
   it("can display an error for a text input", async () => {
     render(<Textarea error="Uh oh!" />);
-    expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
-      "Error: Uh oh!"
-    );
+    expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage("Uh oh!");
   });
 
   it("can display help for a text input", async () => {


### PR DESCRIPTION
## Done

- Removed bold "Error:"/"Caution:"/"Success:" prefix in input field validation message.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to [Input](https://react-components-1063.demos.haus/?path=/docs/input--docs) page in storybook.
- Check examples for [Error](https://react-components-1063.demos.haus/?path=/story/input--error)/[Success](https://react-components-1063.demos.haus/?path=/story/input--success)/[Caution](https://react-components-1063.demos.haus/?path=/story/input--caution). There should be no bold prefix before the message itself.