### PR TITLE
fix(MultiSelect): Add z-index to MultiSelect menu

### DIFF
--- a/src/components/ModularTable/ModularTable.tsx
+++ b/src/components/ModularTable/ModularTable.tsx
@@ -136,7 +136,7 @@ ModularTable components accepts `columns` and `data` arguments in the same forma
 `columns` - The core columns configuration object for the entire table. https://react-table.tanstack.com/docs/api/useTable#column-options
 `data` - The data array that you want to display on the table.
 ### Important note!
-Values passed to both of these params have to me memoized (for example via{" "}
+Values passed to both of these params have to be memoized (for example via{" "}
   <code>React.useMemo</code>). Memoization ensures that our data isn't recreated
   on every render. If we didn't use <code>React.useMemo</code>, the table would
   think it was receiving new data on every render and attempt to recalulate a

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -15,7 +15,7 @@ $dropdown-max-height: 20rem;
   width: 100%;
 
   // Ensure the dropdown is above the modal backdrop
-  z-index: var(--menu-z-index, 151); 
+  z-index: var(--menu-z-index, 151);
 }
 
 .multi-select .p-form-validation__message {

--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -13,6 +13,9 @@ $dropdown-max-height: 20rem;
   margin-bottom: $input-margin-bottom;
   position: relative;
   width: 100%;
+
+  // Ensure the dropdown is above the modal backdrop
+  z-index: var(--menu-z-index, 151); 
 }
 
 .multi-select .p-form-validation__message {


### PR DESCRIPTION
## Done

- Set z-index on multi select menu so it renders above modal backdrop

### Drive-by:

- Fix typo in ModularTable documentation

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### Percy steps

- No visual changes expected