### PR TITLE
docs(storybook): Theming support for stories

### DIFF
--- a/.storybook/addons/withTheme.css
+++ b/.storybook/addons/withTheme.css
@@ -1,0 +1,3 @@
+.docs-story {
+    background: var(--vf-color-background-default);
+}

--- a/.storybook/addons/withTheme.jsx
+++ b/.storybook/addons/withTheme.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef } from "react";
+
+import "./withTheme.css";
+
+const THEMES = [
+  {
+    value: "is-light",
+    title: "Theme: Light",
+  },
+  {
+    value: "is-dark",
+    title: "Theme: Dark",
+  },
+  {
+    value: "is-paper",
+    title: "Theme: Paper",
+  },
+];
+
+export const themeType = {
+  theme: {
+    name: "Theme",
+    description: "Global theme for components",
+    defaultValue: THEMES[0].value,
+    toolbar: {
+      items: THEMES,
+      showName: true,
+      dynamicTitle: true,
+    },
+  },
+};
+
+export const WithThemeProvider = (Story, context) => {
+  const theme = context.globals.theme;
+  const themeRef = useRef(null);
+
+  useEffect(() => {
+    if (themeRef.current !== theme) {
+      if (themeRef.current) {
+        document.body.classList.remove(themeRef.current);
+      }
+
+      document.body.classList.add(theme);
+      themeRef.current = theme;
+    }
+  }, [theme]);
+
+  return <Story {...context} />;
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,8 +1,16 @@
 import { themes } from "@storybook/theming";
 import "vanilla-framework/scss/build.scss";
+import { themeType, WithThemeProvider } from "./addons/withTheme";
 
 export const parameters = {
   docs: {
     theme: themes.vanillaish,
   },
+  backgrounds: {
+    disable: true,
+  },
 };
+
+export const decorators = [WithThemeProvider];
+
+export const globalTypes = themeType;


### PR DESCRIPTION
## Done

- Hide default background select
- Add global theme select Light/Dark/Paper for strorybook
- Add HOC decorator for all stories
- Add special hack for docs background


## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: # .
