### PR TITLE
fix: dynamically set label to match id

### DIFF
--- a/src/components/CustomSelect/CustomSelectDropdown/__snapshots__/CustomSelectDropdown.test.tsx.snap
+++ b/src/components/CustomSelect/CustomSelectDropdown/__snapshots__/CustomSelectDropdown.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`CustomSelectDropdown renders 1`] = `
       >
         <label
           class="u-off-screen"
-          for="search"
+          for="select-search-test-dropdown"
         >
           Search
         </label>

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -68,6 +68,8 @@ export type Props = PropsWithSpread<
 const SearchBox = React.forwardRef<HTMLInputElement, Props>(
   (
     {
+      name = "search",
+      id = "search",
       autocomplete = "on",
       className,
       disabled,
@@ -108,15 +110,15 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
 
     return (
       <div className={classNames("p-search-box", className)}>
-        <label className="u-off-screen" htmlFor="search">
+        <label className="u-off-screen" htmlFor={id}>
           {placeholder || "Search"}
         </label>
         <input
           autoComplete={autocomplete}
           className="p-search-box__input"
           disabled={disabled}
-          id="search"
-          name="search"
+          id={id}
+          name={name}
           onChange={(evt) => onChange?.(evt.target.value)}
           onKeyDown={onKeyDown}
           placeholder={placeholder}


### PR DESCRIPTION
## Done

- Fixes an accessibility issue in the `SearchBox` component by dynamically setting the label’s `htmlFor` to match the input id, when provided. 

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.
