### PR TITLE
feat(textarea component): Enable control+enter form submission from within a text area [WD-10959]

### DIFF
--- a/src/components/Textarea/Textarea.stories.mdx
+++ b/src/components/Textarea/Textarea.stories.mdx
@@ -61,6 +61,7 @@ The Textarea component defines a multi-line text input control.
       id: "textarea2",
       rows: "3",
       defaultValue: "Ubuntu",
+      onControlEnter: () => {alert("onControlEnter() successfully called.")}
     }}
   >
     {Template.bind({})}

--- a/src/components/Textarea/Textarea.test.tsx
+++ b/src/components/Textarea/Textarea.test.tsx
@@ -51,4 +51,40 @@ describe("Textarea ", () => {
     rerender(<Textarea value={testValue} />);
     expect(textarea).toHaveValue("");
   });
+
+  it("adds Ctrl + Enter keydown event listener on mount and removes on unmount", async () => {
+    const addEventListenerSpy = jest.spyOn(document, "addEventListener");
+    const removeEventListenerSpy = jest.spyOn(document, "removeEventListener");
+
+    const { unmount } = render(
+      <Textarea
+        onControlEnter={() => {
+          console.log("OnControlEnter was here.");
+        }}
+      />
+    );
+
+    // Capture the event handler
+    const [event, handler] = addEventListenerSpy.mock.calls[0];
+
+    // Assert that addEventListener was called with the correct event type and handler
+    expect(event).toBe("keydown");
+    expect(typeof handler).toBe("function");
+
+    const keyboardCombo = new KeyboardEvent("keydown", {
+      key: "Enter",
+      ctrlKey: true,
+    });
+    document.dispatchEvent(keyboardCombo);
+
+    // Unmount the component to trigger cleanup
+    unmount();
+
+    // Assert that removeEventListener was called with the same event type and handler
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("keydown", handler);
+
+    // Clean up: restore the original implementations
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
 });

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import React, {
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
@@ -69,6 +70,10 @@ export type Props = PropsWithSpread<
      * Optional class(es) to pass to the wrapping Field component
      */
     wrapperClassName?: string;
+    /**
+     * Function to occur on keyboard event, 'CTRL + Enter'
+     */
+    onControlEnter?: () => void;
   },
   TextareaHTMLAttributes<HTMLTextAreaElement>
 >;
@@ -83,6 +88,7 @@ const Textarea = ({
   label,
   labelClassName,
   onKeyUp,
+  onControlEnter,
   required,
   stacked,
   style,
@@ -98,6 +104,27 @@ const Textarea = ({
   const [innerValue, setInnervalue] = useState(props.defaultValue);
   const defaultTextAreaId = useId();
   const textAreaId = id || defaultTextAreaId;
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (
+        event.key === "Enter" &&
+        (event.ctrlKey || event.metaKey) &&
+        document.activeElement === textareaRef.current
+      ) {
+        onControlEnter();
+      }
+    },
+    [onControlEnter]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   useEffect(() => {
     if (takeFocus) {


### PR DESCRIPTION
…ithin a text area.

## Done

- Added functionality such that a function pass through by "onControlEnter" (for example a submission function) can be executed when CTRL+ENTER are clicked whilst within the textarea.
- Implemented a jest test to verify that the component "adds Ctrl + Enter keydown event listener on mount and removes on unmount".

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Navigate to the textarea component.
- Pres CTRL and Enter at the same time whilst within the component, and note an "alert" function occur.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: # .
