### PR TITLE
refactor: replace internals of MultiSelect with ContextualMenu

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -105,6 +105,12 @@ describe("ContextualMenu ", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("can have a custom toggle button", () => {
+    const label = "Custom toggle";
+    render(<ContextualMenu links={[]} toggle={<button>{label}</button>} />);
+    expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+  });
+
   it("can not have a toggle button", () => {
     render(<ContextualMenu links={[]} />);
     expect(

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -10,7 +10,9 @@ $dropdown-max-height: 20rem;
   // XXX: This is a workaround for https://github.com/canonical/vanilla-framework/issues/5030
   @include vf-b-forms;
 
+  margin-bottom: $input-margin-bottom;
   position: relative;
+  width: 100%;
 }
 
 .multi-select .p-form-validation__message {
@@ -26,6 +28,7 @@ $dropdown-max-height: 20rem;
 
 .multi-select__input {
   cursor: pointer;
+  margin-bottom: 0;
   position: relative;
 
   &.items-selected {
@@ -38,19 +41,6 @@ $dropdown-max-height: 20rem;
   &[disabled="disabled"] {
     opacity: 1;
   }
-}
-
-.multi-select__dropdown {
-  background-color: $colors--theme--background-default;
-  box-shadow: $box-shadow;
-  color: $colors--theme--text-default;
-  left: 0;
-  max-height: $dropdown-max-height;
-  overflow: auto;
-  padding-top: $spv--small;
-  position: absolute;
-  right: 0;
-  top: calc(100% - #{$input-margin-bottom});
 }
 
 .multi-select__dropdown--side-by-side {
@@ -131,6 +121,10 @@ $dropdown-max-height: 20rem;
 
   position: relative;
   z-index: 0;
+
+  .multi-select & {
+    margin-bottom: 0;
+  }
 
   &::after {
     content: "";

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -145,6 +145,14 @@ it("closes the dropdown when clicking outside of the dropdown", async () => {
   expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
 });
 
+it("closes the dropdown when clicking on the button", async () => {
+  render(<MultiSelect items={items} />);
+  await userEvent.click(screen.getByRole("combobox"));
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("combobox"));
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+});
+
 it("updates text in the input field if something is selected", async () => {
   render(
     <MultiSelect items={items} selectedItems={[items[0]]} variant="condensed" />


### PR DESCRIPTION
## Done

- Replace internals of MultiSelect with ContextualMenu so it uses a portal to fix overflow: hidden issues.

## QA

- Go to the [MultiSelect demo](https://react-components-1117.demos.haus/?path=/docs/components-multiselect--docs).
- Open the dropdown and it shouldn't get cut off by the frame around the example.


## Fixes

Fixes: #1116.
