### PR TITLE
fix: reset filters when all filtered notifications are closed

### DIFF
--- a/src/components/Notifications/ToastNotification/ToastNotificationList.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotificationList.tsx
@@ -8,7 +8,7 @@ import {
   ToastNotificationType,
 } from "./ToastNotificationProvider";
 import type { FC } from "react";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import Animate from "./Animate";
 import { usePrefersReducedMotion } from "../../../hooks";
@@ -200,6 +200,13 @@ const ToastNotificationList: FC<Props> = ({
   const filteredNotifications = hasFilters
     ? notifications.filter((notification) => filters.has(notification.type))
     : notifications;
+
+  useEffect(() => {
+    if (hasFilters && filteredNotifications.length === 0) {
+      // if there are no filtered notifications, reset the filters
+      setFilters(new Set());
+    }
+  }, [hasFilters, filteredNotifications]);
 
   // Don't assign alert role for notifications when expanded since we don't want
   // screen readers to announce every existing notification


### PR DESCRIPTION
## Done

- Fix an edge case where filters weren't reset when the filtered notifications were individually dismissed 

Before:

https://github.com/user-attachments/assets/344612bd-7b24-4727-a704-43f1404e544f

After:

https://github.com/user-attachments/assets/8d0994ad-a54a-4844-b867-fd97bad85b6a

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- select a filter
- dismiss all the notifications in that filter by clicking the close (X) icon within each notification
- confirm that the filters are reset when all the filtered notifications are closed

### Percy steps

- No visual changes expected

