### PR TITLE
chore(lint): ignore lint errors from externals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,9 @@ const compat = new FlatCompat({
 });
 
 export default [
+  {
+    ignores: ["src/external/"],
+  },
   ...fixupConfigRules(
     compat.extends("plugin:cypress/recommended", "plugin:prettier/recommended"),
   ),


### PR DESCRIPTION
## Done

- Ignore the lint errors coming from external modules. Fixing these will change the behaviour of those modules.

## QA

Go to the `Files changed` tab on this PR and there should be no lint warnings from `usePortal`.