### PR TITLE
chore: Allow Contextual Menu Component to be positioned optimally [WD-10977]

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -2,7 +2,6 @@ import classNames from "classnames";
 import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { HTMLProps } from "react";
 import usePortal from "react-useportal";
-
 import { useListener, usePrevious } from "hooks";
 import Button from "../Button";
 import type { ButtonProps } from "../Button";

--- a/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
@@ -58,7 +58,7 @@ const getPositionStyle = (
   position: Position,
   verticalPosition: VerticalPosition,
   positionCoords: Props["positionCoords"],
-  constrainPanelWidth: Props["constrainPanelWidth"]
+  constrainPanelWidth: Props["constrainPanelWidth"],
 ): React.CSSProperties => {
   if (!positionCoords) {
     return null;
@@ -101,7 +101,7 @@ const getPositionStyle = (
  */
 export const adjustForWindow = (
   position: Position,
-  fitsWindow: WindowFitment
+  fitsWindow: WindowFitment,
 ): Position => {
   let newPosition: string = position;
   if (!fitsWindow.fromRight.fitsLeft && newPosition === "right") {
@@ -144,7 +144,7 @@ export const adjustForWindow = (
 const generateLink = <L,>(
   link: ButtonProps,
   key: React.Key,
-  handleClose: Props["handleClose"]
+  handleClose: Props["handleClose"],
 ) => {
   const { children, className, onClick, ...props } = link;
   return (
@@ -167,7 +167,7 @@ const generateLink = <L,>(
 };
 
 const getClosestScrollableParent = (
-  node: HTMLElement | null
+  node: HTMLElement | null,
 ): HTMLElement | null => {
   let currentNode = node;
   while (currentNode && currentNode !== document.body) {
@@ -201,7 +201,7 @@ const ContextualMenuDropdown = <L,>({
   contextualMenuClassName,
   ...props
 }: Props<L>): JSX.Element => {
-  const dropdown = useRef();
+  const dropdown = useRef<HTMLDivElement>(null);
   const [verticalPosition, setVerticalPosition] =
     useState<VerticalPosition>("bottom");
   const [positionStyle, setPositionStyle] = useState(
@@ -209,8 +209,8 @@ const ContextualMenuDropdown = <L,>({
       adjustedPosition,
       verticalPosition,
       positionCoords,
-      constrainPanelWidth
-    )
+      constrainPanelWidth,
+    ),
   );
   const [maxHeight, setMaxHeight] = useState<number>();
   // Update the styles to position the menu.
@@ -220,8 +220,8 @@ const ContextualMenuDropdown = <L,>({
         adjustedPosition,
         verticalPosition,
         positionCoords,
-        constrainPanelWidth
-      )
+        constrainPanelWidth,
+      ),
     );
   }, [adjustedPosition, positionCoords, verticalPosition, constrainPanelWidth]);
 
@@ -233,22 +233,37 @@ const ContextualMenuDropdown = <L,>({
     if (!scrollableParent) {
       return null;
     }
+
     const scrollableParentRect = scrollableParent.getBoundingClientRect();
-    const rect = positionNode.getBoundingClientRect();
+    const toggleRect = positionNode.getBoundingClientRect();
 
     // Calculate the rect in relation to the scrollableParent
-    const relativeRect = {
-      top: rect.top - scrollableParentRect.top,
-      bottom: rect.bottom - scrollableParentRect.top,
-      height: rect.height,
+    const relativeToScrollParentRect = {
+      top: toggleRect.top - scrollableParentRect.top,
+      bottom: toggleRect.bottom - scrollableParentRect.top,
     };
 
-    const spaceBelow = scrollableParentRect.height - relativeRect.bottom;
-    const spaceAbove = relativeRect.top;
-    const dropdownHeight = relativeRect.height;
+    // Calculate the rect in relation to the Window
+    const windowRect = {
+      top: window.scrollY,
+      bottom: window.scrollX,
+      height: window.innerHeight,
+    };
+
+    const scrollParentSpaceBelow =
+      scrollableParentRect.height - relativeToScrollParentRect.bottom;
+    const scrollParentSpaceAbove = relativeToScrollParentRect.top;
+
+    const dropdownHeight = dropdown.current.getBoundingClientRect().height ?? 0;
+
+    const windowSpaceBelow = windowRect.height - toggleRect.bottom;
 
     setVerticalPosition(
-      spaceBelow >= dropdownHeight || spaceBelow > spaceAbove ? "bottom" : "top"
+      (scrollParentSpaceBelow >= dropdownHeight &&
+        windowSpaceBelow >= dropdownHeight) ||
+        windowSpaceBelow > scrollParentSpaceAbove
+        ? "bottom"
+        : "top",
     );
   }, [positionNode]);
 
@@ -269,7 +284,7 @@ const ContextualMenuDropdown = <L,>({
       scrollOverflow,
       setAdjustedPosition,
       updateVerticalPosition,
-    ]
+    ],
   );
 
   // Handle adjusting the horizontal position and scrolling of the dropdown so that it remains on screen.
@@ -278,7 +293,7 @@ const ContextualMenuDropdown = <L,>({
     positionNode,
     onUpdateWindowFitment,
     0,
-    isOpen && (autoAdjust || scrollOverflow)
+    isOpen && (autoAdjust || scrollOverflow),
   );
 
   // Update the styles when the position changes.
@@ -320,7 +335,7 @@ const ContextualMenuDropdown = <L,>({
                 return (
                   <span className="p-contextual-menu__group" key={i}>
                     {item.map((link, j) =>
-                      generateLink<L>(link, j, handleClose)
+                      generateLink<L>(link, j, handleClose),
                     )}
                   </span>
                 );

--- a/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
+++ b/src/components/ContextualMenu/ContextualMenuDropdown/ContextualMenuDropdown.tsx
@@ -58,7 +58,7 @@ const getPositionStyle = (
   position: Position,
   verticalPosition: VerticalPosition,
   positionCoords: Props["positionCoords"],
-  constrainPanelWidth: Props["constrainPanelWidth"],
+  constrainPanelWidth: Props["constrainPanelWidth"]
 ): React.CSSProperties => {
   if (!positionCoords) {
     return null;
@@ -101,7 +101,7 @@ const getPositionStyle = (
  */
 export const adjustForWindow = (
   position: Position,
-  fitsWindow: WindowFitment,
+  fitsWindow: WindowFitment
 ): Position => {
   let newPosition: string = position;
   if (!fitsWindow.fromRight.fitsLeft && newPosition === "right") {
@@ -144,7 +144,7 @@ export const adjustForWindow = (
 const generateLink = <L,>(
   link: ButtonProps,
   key: React.Key,
-  handleClose: Props["handleClose"],
+  handleClose: Props["handleClose"]
 ) => {
   const { children, className, onClick, ...props } = link;
   return (
@@ -167,7 +167,7 @@ const generateLink = <L,>(
 };
 
 const getClosestScrollableParent = (
-  node: HTMLElement | null,
+  node: HTMLElement | null
 ): HTMLElement | null => {
   let currentNode = node;
   while (currentNode && currentNode !== document.body) {
@@ -209,8 +209,8 @@ const ContextualMenuDropdown = <L,>({
       adjustedPosition,
       verticalPosition,
       positionCoords,
-      constrainPanelWidth,
-    ),
+      constrainPanelWidth
+    )
   );
   const [maxHeight, setMaxHeight] = useState<number>();
   // Update the styles to position the menu.
@@ -220,8 +220,8 @@ const ContextualMenuDropdown = <L,>({
         adjustedPosition,
         verticalPosition,
         positionCoords,
-        constrainPanelWidth,
-      ),
+        constrainPanelWidth
+      )
     );
   }, [adjustedPosition, positionCoords, verticalPosition, constrainPanelWidth]);
 
@@ -243,27 +243,20 @@ const ContextualMenuDropdown = <L,>({
       bottom: toggleRect.bottom - scrollableParentRect.top,
     };
 
-    // Calculate the rect in relation to the Window
-    const windowRect = {
-      top: window.scrollY,
-      bottom: window.scrollX,
-      height: window.innerHeight,
-    };
-
     const scrollParentSpaceBelow =
       scrollableParentRect.height - relativeToScrollParentRect.bottom;
     const scrollParentSpaceAbove = relativeToScrollParentRect.top;
 
     const dropdownHeight = dropdown.current.getBoundingClientRect().height ?? 0;
 
-    const windowSpaceBelow = windowRect.height - toggleRect.bottom;
+    const windowSpaceBelow = window.innerHeight - toggleRect.bottom;
 
     setVerticalPosition(
       (scrollParentSpaceBelow >= dropdownHeight &&
         windowSpaceBelow >= dropdownHeight) ||
         windowSpaceBelow > scrollParentSpaceAbove
         ? "bottom"
-        : "top",
+        : "top"
     );
   }, [positionNode]);
 
@@ -284,7 +277,7 @@ const ContextualMenuDropdown = <L,>({
       scrollOverflow,
       setAdjustedPosition,
       updateVerticalPosition,
-    ],
+    ]
   );
 
   // Handle adjusting the horizontal position and scrolling of the dropdown so that it remains on screen.
@@ -293,7 +286,7 @@ const ContextualMenuDropdown = <L,>({
     positionNode,
     onUpdateWindowFitment,
     0,
-    isOpen && (autoAdjust || scrollOverflow),
+    isOpen && (autoAdjust || scrollOverflow)
   );
 
   // Update the styles when the position changes.
@@ -335,7 +328,7 @@ const ContextualMenuDropdown = <L,>({
                 return (
                   <span className="p-contextual-menu__group" key={i}>
                     {item.map((link, j) =>
-                      generateLink<L>(link, j, handleClose),
+                      generateLink<L>(link, j, handleClose)
                     )}
                   </span>
                 );


### PR DESCRIPTION
… vertically

## Done

- Added a scss file for Contextual Menu
- Implemented initial logic by @mas-who to vertically position the Menu optimally based on the viewport height.
- Then transferred this logic from AdjustVerticalHeight function in Contextual Menu, to updateVerticalPosition function in ContextualMenuDropdown.tsx such that the menu may be adjusted according to both the container height and the viewport height.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### Percy steps

N/A

## Fixes
- Contextual Menu dropdown now displays "upwards" if there is not enough space downwards.

![image](https://github.com/canonical/react-components/assets/58699506/2ab95787-38d3-46d3-9d82-e203f833fc85)
