### PR TITLE
fix: Add type "button" to close buttons in modals

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -87,6 +87,7 @@ export const ConfirmationModal = ({
           {confirmExtra}
           <Button
             {...cancelButtonProps}
+            type={cancelButtonProps?.type ?? "button"}
             className="u-no-margin--bottom"
             onClick={handleClick(props.close)}
           >

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -185,6 +185,7 @@ export const Modal = ({
             </h2>
             {!!close && (
               <button
+                type="button"
                 className="p-modal__close"
                 aria-label="Close active modal"
                 onClick={handleClose}


### PR DESCRIPTION
## Done

- Add `type="button"` to Close button in **Modal** to avoid submission in a form context
- Add `type="button"` to Cancel button in **ConfirmationModal**

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### Percy steps

- No visual changes expected