### PR TITLE
fix: table-pagination on small screens. adjust spacing and avoid line breaks

### DIFF
--- a/src/components/TablePagination/TablePagination.scss
+++ b/src/components/TablePagination/TablePagination.scss
@@ -45,4 +45,16 @@
     min-width: 0;
     width: 7rem;
   }
+
+  @media screen and (max-width: $breakpoint-small) {
+    .back,
+    .pagination-input {
+      margin-left: 0;
+    }
+
+    .next {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
 }

--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
@@ -138,7 +138,7 @@ const TablePaginationControls = ({
             value={currentPage}
             type="number"
           />{" "}
-          {typeof totalPages === "number" ? `of ${totalPages}` : null}
+          {typeof totalPages === "number" ? <>of&nbsp;{totalPages}</> : null}
         </>
       ) : null}
       <Button

--- a/src/components/TablePagination/__snapshots__/TablePagination.test.tsx.snap
+++ b/src/components/TablePagination/__snapshots__/TablePagination.test.tsx.snap
@@ -42,7 +42,8 @@ exports[`<TablePagination /> renders table pagination and matches the snapshot 1
     </div>
   </div>
    
-  of 1
+  of 
+  1
   <button
     aria-disabled="true"
     aria-label="Next page"


### PR DESCRIPTION
## Done

- fix: table-pagination on small screens. adjust spacing and avoid line breaks

## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open the [table pagination](https://react-components-1211.demos.haus/?path=/story/components-tablepagination--default) in storybook
- Select a small mobile screen and ensure it looks good

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

Discovered in https://github.com/canonical/lxd-ui/pull/1306

# Screenshots

before

![image](https://github.com/user-attachments/assets/771ee6e8-b35b-47ae-8871-3c8e6ec5cfb0)

after

![image](https://github.com/user-attachments/assets/6b2b642f-3190-4f95-bf8c-f6f41b12e111)
