### PR TITLE
feat: add help text to switch component

### DIFF
--- a/src/components/Stepper/Step/Step.scss
+++ b/src/components/Stepper/Step/Step.scss
@@ -85,7 +85,7 @@
   }
 }
 
-.stepper-vertical {
+.stepper-vertical:not(.stepper-horizontal) {
   .p-list__item {
     padding-bottom: 0;
     padding-top: 0;

--- a/src/components/Switch/Switch.scss
+++ b/src/components/Switch/Switch.scss
@@ -1,0 +1,3 @@
+.switch-help-text {
+  margin-left: 2.5rem;
+}

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -27,3 +27,12 @@ export const Disabled: Story = {
     label: "Disabled switch",
   },
 };
+
+export const HelpText: Story = {
+  name: "Help Text",
+
+  args: {
+    label: "Switch with help text",
+    help: "This is some help text",
+  },
+};

--- a/src/components/Switch/Switch.test.tsx
+++ b/src/components/Switch/Switch.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 // import userEvent from "@testing-library/user-event";
 
 import Switch from "./Switch";
@@ -31,5 +31,13 @@ describe("<Switch />", () => {
     expect(container.querySelector("input.p-switch__input")).toHaveAttribute(
       "disabled",
     );
+  });
+
+  it("renders a switch with help text", () => {
+    render(
+      <Switch label="Switch with help text" help="This is some help text" />,
+    );
+
+    expect(screen.getByText("This is some help text")).toBeInTheDocument();
   });
 });

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import classNames from "classnames";
 import type { HTMLProps, ReactNode } from "react";
-
 import type { PropsWithSpread } from "types";
+import "./Switch.scss";
 
 export type Props = PropsWithSpread<
   {
@@ -13,6 +14,14 @@ export type Props = PropsWithSpread<
      * Whether the switch is disabled or not
      */
     disabled?: boolean;
+    /**
+     * Help text to show below the field.
+     */
+    help?: ReactNode;
+    /**
+     * Optional class(es) to pass to the help text element.
+     */
+    helpClassName?: string;
   },
   HTMLProps<HTMLInputElement>
 >;
@@ -23,20 +32,36 @@ export type Props = PropsWithSpread<
 export const Switch = ({
   label,
   disabled = false,
+  help,
+  helpClassName,
   ...inputProps
 }: Props): React.JSX.Element => {
   return (
-    <label className="p-switch">
-      <input
-        type="checkbox"
-        className="p-switch__input"
-        role="switch"
-        disabled={disabled}
-        {...inputProps}
-      ></input>
-      <span className="p-switch__slider"></span>
-      <span className="p-switch__label">{label}</span>
-    </label>
+    <>
+      <label className="p-switch">
+        <input
+          type="checkbox"
+          className="p-switch__input"
+          role="switch"
+          disabled={disabled}
+          {...inputProps}
+        ></input>
+        <span className="p-switch__slider"></span>
+        <span className="p-switch__label">{label}</span>
+      </label>
+      {help && (
+        <p
+          className={classNames(
+            "p-form-help-text",
+            "switch-help-text",
+            helpClassName,
+          )}
+          id={inputProps["aria-describedby"]}
+        >
+          {help}
+        </p>
+      )}
+    </>
   );
 };
 

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import classNames from "classnames";
 import type { HTMLProps, ReactNode } from "react";
 import type { PropsWithSpread } from "types";
+import { useId } from "react";
 import "./Switch.scss";
 
 export type Props = PropsWithSpread<
@@ -36,6 +37,8 @@ export const Switch = ({
   helpClassName,
   ...inputProps
 }: Props): React.JSX.Element => {
+  const helpId = useId();
+
   return (
     <>
       <label className="p-switch">
@@ -56,7 +59,7 @@ export const Switch = ({
             "switch-help-text",
             helpClassName,
           )}
-          id={inputProps["aria-describedby"]}
+          id={helpId}
         >
           {help}
         </p>


### PR DESCRIPTION
## Done

- Add optional help text to switch component

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: #[WD-13578](https://warthogs.atlassian.net/browse/WD-13578)


[WD-13578]: https://warthogs.atlassian.net/browse/WD-13578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ