### PR TITLE
fix: Update SideNavigationLink component's prop type

### DIFF
--- a/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.test.tsx
+++ b/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.test.tsx
@@ -45,6 +45,12 @@ it("can use a custom link component", () => {
 
 it("gets the ref and checks if it can be used to get the element's position", () => {
   const ref = React.createRef<HTMLAnchorElement>();
-  render(<SideNavigationLink label="Test content" forwardRef={ref} />);
+  render(
+    <SideNavigationLink
+      label="Test content"
+      onClick={jest.fn()}
+      forwardRef={ref}
+    />,
+  );
   expect(ref.current?.getBoundingClientRect()).toBeDefined();
 });

--- a/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.tsx
+++ b/src/components/SideNavigation/SideNavigationLink/SideNavigationLink.tsx
@@ -1,29 +1,30 @@
 import React from "react";
 import classNames from "classnames";
-import type { HTMLProps, ReactNode } from "react";
+import type { HTMLProps } from "react";
 
 import type { SideNavigationBaseProps } from "../SideNavigationBase";
 import SideNavigationBase from "../SideNavigationBase";
+import { PropsWithSpread } from "types";
 
 export type LinkDefaultElement = HTMLProps<HTMLAnchorElement>;
 
-export type Props<L = LinkDefaultElement, E = HTMLAnchorElement> = Partial<
+export type Props<
+  L = LinkDefaultElement,
+  E = HTMLAnchorElement,
+> = PropsWithSpread<
+  {
+    /**
+     * The component or element to use for the link element e.g. `a` or `NavLink`.
+     * @default a
+     */
+    component?: SideNavigationBaseProps<L>["component"];
+    /**
+     * A ref to pass to the link element.
+     */
+    forwardRef?: React.Ref<E> | null;
+  },
   Omit<SideNavigationBaseProps<L>, "component">
-> & {
-  /**
-   * The navigation item's label.
-   */
-  label: ReactNode;
-  /**
-   * The component or element to use for the link element e.g. `a` or `NavLink`.
-   * @default a
-   */
-  component?: SideNavigationBaseProps<L>["component"];
-  /**
-   * A ref to pass to the link element.
-   */
-  forwardRef?: React.Ref<E> | null;
-};
+>;
 
 const SideNavigationLink = <L = LinkDefaultElement, E = HTMLAnchorElement>({
   component,


### PR DESCRIPTION
## Done

- [x] Update SideNavigationLink component's prop type to handle props properly.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: # .
