### PR TITLE
feat(MultiSelect): add scrollOverflow prop

### DIFF
--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -31,6 +31,7 @@ export type MultiSelectProps = {
   dropdownFooter?: ReactNode;
   showDropdownFooter?: boolean;
   variant?: "condensed" | "search";
+  scrollOverflow?: boolean;
 };
 
 type ValueSet = Set<MultiSelectItem["value"]>;
@@ -191,6 +192,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   dropdownFooter,
   showDropdownFooter = true,
   variant = "search",
+  scrollOverflow = false,
 }: MultiSelectProps) => {
   const buttonRef = useRef();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -326,6 +328,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         )
       }
       visible={isDropdownOpen}
+      scrollOverflow={scrollOverflow}
     >
       <MultiSelectDropdown
         id={dropdownId}


### PR DESCRIPTION
## Done

When used in certain cases with long lists, it would be useful to set the `scrollOverflow`.
I'd think we need this prop to be `true` all the time, but for the sake of compatibility with other projects, let's keep it false by default as it is right now.

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: # .
