### PR TITLE
fix(step): use vanilla theme colors for stepper component

### DIFF
--- a/src/components/Stepper/Step/Step.scss
+++ b/src/components/Stepper/Step/Step.scss
@@ -1,7 +1,7 @@
 @import "vanilla-framework";
 
 .step-number {
-  border: 0.08rem solid black;
+  border: 0.08rem solid $colors--theme--border-high-contrast;
   border-radius: 1rem;
   height: 1.4rem;
   line-height: 1.3;
@@ -13,8 +13,8 @@
 }
 
 .step-number-disabled {
-  border: 0.08rem solid #757575;
-  color: #757575;
+  border: 0.08rem solid $colors--theme--text-muted;
+  color: $colors--theme--text-muted;
 }
 
 .step-content {
@@ -30,7 +30,7 @@
 }
 
 .step-disabled {
-  color: #757575;
+  color: $colors--theme--text-muted;
   pointer-events: none;
 }
 
@@ -41,7 +41,7 @@
 }
 
 .step-selected {
-  background-color: var(--vf-color-background-alt);
+  background-color: $colors--theme--background-active;
 }
 
 .step-optional-content {
@@ -57,7 +57,7 @@
   }
 
   .step {
-    border-top: 0.2rem solid var(--vf-color-border-default);
+    border-top: 0.2rem solid $colors--theme--border-default;
     display: flex;
     height: 100%;
     padding: 0.4rem $spv--medium;
@@ -77,7 +77,7 @@
   }
 
   .progress-line {
-    border-top: 0.2rem solid black;
+    border-top: 0.2rem solid $colors--theme--border-high-contrast;
   }
 
   :first-child .step {
@@ -92,7 +92,7 @@
   }
 
   .step {
-    border-left: 0.2rem solid var(--vf-color-border-default);
+    border-left: 0.2rem solid $colors--theme--border-default;
     display: flex;
     padding: $spv--medium 0;
     padding-right: 0.5rem;
@@ -100,7 +100,7 @@
   }
 
   .progress-line {
-    border-left: 0.2rem solid black;
+    border-left: 0.2rem solid $colors--theme--border-high-contrast;
   }
 
   :first-child .step {


### PR DESCRIPTION
## Done

- fix(step) use vanilla theme colors for stepper component

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- check the stepper component in storybook

### Percy steps

- the selected colors on the stepper component should be a bit more visible, the background of the active step is more visible. the outline of an active step circle should be improved.