### PR TITLE
ci: Update Percy label workflow to make it work on forks

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,11 +1,13 @@
 name: PR Percy Review Label Required
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 jobs:
   label:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -5,9 +5,7 @@ on:
 jobs:
   label:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
+    permissions: write-all
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:


### PR DESCRIPTION
## Done

- Switch to `pull_request_target` to allow workflow to add commets on PRs from forks

## QA

needs to be merged to qa