### PR TITLE
feat: non-string button labels

### DIFF
--- a/src/components/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.tsx
@@ -1,10 +1,20 @@
-import React, { MouseEvent, ReactElement } from "react";
+import React, { MouseEvent, ReactElement, ReactNode } from "react";
 import { PropsWithSpread, SubComponentProps } from "types";
 import ActionButton, { ActionButtonProps } from "../ActionButton";
 import ConfirmationModal, {
   ConfirmationModalProps,
 } from "../ConfirmationModal";
 import usePortal from "react-useportal";
+
+const generateTitle = (title: ReactNode) => {
+  if (typeof title === "string") {
+    return title;
+  }
+  if (typeof title === "number") {
+    return title.toString();
+  }
+  return null;
+};
 
 export type Props = PropsWithSpread<
   {
@@ -84,7 +94,9 @@ export const ConfirmationButton = ({
       <ActionButton
         {...actionButtonProps}
         onClick={shiftClickEnabled ? handleShiftClick : openPortal}
-        title={onHoverText ?? confirmationModalProps.confirmButtonLabel}
+        title={generateTitle(
+          onHoverText ?? confirmationModalProps.confirmButtonLabel
+        )}
       >
         {actionButtonProps.children}
       </ActionButton>

--- a/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -124,4 +124,30 @@ describe("ConfirmationModal ", () => {
     await userEvent.click(screen.getByText("Proceed"));
     expect(handleExternalClick).toHaveBeenCalledTimes(1);
   });
+
+  it("passes additional props to the buttons", () => {
+    render(
+      <ConfirmationModal
+        cancelButtonLabel="cancel"
+        confirmButtonLabel="submit"
+        cancelButtonProps={{
+          type: "button",
+        }}
+        confirmButtonProps={{
+          type: "submit",
+        }}
+        onConfirm={jest.fn()}
+      >
+        Test
+      </ConfirmationModal>
+    );
+    expect(screen.getByRole("button", { name: "cancel" })).toHaveAttribute(
+      "type",
+      "button"
+    );
+    expect(screen.getByRole("button", { name: "submit" })).toHaveAttribute(
+      "type",
+      "submit"
+    );
+  });
 });

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -10,7 +10,7 @@ export type Props = PropsWithSpread<
     /**
      * Label for the cancel button.
      */
-    cancelButtonLabel?: string;
+    cancelButtonLabel?: ReactNode;
     /**
      * The content of the modal.
      */
@@ -22,7 +22,7 @@ export type Props = PropsWithSpread<
     /**
      * Label for the confirm button.
      */
-    confirmButtonLabel: string;
+    confirmButtonLabel: ReactNode;
     /**
      * Extra elements to be placed in the button row of the modal.
      */

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,9 +1,9 @@
 import React, { MouseEvent, ReactElement } from "react";
 import type { ReactNode } from "react";
 import { PropsWithSpread, ValueOf } from "types";
-import Button, { ButtonAppearance } from "components/Button";
+import Button, { ButtonAppearance, ButtonProps } from "components/Button";
 import Modal, { ModalProps } from "components/Modal";
-import ActionButton from "components/ActionButton";
+import ActionButton, { ActionButtonProps } from "components/ActionButton";
 
 export type Props = PropsWithSpread<
   {
@@ -11,6 +11,10 @@ export type Props = PropsWithSpread<
      * Label for the cancel button.
      */
     cancelButtonLabel?: ReactNode;
+    /**
+     * Additional props to be spread on the cancel button.
+     */
+    cancelButtonProps?: Partial<ButtonProps>;
     /**
      * The content of the modal.
      */
@@ -23,6 +27,10 @@ export type Props = PropsWithSpread<
      * Label for the confirm button.
      */
     confirmButtonLabel: ReactNode;
+    /**
+     * Additional props to be spread on the confirm button.
+     */
+    confirmButtonProps?: Partial<ActionButtonProps>;
     /**
      * Extra elements to be placed in the button row of the modal.
      */
@@ -48,6 +56,7 @@ export type Props = PropsWithSpread<
  */
 export const ConfirmationModal = ({
   cancelButtonLabel = "Cancel",
+  cancelButtonProps,
   children,
   confirmButtonAppearance = "negative",
   confirmButtonLabel,
@@ -55,6 +64,7 @@ export const ConfirmationModal = ({
   onConfirm,
   confirmButtonLoading,
   confirmButtonDisabled,
+  confirmButtonProps,
   ...props
 }: Props): ReactElement => {
   const handleClick =
@@ -74,12 +84,14 @@ export const ConfirmationModal = ({
         <>
           {confirmExtra}
           <Button
+            {...cancelButtonProps}
             className="u-no-margin--bottom"
             onClick={handleClick(props.close)}
           >
             {cancelButtonLabel}
           </Button>
           <ActionButton
+            {...confirmButtonProps}
             appearance={confirmButtonAppearance}
             className="u-no-margin--bottom"
             onClick={handleClick(onConfirm)}


### PR DESCRIPTION
## Done

- Support non-string button labels in the confirmation modal.
