### PR TITLE
feat(ConfirmationButton): Add pre modal open hook

### DIFF
--- a/src/components/ConfirmationButton/ConfirmationButton.stories.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.stories.tsx
@@ -154,3 +154,49 @@ export const BaseAppearance: Story = {
 
   name: "Base appearance",
 };
+
+export const WithPreModalOpenHook: Story = {
+  render: () => {
+    const dontOpenModal = () => false;
+    const openModal = () => true;
+
+    return (
+      <>
+        <ConfirmationButton
+          preModalOpenHook={dontOpenModal}
+          confirmationModalProps={{
+            title: "Confirm delete",
+            confirmButtonLabel: "Delete",
+            children: (
+              <p>
+                This will permanently delete the user "Simon".
+                <br />
+                You cannot undo this action.
+              </p>
+            ),
+          }}
+        >
+          Don't open modal
+        </ConfirmationButton>
+        <ConfirmationButton
+          preModalOpenHook={openModal}
+          confirmationModalProps={{
+            title: "Confirm delete",
+            confirmButtonLabel: "Delete",
+            children: (
+              <p>
+                This will permanently delete the user "Simon".
+                <br />
+                You cannot undo this action.
+              </p>
+            ),
+          }}
+        >
+          Open modal
+        </ConfirmationButton>
+      </>
+    );
+  },
+
+  name: "With preModalOpenHook handler",
+};

--- a/src/components/ConfirmationButton/ConfirmationButton.test.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.test.tsx
@@ -113,4 +113,47 @@ describe("ConfirmationButton ", () => {
     );
     expect(screen.getByTitle("Confirm")).toHaveClass("extra-class");
   });
+
+  it("does not show the modal if shouldShowModal returns false", () => {
+    const shouldShowModal = jest.fn().mockReturnValue(false);
+    const onConfirm = jest.fn();
+
+    render(
+      <ConfirmationButton
+        preModalOpenHook={shouldShowModal}
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm,
+        }}
+      />,
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(shouldShowModal).toHaveBeenCalled();
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("shows the modal if shouldShowModal returns true", () => {
+    const shouldShowModal = jest.fn().mockReturnValue(true);
+    const onConfirm = jest.fn();
+
+    render(
+      <ConfirmationButton
+        preModalOpenHook={shouldShowModal}
+        confirmationModalProps={{
+          confirmButtonLabel: "Confirm",
+          onConfirm,
+        }}
+      />,
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(shouldShowModal).toHaveBeenCalled();
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+  });
 });

--- a/src/components/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.tsx
@@ -35,6 +35,11 @@ export type Props = PropsWithSpread<
      * Whether to show a hint about the SHIFT+Click shortcut to skip the confirmation modal.
      */
     showShiftClickHint?: boolean;
+    /**
+     * A handler that determines whether the confirmation modal should be shown.
+     * If it returns `true`, the modal is shown. If it returns `false`, the modal is not shown.
+     */
+    preModalOpenHook?: (event: MouseEvent<HTMLButtonElement>) => boolean;
   },
   ActionButtonProps
 >;
@@ -47,6 +52,7 @@ export const ConfirmationButton = ({
   onHoverText,
   shiftClickEnabled = false,
   showShiftClickHint = false,
+  preModalOpenHook,
   ...actionButtonProps
 }: Props): React.JSX.Element => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
@@ -71,6 +77,16 @@ export const ConfirmationButton = ({
     }
   };
 
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (preModalOpenHook) {
+      const result = preModalOpenHook(e);
+
+      if (!result) return;
+    }
+
+    shiftClickEnabled ? handleShiftClick(e) : openPortal(e);
+  };
+
   return (
     <>
       {isOpen && (
@@ -93,7 +109,7 @@ export const ConfirmationButton = ({
       )}
       <ActionButton
         {...actionButtonProps}
-        onClick={shiftClickEnabled ? handleShiftClick : openPortal}
+        onClick={handleClick}
         title={generateTitle(
           onHoverText ?? confirmationModalProps.confirmButtonLabel,
         )}


### PR DESCRIPTION
## Done

- Add a pre modal open hook

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to https://react-components-1190.demos.haus/?path=/story/components-confirmationbutton--with-should-show-modal-handler
- Make sure the buttons work

### Percy steps

- No visual changes expected.