### PR TITLE
fix(CodeSnippet): Remove iframe from CodeSnippet example

### DIFF
--- a/src/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/src/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -4,6 +4,7 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import CodeSnippet from "./CodeSnippet";
 import { CodeSnippetBlockAppearance } from "./CodeSnippetBlock";
+import Button from "components/Button";
 
 const meta: Meta<typeof CodeSnippet> = {
   component: CodeSnippet,
@@ -351,13 +352,12 @@ export const Content: Story = {
     <CodeSnippet
       blocks={[
         {
-          title: "With embedded iframe",
-          code: "<iframe src='./iframe.html?viewMode=story&id=components-button--default&args='></iframe>",
+          title: "A button example",
+          code: "<Button>Button</Button>",
           content: (
-            <iframe
-              title="iframe"
-              src="./iframe.html?viewMode=story&id=components-button--default&args="
-            ></iframe>
+            <div style={{ margin: "0.5rem" }}>
+              <Button>Button</Button>
+            </div>
           ),
         },
       ]}
@@ -377,9 +377,9 @@ export const JsxCodeElements: Story = {
         {
           code: (
             <>
-              <strong>snap</strong>install<a href="#test">toto</a>
+              <strong>snap</strong> install <a href="#test">toto</a>
               <br />
-              <strong>apt</strong>install<a href="#test">toto</a>
+              <strong>apt</strong> install <a href="#test">toto</a>
             </>
           ),
         },


### PR DESCRIPTION
Removes iframe from CodeSnippet example to fix unstable Percy tests.

Drive-by: fix spacing in the JSX code elements example

Fixes #1144 

## QA

- Check demo: https://react-components-1145.demos.haus/?path=/docs/components-codesnippet--docs#content
- Make sure example is not using iframe
- Check following example, make sure there are spaces in `snap install toto`

<img width="1064" alt="image" src="https://github.com/user-attachments/assets/93981567-aeae-4feb-91e9-130036ee97dc">
