### PR TITLE
fix: avoid trapping tab key presses when the search and filter is closed

### DIFF
--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -343,6 +343,7 @@ const SearchAndFilter = ({
                   toggleSelected={toggleSelected}
                   searchData={searchData}
                   searchTerm={searchTerm}
+                  sectionHidden={filterPanelHidden}
                 />
               );
             })}


### PR DESCRIPTION
## Done

- avoid trapping tab key presses when the search and filter is closed

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```
### QA steps

- open the search and filter in storybook
- press tab and ensure you can tab over the closed search and filter with few tab key presses
- previously, all the hidden chips in the hidden search and filter panel would trap the tab key.
