### PR TITLE
fix: fix highlightSubstring not being able to handle special characters for regex

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -21,4 +21,11 @@ describe("highlightSubString function ", () => {
       match: false,
     });
   });
+
+  it("handles special substrings for regex matching", () => {
+    expect(highlightSubString("somestring\\", "\\")).toEqual({
+      text: "somestring<strong>\\</strong>",
+      match: true,
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,9 @@ export const highlightSubString = (
       match: false,
     };
   }
-  const caseInsensitiveRegex = new RegExp(subString, "gi");
+
+  const escapedSubstring = subString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const caseInsensitiveRegex = new RegExp(escapedSubstring, "gi");
   const newStr = str.replace(
     caseInsensitiveRegex,
     (match) => `<strong>${match}</strong>`,


### PR DESCRIPTION
## Done

- Fixed issue with `highlightSubstring` breaking related UI components for special character inputs such as `\`

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Navigate to the `SearchAndFilter` component in storybook and type `\`. It should no longer break the UI.
