### PR TITLE
fix(Select): Add support for required attribute

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -49,6 +49,12 @@ const meta: Meta<typeof Select> = {
         disable: true,
       },
     },
+
+    required: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
 };
 
@@ -118,4 +124,44 @@ export const SelectMultiple: Story = {
   ),
 
   name: "Select multiple",
+};
+
+export const RequiredSelect: Story = {
+  args: {
+    required: true,
+  },
+
+  render: (args) => (
+    <form>
+      <Select
+        name="exampleSelectRequired"
+        id="exampleSelectRequired"
+        options={[
+          {
+            value: "",
+            disabled: true,
+            label: "Select an option",
+          },
+          {
+            value: "1",
+            label: "Cosmic Cuttlefish",
+          },
+          {
+            value: "2",
+            label: "Bionic Beaver",
+          },
+          {
+            value: "3",
+            label: "Xenial Xerus",
+          },
+        ]}
+        label="Ubuntu releases (required)"
+        required={args.required}
+        defaultValue=""
+      />
+      <button type="submit">Submit</button>
+    </form>
+  ),
+
+  name: "Select with required",
 };

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -15,7 +15,7 @@ describe("Select", () => {
           { value: "3", label: "Xenial Xerus" },
         ]}
         wrapperClassName="select"
-      />
+      />,
     );
     expect(screen.getByRole("combobox")).toMatchSnapshot();
   });
@@ -30,7 +30,7 @@ describe("Select", () => {
     render(<Select options={[]} onChange={onChangeMock} />);
     fireEvent.change(screen.getByRole("combobox"), event);
     expect(onChangeMock.mock.calls[0][0].target).toBe(
-      screen.getByRole("combobox")
+      screen.getByRole("combobox"),
     );
   });
 
@@ -62,5 +62,38 @@ describe("Select", () => {
     const help = "Save me!";
     render(<Select help={help} />);
     expect(screen.getByRole("combobox")).toHaveAccessibleDescription(help);
+  });
+
+  it("renders with required attribute", () => {
+    render(
+      <Select
+        id="test-required"
+        options={[
+          { value: "", disabled: true, label: "Select an option" },
+          { value: "1", label: "Cosmic Cuttlefish" },
+          { value: "2", label: "Bionic Beaver" },
+          { value: "3", label: "Xenial Xerus" },
+        ]}
+        required
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    expect(select).toBeRequired();
+  });
+
+  it("renders without required attribute when not set", () => {
+    render(
+      <Select
+        id="test-not-required"
+        options={[
+          { value: "", disabled: true, label: "Select an option" },
+          { value: "1", label: "Cosmic Cuttlefish" },
+          { value: "2", label: "Bionic Beaver" },
+          { value: "3", label: "Xenial Xerus" },
+        ]}
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    expect(select).not.toBeRequired();
   });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -146,6 +146,7 @@ const Select = ({
         id={selectId}
         onChange={(evt) => onChange && onChange(evt)}
         ref={selectRef}
+        required={required}
         {...selectProps}
       >
         {generateOptions(options)}


### PR DESCRIPTION
## Done

- Implemented the `required` attribute in the `Select` component, ensuring it is correctly passed down to the `<select>` element.
- Updated the Storybook documentation to include examples demonstrating the use of the required attribute.
- Added tests to confirm that the `required` attribute behaves as expected, both when set and not set.


## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

1. Render the `Select` component with the `required` attribute.
2. Attempt to submit a form without selecting an option, ensuring the form validation prevents submission.
3. Verify that removing the `required` attribute allows the form to be submitted without selecting an option.

### Percy steps

- No visual changes expected

## Fixes

Fixes: #1045
