### PR TITLE
fix: table-pagination to encounter more space to fit content

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "tsc-alias": "1.8.10",
     "typescript": "5.7.3",
     "typescript-eslint": "8.24.1",
-    "vanilla-framework": "4.23.0",
+    "vanilla-framework": "4.24.1",
     "wait-on": "8.0.2",
     "webpack": "5.98.0"
   },

--- a/src/components/TablePagination/TablePagination.scss
+++ b/src/components/TablePagination/TablePagination.scss
@@ -36,7 +36,7 @@
   .pagination-input {
     margin: 0 $spv--small 0 $spv--large;
     min-width: 0;
-    width: 3rem;
+    width: 4rem;
   }
 
   .pagination-select {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13093,10 +13093,10 @@ validate-npm-package-name@^5.0.1:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
   integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
-vanilla-framework@4.23.0:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.23.0.tgz#4c2f87743501d88e646de818253a1dcacd2f9c66"
-  integrity sha512-GdlN4PVSanY96IUxQwxv2T1Ls+UgRA+BZqUuGqhO6AlgEet9uKJI7XFSfdieedc0F5P8ySCZA9MkALTGHr6jbA==
+vanilla-framework@4.24.1:
+  version "4.24.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.24.1.tgz#cd1f24ef3d048d410fda252aeafc015c44adc8cf"
+  integrity sha512-mX2kugxhMtoo1IbvRDyA0WY8IJ/z7Q3MO4k8LMz0Plc/ZnPTuOcUYretx/e/TmgLrCko0rmTLjrSiEkWJWySxA==
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
## Done

- fix(table-pagination) encounter more space for pagination, as the horizontal input padding in vanilla increased
- this is to fix fallout from https://github.com/canonical/vanilla-framework/pull/5539
- for the problematic pagination see [this demo](https://react-components-1198.demos.haus/?path=/story/components-tablepagination--default) from https://github.com/canonical/react-components/pull/1198

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- check the [table pagination](https://react-components-1210.demos.haus/?path=/story/components-tablepagination--default) with new vanilla version

### Percy steps

- Table pagination width should have increased.