### PR TITLE
chore(TICS): Migrate to new org TICS token

### DIFF
--- a/.github/workflows/tics-coverage.yml
+++ b/.github/workflows/tics-coverage.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          export TICSAUTHTOKEN=${{ secrets.TICS_AUTH_TOKEN }}
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
           curl --silent --show-error "https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/" > install_tics.sh
           . ./install_tics.sh
           TICSQServer -project react-components -tmpdir /tmp/tics -branchdir .


### PR DESCRIPTION
## Done

TICS uploads are [currently failing with a 401 unauthorized error](https://github.com/canonical/react-components/actions/runs/14358736656/job/40254602990). This is because the TICS token [was recently migrated](https://chat.canonical.com/canonical/pl/czanfrzz8fn4ugugy5h3sfjfqh), and we are still using the old `TICS_AUTH_TOKEN`. 

This updates the TICS workflow to use the new secret, per [example](https://chat.canonical.com/canonical/pl/yjdtscej13bm9btcy4sxn56ger) from @jw-can 

## QA
Go to the [secrets page](https://github.com/canonical/react-components/settings/secrets/actions) and verify that the secret name used in this PR matches the new org TICS secret name.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### Percy steps

- No visual changes expected
