### PR TITLE
fix(TablePaginationControls): Hide total pages text when page input is hidden

### DIFF
--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.test.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.test.tsx
@@ -112,6 +112,7 @@ describe("<TablePaginationControls />", () => {
     expect(
       screen.queryByRole("spinbutton", { name: Label.PAGE_NUMBER }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText("of 5")).not.toBeInTheDocument();
   });
 
   it("can display the description", async () => {

--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
@@ -138,9 +138,9 @@ const TablePaginationControls = ({
             value={currentPage}
             type="number"
           />{" "}
+          {typeof totalPages === "number" ? `of ${totalPages}` : null}
         </>
       ) : null}
-      {typeof totalPages === "number" ? `of ${totalPages}` : null}
       <Button
         aria-label={Label.NEXT_PAGE}
         className="next"


### PR DESCRIPTION
## Done

- Hide the total pages text when **showPageInput** is set to `false`

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Set `showPageInput` to `false` in the **ControlsOnly** example of `TablePagination.stories.tsx`.
- You should not see any text between the buttons in the **Controls Only** example of `TablePagination`.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: https://chat.canonical.com/canonical/pl/6paertj3fpd3jkutj7j69715jw