### PR TITLE
ci(tics): Don't upload TICS report to artifacts

### DIFF
--- a/.github/workflows/tics-coverage.yml
+++ b/.github/workflows/tics-coverage.yml
@@ -35,10 +35,3 @@ jobs:
           . ./install_tics.sh
           TICSQServer -project react-components -tmpdir /tmp/tics -branchdir .
 
-      - name: Upload TICS report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: tics-report
-          path: /tmp/tics/ticstmpdir
-          retention-days: 7


### PR DESCRIPTION
## Done

For security reasons we are removing the step that uploads TICS report as action artifact.


