### PR TITLE
fix(textarea): reset value to an empty string

### DIFF
--- a/src/components/Textarea/Textarea.test.tsx
+++ b/src/components/Textarea/Textarea.test.tsx
@@ -40,4 +40,15 @@ describe("Textarea ", () => {
     render(<Textarea help={help} />);
     expect(screen.getByRole("textbox")).toHaveAccessibleDescription(help);
   });
+
+  it("can change value to an empty string", () => {
+    let testValue = "test";
+    const { rerender } = render(<Textarea value={testValue} />);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveValue("test");
+
+    testValue = ""; // simulate an external change of the value
+    rerender(<Textarea value={testValue} />);
+    expect(textarea).toHaveValue("");
+  });
 });

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -159,7 +159,7 @@ const Textarea = ({
           style
         }
         {...props}
-        value={props.value || innerValue}
+        value={props.value ?? innerValue}
       />
     </Field>
   );


### PR DESCRIPTION
## Done

- Allow setting the value to an empty string. Otherwise, the previous value isn't updated.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

You should be able to replicate this in a simplified example such as the one in the issue (#1068).

### Percy steps

No visual change

## Fixes

Fixes: #1068