### PR TITLE
refactor(Notification): Add type="button" and allow passing in ReactNode to Notification Actions

### DIFF
--- a/src/components/Notification/Notification.test.tsx
+++ b/src/components/Notification/Notification.test.tsx
@@ -88,6 +88,14 @@ describe("Notification", () => {
     expect(onActionClick).toHaveBeenCalled();
   });
 
+  it("can be given ReactNodes as actions", () => {
+    const CustomAction = () => (
+      <div data-testid="custom-action">Custom Action</div>
+    );
+    render(<Notification actions={[<CustomAction key="custom" />]} />);
+    expect(screen.getByTestId("custom-action")).toBeInTheDocument();
+  });
+
   it("can automatically dismiss the notification after a given timeout period", () => {
     const onDismiss = jest.fn();
     const timeout = 1000;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -28,6 +28,7 @@ export const DefaultTitles = {
 type NotificationAction = {
   label: string;
   onClick: () => void;
+  disabled?: boolean;
 };
 
 /**
@@ -177,6 +178,7 @@ const Notification = ({
         <p className="p-notification__message">{children}</p>
         {onDismiss && (
           <button
+            type="button"
             className="p-notification__close"
             data-testid="notification-close-button"
             onClick={onDismiss}
@@ -199,11 +201,13 @@ const Notification = ({
             <div className="p-notification__actions">
               {actions.map((action, i) => (
                 <Button
+                  type="button"
                   appearance={ButtonAppearance.LINK}
                   className="p-notification__action"
                   data-testid="notification-action"
                   key={`${action.label}-${i}`}
                   onClick={action.onClick}
+                  disabled={action.disabled}
                 >
                   {action.label}
                 </Button>

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,5 +1,11 @@
 import classNames from "classnames";
-import React, { ElementType, Fragment, useEffect, useRef } from "react";
+import React, {
+  ElementType,
+  Fragment,
+  isValidElement,
+  useEffect,
+  useRef,
+} from "react";
 import type { HTMLProps, ReactNode } from "react";
 
 import Button, { ButtonAppearance } from "../Button";
@@ -211,7 +217,7 @@ const Notification = ({
                       {action.label}
                     </Button>
                   ) : (
-                    action
+                    isValidElement(action) && action
                   )}
                 </Fragment>
               ))}

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,15 +1,9 @@
 import classNames from "classnames";
-import React, {
-  ElementType,
-  Fragment,
-  isValidElement,
-  useEffect,
-  useRef,
-} from "react";
+import React, { ElementType, useEffect, useRef } from "react";
 import type { HTMLProps, ReactNode } from "react";
 
 import Button, { ButtonAppearance } from "../Button";
-import { IS_DEV } from "../../utils";
+import { IS_DEV, isReactNode } from "../../utils";
 
 import type { ClassName, PropsWithSpread, ValueOf } from "types";
 
@@ -204,23 +198,22 @@ const Notification = ({
           )}
           {hasActions ? (
             <div className="p-notification__actions">
-              {actions.map((action, i) => (
-                <Fragment key={i}>
-                  {action && typeof action === "object" && "label" in action ? (
-                    <Button
-                      type="button"
-                      appearance={ButtonAppearance.LINK}
-                      className="p-notification__action"
-                      data-testid="notification-action"
-                      onClick={action.onClick}
-                    >
-                      {action.label}
-                    </Button>
-                  ) : (
-                    isValidElement(action) && action
-                  )}
-                </Fragment>
-              ))}
+              {actions.map((action, i) =>
+                isReactNode(action) ? (
+                  action
+                ) : (
+                  <Button
+                    type="button"
+                    appearance={ButtonAppearance.LINK}
+                    className="p-notification__action"
+                    data-testid="notification-action"
+                    key={`${action.label}-${i}`}
+                    onClick={action.onClick}
+                  >
+                    {action.label}
+                  </Button>
+                ),
+              )}
             </div>
           ) : null}
         </div>

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -200,7 +200,7 @@ const Notification = ({
             <div className="p-notification__actions">
               {actions.map((action, i) => (
                 <Fragment key={i}>
-                  {typeof action === "object" && "label" in action ? (
+                  {action && typeof action === "object" && "label" in action ? (
                     <Button
                       type="button"
                       appearance={ButtonAppearance.LINK}

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { ElementType, useEffect, useRef } from "react";
+import React, { ElementType, Fragment, useEffect, useRef } from "react";
 import type { HTMLProps, ReactNode } from "react";
 
 import Button, { ButtonAppearance } from "../Button";
@@ -28,7 +28,6 @@ export const DefaultTitles = {
 type NotificationAction = {
   label: string;
   onClick: () => void;
-  disabled?: boolean;
 };
 
 /**
@@ -39,7 +38,7 @@ export type Props = PropsWithSpread<
     /**
      * A list of up to two actions that the notification can perform.
      */
-    actions?: NotificationAction[];
+    actions?: (NotificationAction | ReactNode)[];
     /**
      * Whether the notification should not have a border.
      */
@@ -200,17 +199,21 @@ const Notification = ({
           {hasActions ? (
             <div className="p-notification__actions">
               {actions.map((action, i) => (
-                <Button
-                  type="button"
-                  appearance={ButtonAppearance.LINK}
-                  className="p-notification__action"
-                  data-testid="notification-action"
-                  key={`${action.label}-${i}`}
-                  onClick={action.onClick}
-                  disabled={action.disabled}
-                >
-                  {action.label}
-                </Button>
+                <Fragment key={i}>
+                  {typeof action === "object" && "label" in action ? (
+                    <Button
+                      type="button"
+                      appearance={ButtonAppearance.LINK}
+                      className="p-notification__action"
+                      data-testid="notification-action"
+                      onClick={action.onClick}
+                    >
+                      {action.label}
+                    </Button>
+                  ) : (
+                    action
+                  )}
+                </Fragment>
               ))}
             </div>
           ) : null}

--- a/src/components/NotificationProvider/__snapshots__/NotificationProvider.test.tsx.snap
+++ b/src/components/NotificationProvider/__snapshots__/NotificationProvider.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`NotificationProvider stores and renders notifications 1`] = `
         <button
           class="p-notification__close"
           data-testid="notification-close-button"
+          type="button"
         >
           Close notification
         </button>
@@ -61,6 +62,7 @@ exports[`NotificationProvider stores and renders notifications 2`] = `
         <button
           class="p-notification__close"
           data-testid="notification-close-button"
+          type="button"
         >
           Close notification
         </button>
@@ -75,6 +77,7 @@ exports[`NotificationProvider stores and renders notifications 2`] = `
           <button
             class="p-button--link p-notification__action"
             data-testid="notification-action"
+            type="button"
           >
             Retry
           </button>
@@ -110,6 +113,7 @@ exports[`NotificationProvider stores and renders notifications 3`] = `
         <button
           class="p-notification__close"
           data-testid="notification-close-button"
+          type="button"
         >
           Close notification
         </button>


### PR DESCRIPTION
## Done

- Add `type="button"` prop to notification action buttons and dismiss button
- Allow passing in `ReactNode` to notification actions

## QA

### Percy steps

- No visual changes expected.
