### PR TITLE
docs: Add section to README to list related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ yarn link @canonical/react-components
 cd react-components
 yarn run unlink-packages
 ```
+
+## Related projects
+The following projects are related to, or build upon this library:
+- [Store components](https://github.com/canonical/store-components)

--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ yarn run unlink-packages
 ## Related projects
 The following projects are related to, or build upon this library:
 - [Store components](https://github.com/canonical/store-components)
+- [MAAS React components](https://github.com/canonical/maas-react-components)


### PR DESCRIPTION
## Done

Added a section to the README which lists projects related to or that build upon this library.

## QA
- Look at README
- Does it make sense?