### PR TITLE
fix(step): inherit stepper's width for steps

### DIFF
--- a/src/components/Stepper/Step/Step.scss
+++ b/src/components/Stepper/Step/Step.scss
@@ -96,7 +96,7 @@
     display: flex;
     padding: $spv--medium 0;
     padding-right: 0.5rem;
-    width: fit-content;
+    width: inherit;
   }
 
   .progress-line {

--- a/src/components/Stepper/Stepper.stories.tsx
+++ b/src/components/Stepper/Stepper.stories.tsx
@@ -213,53 +213,55 @@ export const HorizontalOptional: Story = {
 export const VerticalSelected: Story = {
   name: "Vertical variant: Selected step",
   render: () => (
-    <Stepper
-      steps={[
-        <Step
-          key="Vertical Selected Step 1"
-          title="Step 1"
-          index={1}
-          enabled={true}
-          hasProgressLine={true}
-          iconName="success"
-          label="Optional label"
-          handleClick={() => {}}
-        />,
-        <Step
-          key="Vertical Selected Step 2"
-          title="Step 2"
-          index={2}
-          enabled={true}
-          hasProgressLine={true}
-          iconName="success"
-          handleClick={() => {}}
-          label="Optional label"
-          selected={true}
-        />,
-        <Step
-          key="Vertical Selected Step 3"
-          title="Step 3"
-          index={3}
-          enabled={true}
-          hasProgressLine={true}
-          iconName="number"
-          label="Optional label"
-          linkProps={{ children: "Optional link" }}
-          handleClick={() => {}}
-        />,
-        <Step
-          key="Vertical Selected Step 4"
-          title="Step 4"
-          index={4}
-          enabled={false}
-          hasProgressLine={false}
-          linkProps={{ children: "Optional link" }}
-          iconName="number"
-          label="Optional label"
-          handleClick={() => {}}
-        />,
-      ]}
-    />
+    <div style={{ width: "50%" }}>
+      <Stepper
+        steps={[
+          <Step
+            key="Vertical Selected Step 1"
+            title="Step 1"
+            index={1}
+            enabled={true}
+            hasProgressLine={true}
+            iconName="success"
+            label="Optional label"
+            handleClick={() => {}}
+          />,
+          <Step
+            key="Vertical Selected Step 2"
+            title="Step 2"
+            index={2}
+            enabled={true}
+            hasProgressLine={true}
+            iconName="success"
+            handleClick={() => {}}
+            label="Optional label"
+            selected={true}
+          />,
+          <Step
+            key="Vertical Selected Step 3"
+            title="Step 3"
+            index={3}
+            enabled={true}
+            hasProgressLine={true}
+            iconName="number"
+            label="Optional label"
+            linkProps={{ children: "Optional link" }}
+            handleClick={() => {}}
+          />,
+          <Step
+            key="Vertical Selected Step 4"
+            title="Step 4"
+            index={4}
+            enabled={false}
+            hasProgressLine={false}
+            linkProps={{ children: "Optional link" }}
+            iconName="number"
+            label="Optional label"
+            handleClick={() => {}}
+          />,
+        ]}
+      />
+    </div>
   ),
 };
 


### PR DESCRIPTION
## Done

Previously, `width: fit-content` caused uneven widths in the vertical stepper, which was visible when individual steps were selected. Updated it to `inherit` for vertical steppers.

**Before**
<img width="385" alt="Screenshot 2025-07-04 at 1 20 24 AM" src="https://github.com/user-attachments/assets/7d0fc173-244f-49b4-b669-f419e7f54067" />
<img width="365" alt="Screenshot 2025-07-04 at 1 20 50 AM" src="https://github.com/user-attachments/assets/1305bfa9-f262-491f-9e9d-5b6bbbb92353" />

**After**
<img width="534" alt="Screenshot 2025-07-04 at 1 21 07 AM" src="https://github.com/user-attachments/assets/d029d496-4681-49d3-b2f7-b37fe9143fcb" />
<img width="532" alt="Screenshot 2025-07-04 at 1 21 30 AM" src="https://github.com/user-attachments/assets/87167885-6987-48bc-ace5-8d50059b1701" />


## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```
