### PR TITLE
fix(searchbox): handle Enter key in the input field to search + blur

### DIFF
--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { HTMLProps, useRef } from "react";
+import React, { HTMLProps, KeyboardEvent, useRef } from "react";
 
 import Icon from "../Icon";
 
@@ -33,7 +33,7 @@ export type Props = PropsWithSpread<
      */
     onChange?: (inputValue: string) => void;
     /**
-     * A function that is called when the user clicks the search icon
+     * A function that is called when the user clicks the search icon or presses enter
      */
     onSearch?: () => void;
     /**
@@ -91,6 +91,13 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
       onSearch && onSearch();
     };
 
+    const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && internalRef.current.checkValidity()) {
+        internalRef.current.blur();
+        triggerSearch();
+      }
+    };
+
     return (
       <div className={classNames("p-search-box", className)}>
         <label className="u-off-screen" htmlFor="search">
@@ -103,6 +110,7 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
           id="search"
           name="search"
           onChange={(evt) => onChange?.(evt.target.value)}
+          onKeyDown={onKeyDown}
           placeholder={placeholder}
           ref={(input) => {
             internalRef.current = input;


### PR DESCRIPTION
## Done

- Make `SearchBox` trigger search on Enter keydown, and blur the input field.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check `SearchBox` examples in [Storybook](https://react-components-1065.demos.haus/?path=/docs/searchbox--docs#default)
- Press "Enter" on the enabled examples and see that the input field blurs

### Percy steps

This should not produce visual changes in Percy.