### PR TITLE
fix: search and filter panel no longer opens when dismissing a filter

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -35,7 +35,7 @@ export type Props = PropsWithSpread<
     /**
      * Function for handling dismissing a chip.
      */
-    onDismiss?: () => void;
+    onDismiss?: (event: MouseEvent<HTMLButtonElement>) => void;
     /**
      * Whether the chip is selected.
      */

--- a/src/components/SearchAndFilter/SearchAndFilter.test.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 
 import SearchAndFilter from "./SearchAndFilter";
@@ -412,5 +412,41 @@ describe("Search and filter", () => {
       await userEvent.click(screen.getByRole("button", { name: "+1" }));
     });
     expect(onExpandChange).toHaveBeenCalled();
+  });
+
+  it("does not toggle the panel when a filter is dismissed", async () => {
+    const returnSearchData = jest.fn();
+    const onExpandChange = jest.fn();
+    const onPanelToggle = jest.fn();
+    render(
+      <SearchAndFilter
+        filterPanelData={sampleData}
+        returnSearchData={returnSearchData}
+        onExpandChange={onExpandChange}
+        onPanelToggle={onPanelToggle}
+        existingSearchData={[
+          { lead: "Cloud", value: "Google" },
+          { lead: "Region", value: "eu-west-1" },
+        ]}
+      />,
+    );
+
+    // onPanelToggle is called on initial render, so we need to clear the mock before asserting
+    onPanelToggle.mockClear();
+
+    // Dismiss the Cloud: Google filter chip
+    await waitFor(async () => {
+      const cloudChip: HTMLElement = screen
+        .getByText("CLOUD")
+        .closest(".p-chip");
+
+      const dismissButton = within(cloudChip).getByRole("button", {
+        name: "Dismiss",
+      });
+
+      await userEvent.click(dismissButton);
+    });
+
+    expect(onPanelToggle).not.toHaveBeenCalled();
   });
 });

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -264,7 +264,11 @@ const SearchAndFilter = ({
               lead={chip.lead}
               value={chip.value}
               key={`search-${chip.lead}+${chip.value}`}
-              onDismiss={() => removeFromSelected(chip)}
+              onDismiss={(event) => {
+                // Prevent filter chip dismissals from bubbling up and triggering the parent onClick handler
+                event.stopPropagation();
+                removeFromSelected(chip);
+              }}
               selected={true}
               quoteValue={chip.quoteValue}
             />


### PR DESCRIPTION
## Done

Fixes the search & filter component re-opening the filter panel when removing a filter. The component will now behave as it does in the [behaviour spec](https://discourse.ubuntu.com/t/behaviour-delete-a-filter-chip/21546)

### The problem
The search & filter component has an [on-click handler](https://github.com/canonical/react-components/blob/288b3856b3133e14b8ced3b5b830211403eb92bd/src/components/SearchAndFilter/SearchAndFilter.tsx#L239) that opens the filter panel. This is currently being triggered by any clicks within the search and filter element and its descendants. This means that when a user clicks a chip dismissal button, the event bubbles up to the search & filter component & shows the filter panel.

### Proposed solution
1. Added the dismissal event to the parameter list of the `Chip` component's `onDismiss` callback. 
2. Call `event.stopPropagation` in the `onDismiss` callback passed into the filter chips by the search & filter component

### Another possible solution
I initially tried another solution that removed the `onClick` handler from the search and filter component and moved it to the `onFocus` callback of the search input textbox. This also solves the issue, however it loses some functionality as clicking anywhere in the search and filter no longer opens the filter panel, and the only way to open the filter panel when it is overflowed is to click the CTA. So, I abandoned this approach for the approach in this PR.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

1. Open [Search & Filter component](https://react-components-1093.demos.haus/?path=/story/components-searchandfilter--with-existing-search-data)
2. Click the component to open the filter panel.
3. Add several filters.
4. Close the filter panel by clicking outside of the component.
5. Dismiss a filter by clicking its "x" button.
6. Observe that the filter has been removed and the filter panel is still closed.

### Percy steps

- No visual changes expected

## Fixes

Fixes: #621 
