### PR TITLE
fix: reduce percy snapshot concurrency to resolve random test failures

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -3,6 +3,7 @@ snapshot:
   widths: [1280]
   enable-javascript: true
 discovery:
+  concurrency: 2
   network-idle-timeout: 700
   retry: true
   launch-options:


### PR DESCRIPTION
## Done

- reduced percy snapshot concurrency, this should fix random test failures in percy
- based on discussion from this [issue](https://github.com/percy/percy-storybook/issues/1008)

## QA

- Ensure CI passes

## Fixes

Fixes: #1170 
