### PR TITLE
fix: disable input controls when there is only one page in TablePagination

### DIFF
--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.test.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.test.tsx
@@ -154,4 +154,48 @@ describe("<TablePaginationControls />", () => {
       document.querySelector(".description")?.textContent,
     ).not.toBeUndefined();
   });
+
+  it("disables page input when there is only one page", () => {
+    render(
+      <TablePaginationControls
+        visibleCount={5}
+        itemName="item"
+        pageLimits={[20, 50, 100]}
+        totalItems={5}
+        currentPage={1}
+        pageSize={20}
+        onPageChange={jest.fn()}
+        onPageSizeChange={jest.fn()}
+      />,
+    );
+
+    const pageInput = screen.getByRole("spinbutton", {
+      name: Label.PAGE_NUMBER,
+    });
+    expect(pageInput).toBeDisabled();
+    expect(pageInput).toHaveAttribute("min", "1");
+    expect(pageInput).toHaveAttribute("max", "1");
+  });
+
+  it("enables page input when there are multiple pages", () => {
+    render(
+      <TablePaginationControls
+        visibleCount={20}
+        itemName="item"
+        pageLimits={[20, 50, 100]}
+        totalItems={100}
+        currentPage={1}
+        pageSize={20}
+        onPageChange={jest.fn()}
+        onPageSizeChange={jest.fn()}
+      />,
+    );
+
+    const pageInput = screen.getByRole("spinbutton", {
+      name: Label.PAGE_NUMBER,
+    });
+    expect(pageInput).not.toBeDisabled();
+    expect(pageInput).toHaveAttribute("min", "1");
+    expect(pageInput).toHaveAttribute("max", "5");
+  });
 });

--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
@@ -138,8 +138,8 @@ const TablePaginationControls = ({
             value={currentPage}
             type="number"
             disabled={totalPages === 1}
-            min={totalPages === 1 ? 1 : 1}
-            max={totalPages === 1 ? 1 : totalPages}
+            min={1}
+            max={typeof totalPages === "number" ? totalPages : 1}
           />{" "}
           {typeof totalPages === "number" ? <>of&nbsp;{totalPages}</> : null}
         </>

--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
@@ -103,6 +103,9 @@ const TablePaginationControls = ({
     onPageSizeChange(parseInt(e.target.value));
   };
 
+  const isInputDisabled = !totalPages || totalPages == 1;
+  const maxPageValue = typeof totalPages === "number" ? totalPages : 1;
+
   return (
     <div
       className={classnames("pagination", className)}
@@ -117,7 +120,7 @@ const TablePaginationControls = ({
         className="back"
         appearance="base"
         hasIcon
-        disabled={currentPage === 1}
+        disabled={isInputDisabled || currentPage === 1}
         onClick={() => handleDecrementPage(currentPage)}
         {...previousButtonProps}
       >
@@ -137,9 +140,9 @@ const TablePaginationControls = ({
             onChange={handleInputPageChange}
             value={currentPage}
             type="number"
-            disabled={totalPages === 1}
+            disabled={isInputDisabled}
             min={1}
-            max={typeof totalPages === "number" ? totalPages : 1}
+            max={maxPageValue}
           />{" "}
           {typeof totalPages === "number" ? <>of&nbsp;{totalPages}</> : null}
         </>
@@ -149,7 +152,7 @@ const TablePaginationControls = ({
         className="next"
         appearance="base"
         hasIcon
-        disabled={currentPage === totalPages}
+        disabled={isInputDisabled || currentPage === totalPages}
         onClick={() => handleIncrementPage(currentPage, totalPages)}
         {...nextButtonProps}
       >

--- a/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
+++ b/src/components/TablePagination/TablePaginationControls/TablePaginationControls.tsx
@@ -137,6 +137,9 @@ const TablePaginationControls = ({
             onChange={handleInputPageChange}
             value={currentPage}
             type="number"
+            disabled={totalPages === 1}
+            min={totalPages === 1 ? 1 : 1}
+            max={totalPages === 1 ? 1 : totalPages}
           />{" "}
           {typeof totalPages === "number" ? <>of&nbsp;{totalPages}</> : null}
         </>

--- a/src/components/TablePagination/TablePaginationControls/__snapshots__/TablePaginationControls.test.tsx.snap
+++ b/src/components/TablePagination/TablePaginationControls/__snapshots__/TablePaginationControls.test.tsx.snap
@@ -26,6 +26,8 @@ exports[`<TablePaginationControls /> renders table pagination controls and match
   aria-invalid="false"
   class="p-form-validation__input u-no-margin--bottom pagination-input"
   id="paginationPageInput"
+  max="5"
+  min="1"
   type="number"
   value="0"
 />

--- a/src/components/TablePagination/__snapshots__/TablePagination.test.tsx.snap
+++ b/src/components/TablePagination/__snapshots__/TablePagination.test.tsx.snap
@@ -35,7 +35,10 @@ exports[`<TablePagination /> renders table pagination and matches the snapshot 1
       <input
         aria-invalid="false"
         class="p-form-validation__input u-no-margin--bottom pagination-input"
+        disabled=""
         id="paginationPageInput"
+        max="1"
+        min="1"
         type="number"
         value="1"
       />


### PR DESCRIPTION
## Problem

In Safari, when the `TablePagination` component displays only one page of data, the number input field's native stepper controls (up/down arrows) remain enabled and functional, creating a confusing user experience. Additionally, users can clear the input field and leave it empty, which should not be possible when there's only one valid page.

**Sidenote**: Although, main issue #1212 only mentioned Safari, this doesn't seem to only a Safari issue. I was able to reproduce it on Arc Browser.

## Solution

This PR fixes the issue by properly disabling the page number input field in the `TablePaginationControls` component when there's only one page or no pages. The solution uses the `disabled` attribute to completely prevent user interaction with the input field, ensuring that:

- Native browser stepper controls are non-functional
- Users cannot edit the input value
- Users cannot clear the input field
- The input displays the correct disabled styling

## Done

- **Fixed TablePaginationControls component**: Modified the page number input field to be disabled when there are no pages or only one page
- **Improved robustness**: Added handling for edge cases such as null/undefined/zero totalPages values
- **Code cleanup**: Extracted reused logic into named variables for better maintainability and readability
- **Enhanced consistency**: Applied the same disabling logic to navigation buttons for a consistent user experience
- **Added input constraints**: Set appropriate `min` and `max` attributes - `min="1"` for all cases, and proper `max` values
- **Comprehensive test coverage**: Added unit tests for both single page and multiple page scenarios to ensure the fix works correctly
- **Updated snapshots**: Updated Jest snapshots to reflect the new disabled state and input attributes
- **Maintained backward compatibility**: No breaking changes - existing behavior for multiple pages remains unchanged

Quick demo video of fix: 

https://github.com/user-attachments/assets/73276d86-f27b-4697-b4df-de193c065a73



## QA

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

#### Critical Test Cases:

1. **Single page scenario (Primary fix validation):**

   - Set up `TablePagination` with data that results in only 1 page (e.g., 5 items with 20 per page)
   - **Expected behavior:**
     - Page number input field should be visually disabled (grayed out)
     - Input should have `disabled` attribute set to `true`
     - Input should have `min="1"` and appropriate `max` attribute
     - In Safari: Stepper controls (up/down arrows) should not increment/decrement the value
     - "Previous" button should be disabled
     - "Next" button should be disabled

2. **Multiple pages scenario (Regression testing):**

   - Set up `TablePagination` with data that results in multiple pages (e.g., 100 items with 20 per page)
   - **Expected behavior:**
     - Page number input field should be enabled and functional
     - Input should NOT have `disabled` attribute
     - Input should have `min="1"` and `max="{totalPages}"` attributes
     - Stepper controls should work normally in all browsers
     - Navigation buttons should enable/disable appropriately based on current page
     - All existing functionality should remain unchanged

3. **Cross-browser testing (Focus on Safari):**
   - **Safari**: Primary browser where the issue was reported - ensure stepper controls are non-functional for single page
   - **Chrome**: Ensure no regression in behavior
   - **Firefox**: Ensure no regression in behavior

### Percy steps

- **Expected visual change**: The page number input in TablePagination should appear disabled (grayed out) when there is only one page of results or no pages. This is a minor visual change that reflects the new disabled state of the input control.

## Fixes

Fixes: #1212
