### PR TITLE
fix: tooltip should not reopen when target element is not hovered anymore

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -184,6 +184,7 @@ export const adjustForWindow = (
  * @param positionElementClassName An optional class to apply to the element that wraps the children.
  * @param tooltipClassName An optional class to apply to the tooltip message element.
  * @param zIndex The z-index value of the tooltip message element.
+ * @param delay Delay in ms after which Tooltip will appear (defaults to 350ms).
  */
 const Tooltip = ({
   autoAdjust = true,
@@ -305,9 +306,15 @@ const Tooltip = ({
   };
 
   const delayedOpenPortal: MouseEventHandler = useCallback(() => {
+    if (isOpen) {
+      return;
+    }
+    if (timer) {
+      clearTimeout(timer);
+    }
     const timeout = setTimeout(() => openPortal(), delay);
     setTimer(timeout);
-  }, [delay, openPortal]);
+  }, [delay, openPortal, timer, isOpen]);
 
   return (
     <>


### PR DESCRIPTION
## Done

- tooltip should not reopen when target element is not hovered anymore. Tooltip was running multiple timers in the background, that would reopen it after it was closed.



## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- hover a tooltip and quickly move the mouse over the target element. The tooltip should close and not reopen

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: #1073
