### PR TITLE
fix(app-layout): prevent display of empty app navigation panel

### DIFF
--- a/src/components/ApplicationLayout/ApplicationLayout.stories.tsx
+++ b/src/components/ApplicationLayout/ApplicationLayout.stories.tsx
@@ -59,8 +59,9 @@ export const Default: Story = {
         ]}
         aside={
           showAside ? (
-            <AppAside title="Aside panel" pinned={asidePinned}>
+            <AppAside pinned={asidePinned}>
               <Panel
+                title="Aside panel"
                 controls={
                   <>
                     <Button
@@ -266,6 +267,24 @@ export const Navigation: Story = {
         }
       >
         <Panel title="Application Layout">
+          <Row>
+            <Col size={12}>Content</Col>
+          </Row>
+        </Panel>
+      </ApplicationLayout>
+    );
+  },
+};
+
+/**
+ * App navigation can also be completely opted out of, for some
+ * particular scenarios (e.g. login page, error pages).
+ */
+export const NoNavigation: Story = {
+  render: () => {
+    return (
+      <ApplicationLayout>
+        <Panel title="Application Layout with no navigation">
           <Row>
             <Col size={12}>Content</Col>
           </Row>

--- a/src/components/ApplicationLayout/ApplicationLayout.test.tsx
+++ b/src/components/ApplicationLayout/ApplicationLayout.test.tsx
@@ -111,3 +111,8 @@ it("collapses the menu using external state", async () => {
   await userEvent.click(screen.getByRole("button", { name: "Menu" }));
   expect(onCollapseMenu).toHaveBeenCalledWith(false);
 });
+
+it("can opt out of app navigation", async () => {
+  render(<ApplicationLayout />);
+  expect(document.querySelector(".l-navigation")).toBeNull();
+});

--- a/src/components/ApplicationLayout/ApplicationLayout.tsx
+++ b/src/components/ApplicationLayout/ApplicationLayout.tsx
@@ -44,7 +44,7 @@ export type BaseProps<
     /**
      * The logo to appear in the navigation panels.
      */
-    logo: NonNullable<PanelProps<PL>["logo"]>;
+    logo?: PanelProps<PL>["logo"];
     /**
      * The component to use to render links inside the navigation e.g. when
      * using react-router you'd pass `Link` to this prop.
@@ -96,10 +96,10 @@ export type Props<
 > = BaseProps<NI, PL> &
   ExclusiveProps<
     {
-      navItems: NonNullable<SideNavigationProps<NI>["items"]>;
+      navItems?: SideNavigationProps<NI>["items"];
     },
     {
-      sideNavigation: ReactNode;
+      sideNavigation?: ReactNode;
     }
   >;
 
@@ -145,81 +145,86 @@ const ApplicationLayout = <
 
   return (
     <Application {...props}>
-      <AppNavigationBar className={navigationBarClassName}>
-        <Panel<PL>
-          dark={dark}
-          logo={logo}
-          toggle={{
-            label: "Menu",
-            onClick: () => setMenuCollapsed(!menuIsCollapsed),
-          }}
-        />
-      </AppNavigationBar>
-      <AppNavigation
-        className={navigationClassName}
-        collapsed={menuIsCollapsed}
-        pinned={menuIsPinned}
-      >
-        <Panel<PL>
-          dark={dark}
-          controls={
-            <>
-              <Button
-                hasIcon
-                appearance="base"
-                className={classNames("u-no-margin u-hide--medium", {
-                  "is-dark": dark,
-                })}
-                onClick={(evt) => {
-                  setMenuCollapsed(true);
-                  // The menu stays open while its content has focus, so the
-                  // close button must blur to actually close the menu.
-                  evt.currentTarget.blur();
-                }}
-              >
-                <Icon name="close" className={classNames({ "is-light": dark })}>
-                  Close menu
-                </Icon>
-              </Button>
-              <Button
-                hasIcon
-                appearance="base"
-                className={classNames("u-no-margin u-hide--small", {
-                  "is-dark": dark,
-                })}
-                onClick={() => {
-                  setMenuPinned(!menuIsPinned);
-                }}
-              >
-                <Icon
-                  name={menuIsPinned ? "close" : "pin"}
-                  className={classNames({ "is-light": dark })}
-                >
-                  {menuIsPinned ? "Unpin menu" : "Pin menu"}
-                </Icon>
-              </Button>
-            </>
-          }
-          controlsClassName="u-hide--large"
-          stickyHeader
-          logo={logo}
-        >
-          {navItems ? (
-            <SideNavigation<NI>
+      {(navItems || sideNavigation) && (
+        <>
+          <AppNavigationBar className={navigationBarClassName}>
+            <Panel<PL>
               dark={dark}
-              items={navItems}
-              linkComponent={navLinkComponent}
+              logo={logo}
+              toggle={{
+                label: "Menu",
+                onClick: () => setMenuCollapsed(!menuIsCollapsed),
+              }}
             />
-          ) : (
-            sideNavigation
-          )}
-        </Panel>
-      </AppNavigation>
+          </AppNavigationBar>
+          <AppNavigation
+            className={navigationClassName}
+            collapsed={menuIsCollapsed}
+            pinned={menuIsPinned}
+          >
+            <Panel<PL>
+              dark={dark}
+              controls={
+                <>
+                  <Button
+                    hasIcon
+                    appearance="base"
+                    className={classNames("u-no-margin u-hide--medium", {
+                      "is-dark": dark,
+                    })}
+                    onClick={(evt) => {
+                      setMenuCollapsed(true);
+                      // The menu stays open while its content has focus, so the
+                      // close button must blur to actually close the menu.
+                      evt.currentTarget.blur();
+                    }}
+                  >
+                    <Icon
+                      name="close"
+                      className={classNames({ "is-light": dark })}
+                    >
+                      Close menu
+                    </Icon>
+                  </Button>
+                  <Button
+                    hasIcon
+                    appearance="base"
+                    className={classNames("u-no-margin u-hide--small", {
+                      "is-dark": dark,
+                    })}
+                    onClick={() => {
+                      setMenuPinned(!menuIsPinned);
+                    }}
+                  >
+                    <Icon
+                      name={menuIsPinned ? "close" : "pin"}
+                      className={classNames({ "is-light": dark })}
+                    >
+                      {menuIsPinned ? "Unpin menu" : "Pin menu"}
+                    </Icon>
+                  </Button>
+                </>
+              }
+              controlsClassName="u-hide--large"
+              stickyHeader
+              logo={logo}
+            >
+              {navItems ? (
+                <SideNavigation<NI>
+                  dark={dark}
+                  items={navItems}
+                  linkComponent={navLinkComponent}
+                />
+              ) : (
+                sideNavigation
+              )}
+            </Panel>
+          </AppNavigation>
+        </>
+      )}
       <AppMain className={mainClassName}>{children}</AppMain>
       {aside}
-      {status ? (
-        <AppStatus className={statusClassName}>{status}</AppStatus>
-      ) : null}
+      {status && <AppStatus className={statusClassName}>{status}</AppStatus>}
     </Application>
   );
 };


### PR DESCRIPTION
## Done

- Prevented display of an empty app navigation panel when passing no `navItems` and `undefined` as `sideNavigation` props.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check the new "No Navigation" story for ApplicationLayout in Storybook: it displays no app navigation at all.

### Percy steps

- There should be a new story in Storybook for ApplicationLayout, called "No Navigation". This should be the only visual difference.