### PR TITLE
fix(button): link button example in storybook was using base appearance

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from "react";
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import Tooltip from "components/Tooltip";
@@ -75,20 +75,16 @@ export const Link = {
 
   args: {
     children: "Link button",
-    appearance: "base",
-    element: "a",
-    href: "#test",
+    appearance: "link",
   },
 };
 
-export const LinkDisabled: Story<HTMLProps<HTMLAnchorElement>> = {
+export const LinkDisabled = {
   name: "Link disabled",
 
   args: {
     children: "Link button disabled",
-    appearance: "base",
-    element: "a",
-    href: "#test",
+    appearance: "link",
     disabled: true,
   },
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { HTMLProps } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import Tooltip from "components/Tooltip";
@@ -40,6 +40,13 @@ export const Default: Story = {
   args: {
     children: "Button",
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with default appearance",
+      },
+    },
+  },
 };
 
 export const DefaultDisabled: Story = {
@@ -49,6 +56,13 @@ export const DefaultDisabled: Story = {
     children: "Button",
     disabled: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button with default appearance",
+      },
+    },
+  },
 };
 
 export const Base: Story = {
@@ -57,6 +71,13 @@ export const Base: Story = {
   args: {
     children: "Base button",
     appearance: "base",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with base appearance",
+      },
+    },
   },
 };
 
@@ -68,6 +89,13 @@ export const BaseDisabled: Story = {
     appearance: "base",
     disabled: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button with base appearance",
+      },
+    },
+  },
 };
 
 export const Link = {
@@ -76,6 +104,13 @@ export const Link = {
   args: {
     children: "Link button",
     appearance: "link",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with link appearance",
+      },
+    },
   },
 };
 
@@ -87,6 +122,13 @@ export const LinkDisabled = {
     appearance: "link",
     disabled: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button with link appearance",
+      },
+    },
+  },
 };
 
 export const Positive: Story = {
@@ -95,6 +137,13 @@ export const Positive: Story = {
   args: {
     children: "Positive button",
     appearance: "positive",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with positive appearance",
+      },
+    },
   },
 };
 
@@ -106,6 +155,13 @@ export const PositiveDisabled: Story = {
     appearance: "positive",
     disabled: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button with positive appearance",
+      },
+    },
+  },
 };
 
 export const Negative: Story = {
@@ -114,6 +170,13 @@ export const Negative: Story = {
   args: {
     children: "Negative button",
     appearance: "negative",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with negative appearance",
+      },
+    },
   },
 };
 
@@ -125,6 +188,13 @@ export const NegativeDisabled: Story = {
     appearance: "negative",
     disabled: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button with negative appearance",
+      },
+    },
+  },
 };
 
 export const Brand: Story = {
@@ -133,6 +203,13 @@ export const Brand: Story = {
   args: {
     children: "Brand button",
     appearance: "brand",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with brand appearance",
+      },
+    },
   },
 };
 
@@ -143,6 +220,13 @@ export const BrandDisabled: Story = {
     children: "Brand button disabled",
     appearance: "brand",
     disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button with brand appearance",
+      },
+    },
   },
 };
 
@@ -157,6 +241,13 @@ export const Inline: Story = {
   ),
 
   name: "Inline",
+  parameters: {
+    docs: {
+      description: {
+        story: "Button that displays on the same line as the sibling elements",
+      },
+    },
+  },
 };
 
 export const Dense: Story = {
@@ -168,6 +259,13 @@ export const Dense: Story = {
   ),
 
   name: "Dense",
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with reduced vertical padding",
+      },
+    },
+  },
 };
 
 export const Small: Story = {
@@ -181,6 +279,13 @@ export const Small: Story = {
   ),
 
   name: "Small",
+  parameters: {
+    docs: {
+      description: {
+        story: "Button that can fit small text inside",
+      },
+    },
+  },
 };
 
 export const Icon: Story = {
@@ -189,6 +294,13 @@ export const Icon: Story = {
   args: {
     children: <i className="p-icon--plus"></i>,
     hasIcon: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with an icon inside",
+      },
+    },
   },
 };
 
@@ -204,9 +316,16 @@ export const IconText: Story = {
 
     hasIcon: true,
   },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button with both an icon and text inside",
+      },
+    },
+  },
 };
 
-export const IconWithTooltip: Story = {
+export const DisabledWithTooltip: Story = {
   name: "Disabled with tooltip",
 
   args: {
@@ -220,4 +339,48 @@ export const IconWithTooltip: Story = {
       </Tooltip>
     </div>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button that displays a tooltip when hovered",
+      },
+    },
+  },
+};
+
+export const ButtonAsLink = {
+  name: "Button as link",
+
+  args: {
+    children: "Button as link",
+    appearance: "base",
+    element: "a",
+    href: "#test",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Button that is rendered as an `a` element",
+      },
+    },
+  },
+};
+
+export const ButtonAsLinkDisabled: Story<HTMLProps<HTMLAnchorElement>> = {
+  name: "Button as link disabled",
+
+  args: {
+    children: "Button as link disabled",
+    appearance: "base",
+    element: "a",
+    href: "#test",
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled button that is rendered as an `a` element",
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Done

- Updated Storybook example for the "[Link button](https://react-components-1176.demos.haus/?path=/story/components-button--link)"
- Added the "Button as link" story at the bottom
- Added descriptions for all the button stories

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check the updated Storybook example for the "[Link button](https://react-components-1176.demos.haus/?path=/story/components-button--link)" - it should now look like a link, instead of a base button.
- Check that the storybook page for the `Button` component looks as expected

### Percy steps

- Confirm that the only visual changes are in the "Button" page of the Storybook.

## Fixes

Fixes: #1175