### PR TITLE
fix(toast): improve mobile compatibility by using dvh unit instead of vh

### DIFF
--- a/src/components/Notifications/ToastNotification/Toast.scss
+++ b/src/components/Notifications/ToastNotification/Toast.scss
@@ -35,7 +35,7 @@
 .toast-notification-list {
   background-color: white;
   box-shadow: 0 0 2rem 0.5rem rgb(0 0 0 / 22%);
-  max-height: calc(100vh - 4.5rem);
+  max-height: calc(100dvh - 4.5rem);
   overflow: auto;
   padding: 0 0.5rem;
   z-index: 102;


### PR DESCRIPTION
## Done

- Using the dvh unit instead of vh ensures that the address bar on mobile browsers is not counted as part of the viewport height.