### PR TITLE
fix(a11y): add label to number input in slider

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -132,6 +132,7 @@ export const Slider = ({
         />
         {showInput && (
           <input
+            aria-label={typeof label === "string" ? label : undefined}
             aria-describedby={help ? helpId : null}
             aria-errormessage={hasError ? validationId : null}
             aria-invalid={hasError}


### PR DESCRIPTION
## Done

- Resolves "Missing form label" a11y issue flagged by WAVE

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.
