### PR TITLE
fix(side nav): Pass ref to SideNavBase and write a test

### DIFF
--- a/src/components/SideNavigation/SideNavigationBase/SideNavigationBase.tsx
+++ b/src/components/SideNavigation/SideNavigationBase/SideNavigationBase.tsx
@@ -25,6 +25,10 @@ export type Props<C> = PropsWithSpread<
      * The navigation item's status.
      */
     status?: ReactNode;
+    /**
+     * A ref to pass to the element.
+     */
+    forwardRef?: React.Ref<C> | null;
   },
   C
 >;
@@ -35,10 +39,11 @@ const SideNavigationBase = <C,>({
   icon,
   label,
   status,
+  forwardRef,
   ...props
 }: Props<C>) => {
   return (
-    <Component {...props}>
+    <Component ref={forwardRef} {...props}>
       {icon ? (
         <Icon name={icon} light={dark} className="p-side-navigation__icon" />
       ) : null}

--- a/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.test.tsx
+++ b/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.test.tsx
@@ -42,3 +42,9 @@ it("can use a custom link component", () => {
     "p-side-navigation__link",
   );
 });
+
+it("gets the ref and checks if it can be used to get the element's position", () => {
+  const ref = React.createRef<HTMLAnchorElement>();
+  render(<SideNavigationLink label="Test content" forwardRef={ref} />);
+  expect(ref.current?.getBoundingClientRect()).toBeDefined();
+});

--- a/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.tsx
+++ b/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.tsx
@@ -1,16 +1,19 @@
 import React from "react";
 import classNames from "classnames";
-import type { HTMLProps } from "react";
+import type { HTMLProps, ReactNode } from "react";
 
 import type { SideNavigationBaseProps } from "../SideNavigationBase";
 import SideNavigationBase from "../SideNavigationBase";
 
 export type LinkDefaultElement = HTMLProps<HTMLAnchorElement>;
 
-export type Props<L = LinkDefaultElement, E = HTMLAnchorElement> = Omit<
-  SideNavigationBaseProps<L>,
-  "component"
+export type Props<L = LinkDefaultElement, E = HTMLAnchorElement> = Partial<
+  Omit<SideNavigationBaseProps<L>, "component">
 > & {
+  /**
+   * The navigation item's label.
+   */
+  label: ReactNode;
   /**
    * The component or element to use for the link element e.g. `a` or `NavLink`.
    * @default a
@@ -36,8 +39,8 @@ const SideNavigationLink = <L = LinkDefaultElement, E = HTMLAnchorElement>({
     <SideNavigationBase
       className={classNames("p-side-navigation__link", className)}
       component={component ?? "a"}
+      forwardRef={forwardRef}
       {...props}
-      ref={forwardRef}
     />
   );
 };


### PR DESCRIPTION
## Done

- [x] Passed the ref to `SideNavigationBase` component. This fixes the "Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?" error while trying to access ref from `SideNavigationLink` component."
- [x] Added a test to check if we're able to properly get value from ref.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: [WD-14589](https://warthogs.atlassian.net/browse/WD-14589)


[WD-14589]: https://warthogs.atlassian.net/browse/WD-14589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ