### PR TITLE
feat(scrollable-container): add scrollable container and scrollable table components

### DIFF
--- a/src/components/ScrollableContainer/ScrollableContainer.scss
+++ b/src/components/ScrollableContainer/ScrollableContainer.scss
@@ -1,0 +1,7 @@
+.scrollable-container {
+  .content-details {
+    display: block;
+    overflow: auto;
+    scrollbar-gutter: stable;
+  }
+}

--- a/src/components/ScrollableContainer/ScrollableContainer.stories.tsx
+++ b/src/components/ScrollableContainer/ScrollableContainer.stories.tsx
@@ -1,0 +1,101 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import ScrollableContainer from "./ScrollableContainer";
+import React from "react";
+import { Description, Subtitle, Title } from "@storybook/blocks";
+
+const meta: Meta<typeof ScrollableContainer> = {
+  component: ScrollableContainer,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ScrollableContainer>;
+
+const StoryExample = (args: Story["args"]) => {
+  return (
+    <div>
+      <h1>Above contents</h1>
+      <ScrollableContainer belowIds={args.belowIds} dependencies={[]}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras varius
+          mi eu pretium vulputate. Nunc commodo sit amet nibh quis rhoncus.
+          Aliquam rhoncus porttitor semper. Aenean faucibus consectetur neque in
+          sodales. Sed cursus mauris id ex sollicitudin sodales. Quisque
+          molestie rutrum odio, ornare pharetra ligula. Pellentesque ornare
+          tristique feugiat. In a augue neque. Aenean eget arcu quis lacus
+          tempus posuere in sit amet dui. Suspendisse faucibus sapien nisl, nec
+          laoreet sem convallis nec.
+        </p>
+        <p>
+          Vestibulum sed placerat lorem. Nam luctus ex id nisi luctus, id
+          vestibulum sem bibendum. Vivamus turpis sem, pellentesque fermentum
+          malesuada eu, faucibus porta libero. Duis eget venenatis odio. Etiam
+          sed volutpat magna, non tempus erat. Nunc id tortor ac quam
+          consectetur dapibus ac ut tellus. Pellentesque ut tellus venenatis
+          elit vehicula condimentum eget quis lorem. Ut non consectetur est, a
+          fringilla ipsum. Nunc vitae ligula ipsum. Etiam suscipit, libero ut
+          lacinia viverra, nunc urna consequat ex, vel eleifend eros mauris
+          vitae ipsum. Pellentesque sed dictum augue. Ut sit amet ullamcorper
+          mauris. Nunc congue orci mollis purus sodales facilisis ac ut arcu.
+          Maecenas feugiat sapien ac massa mollis sodales. Donec vitae turpis eu
+          nisi laoreet pulvinar quis at nisl. Integer volutpat, metus eget
+          elementum dictum, lacus sapien viverra felis, consequat fermentum nisl
+          mi ac dui.
+        </p>
+        <p>
+          Nullam nulla turpis, dignissim vel dapibus ut, volutpat ac dui. Donec
+          vel elementum lacus. Mauris maximus nec felis at faucibus. Nunc
+          faucibus gravida velit, id blandit lectus tincidunt ac. Vestibulum
+          orci diam, elementum in congue eu, placerat id risus. Sed tempor
+          tempus tellus, vitae iaculis turpis fringilla nec. Phasellus imperdiet
+          facilisis velit, sit amet lobortis odio dignissim ut.
+        </p>
+        <p>
+          Nam placerat urna vitae ligula hendrerit, ac tincidunt lorem maximus.
+          Mauris eu odio nisi. Nulla facilisi. Sed egestas elit sed velit
+          rutrum, sit amet bibendum metus hendrerit. Pellentesque luctus
+          placerat tellus, eu bibendum justo. Cras eget leo ac ex volutpat
+          gravida. Duis vitae mollis ante. Duis a congue nunc. Aenean aliquet,
+          sapien quis tincidunt tincidunt, odio eros consectetur lacus, vel
+          finibus mauris tortor id velit. Donec tincidunt vitae purus eu
+          interdum. Pellentesque scelerisque dui viverra ex ullamcorper
+          volutpat. Vestibulum lacinia vitae arcu volutpat porta. Etiam et
+          cursus nulla, id aliquet felis. Nam ultricies, urna id mattis pretium,
+          velit erat viverra elit, eu maximus diam eros id nisi.
+        </p>
+        <p>
+          Nullam eget nisl lectus. Pellentesque eu mauris ut tortor malesuada
+          sagittis. Cras dictum cursus est non ultricies. Duis mollis non neque
+          at commodo. Nunc feugiat justo et consequat aliquam. Ut consectetur
+          libero eu erat feugiat finibus. Duis varius convallis quam eu
+          sagittis. Maecenas ac est arcu. Suspendisse at enim eget nibh
+          ultricies dictum. Etiam aliquet tellus vel felis malesuada laoreet.
+        </p>
+      </ScrollableContainer>
+      <div id="footer">
+        <h2 className="u-no-margin">Below contents</h2>
+        <div>here be dragons.</div>
+      </div>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    belowIds: ["footer"],
+  },
+  render: StoryExample,
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+        </>
+      ),
+    },
+  },
+};

--- a/src/components/ScrollableContainer/ScrollableContainer.test.tsx
+++ b/src/components/ScrollableContainer/ScrollableContainer.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import ScrollableContainer from "./ScrollableContainer";
+
+it("renders", () => {
+  render(
+    <ScrollableContainer dependencies={[]}>
+      Scrollable contents
+    </ScrollableContainer>,
+  );
+  expect(screen.getByText("Scrollable contents")).toBeInTheDocument();
+});
+
+it("respects above spacing", () => {
+  render(
+    <div role="main">
+      <h1>Above</h1>
+      <ScrollableContainer dependencies={[]}>
+        Scrollable contents
+      </ScrollableContainer>
+    </div>,
+  );
+  expect(screen.getByRole("main")).toMatchSnapshot();
+});
+
+it("respects below spacing", () => {
+  render(
+    <div role="main">
+      <h1>Above</h1>
+      <ScrollableContainer dependencies={[]} belowIds={["footer"]}>
+        Scrollable contents
+      </ScrollableContainer>
+      <div id="footer">
+        <h2>Below</h2>
+      </div>
+    </div>,
+  );
+  expect(screen.getByRole("main")).toMatchSnapshot();
+});

--- a/src/components/ScrollableContainer/ScrollableContainer.tsx
+++ b/src/components/ScrollableContainer/ScrollableContainer.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import type { DependencyList, FC, ReactNode } from "react";
+import { useEffect, useRef } from "react";
+import classnames from "classnames";
+import "./ScrollableContainer.scss";
+import { getAbsoluteHeightBelowById, getParentsBottomSpacing } from "utils";
+import { useListener } from "hooks";
+
+export type Props = {
+  /**
+   * The content that should be scrollable on overflow.
+   */
+  children: ReactNode;
+
+  /**
+   * An array of dependencies that will trigger a re-calculation of the scrollable height when changed.
+   */
+  dependencies: DependencyList;
+
+  /**
+   * An array of element IDs below the scrollable container that should be considered when calculating the height.
+   */
+  belowIds?: string[];
+
+  /**
+   * Additional CSS classes to apply to the scrollable container.
+   */
+  className?: string;
+};
+
+/**
+ * This is a [React](https://reactjs.org/) component for use within the [Vanilla framework](https://docs.vanillaframework.io/).
+ *
+ * It is used to make any child element scrollable by adjusting the height based on the viewport height and the heights of elements above and below it. As a result the surrounding elements are sticky and only the wrapped element contents scroll
+ */
+const ScrollableContainer: FC<Props> = ({
+  dependencies,
+  children,
+  belowIds = ["status-bar"],
+  className,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const updateChildContainerHeight = () => {
+    const childContainer = ref.current?.children[0];
+    if (!childContainer) {
+      return;
+    }
+
+    const above = childContainer.getBoundingClientRect().top + 1;
+    const below = belowIds.reduce(
+      (acc, belowId) => acc + getAbsoluteHeightBelowById(belowId),
+      0,
+    );
+    const parentsBottomSpacing = getParentsBottomSpacing(childContainer);
+    const offset = Math.ceil(above + below + parentsBottomSpacing);
+    const style = `height: calc(100dvh - ${offset}px); min-height: calc(100dvh - ${offset}px)`;
+    childContainer.setAttribute("style", style);
+  };
+
+  useListener(window, updateChildContainerHeight, "resize", true);
+  useEffect(updateChildContainerHeight, [dependencies, belowIds, ref]);
+
+  return (
+    <div ref={ref} className={classnames("scrollable-container", className)}>
+      <div id="content-details" className="content-details">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default ScrollableContainer;

--- a/src/components/ScrollableContainer/__snapshots__/ScrollableContainer.test.tsx.snap
+++ b/src/components/ScrollableContainer/__snapshots__/ScrollableContainer.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`respects above spacing 1`] = `
+<div
+  role="main"
+>
+  <h1>
+    Above
+  </h1>
+  <div
+    class="scrollable-container"
+  >
+    <div
+      class="content-details"
+      id="content-details"
+      style="height: calc(100dvh - 9px); min-height: calc(100dvh - 9px)"
+    >
+      Scrollable contents
+    </div>
+  </div>
+</div>
+`;
+
+exports[`respects below spacing 1`] = `
+<div
+  role="main"
+>
+  <h1>
+    Above
+  </h1>
+  <div
+    class="scrollable-container"
+  >
+    <div
+      class="content-details"
+      id="content-details"
+      style="height: calc(100dvh - 10px); min-height: calc(100dvh - 10px)"
+    >
+      Scrollable contents
+    </div>
+  </div>
+  <div
+    id="footer"
+  >
+    <h2>
+      Below
+    </h2>
+  </div>
+</div>
+`;

--- a/src/components/ScrollableContainer/index.ts
+++ b/src/components/ScrollableContainer/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ScrollableContainer";
+export type { Props as ScrollableContainerProps } from "./ScrollableContainer";

--- a/src/components/ScrollableTable/ScrollableTable.scss
+++ b/src/components/ScrollableTable/ScrollableTable.scss
@@ -1,0 +1,58 @@
+@import "vanilla-framework/scss/settings";
+
+/* stylelint-disable selector-max-type */
+.scrollable-table {
+  table {
+    margin-bottom: 0;
+  }
+
+  th,
+  td {
+    display: table-cell;
+    vertical-align: top;
+  }
+
+  th::before {
+    content: "";
+    height: 1rem;
+  }
+
+  thead,
+  tbody {
+    display: block;
+    overflow: hidden auto;
+    scrollbar-gutter: stable;
+  }
+
+  tbody {
+    height: calc(100dvh - 323px);
+  }
+
+  thead tr,
+  tbody tr {
+    display: table;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  @media screen and (max-width: $breakpoint-large) {
+    .p-table--mobile-card {
+      thead {
+        display: none;
+      }
+
+      td {
+        display: block;
+      }
+
+      tbody tr {
+        display: block;
+      }
+
+      tbody tr:first-child {
+        margin-top: $spv--x-large;
+      }
+    }
+  }
+}
+/* stylelint-enable selector-max-type */

--- a/src/components/ScrollableTable/ScrollableTable.stories.tsx
+++ b/src/components/ScrollableTable/ScrollableTable.stories.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import ScrollableTable from "./ScrollableTable";
+import { MainTable } from "../../index";
+import { Description, Subtitle, Title } from "@storybook/blocks";
+
+const meta: Meta<typeof ScrollableTable> = {
+  component: ScrollableTable,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ScrollableTable>;
+
+const StoryExample = (args: Story["args"]) => {
+  const headers = [
+    { content: "Fact" },
+    { content: "Relevancy score" },
+    { content: "Size" },
+    { content: "ID" },
+    { "aria-label": "Actions", className: "actions" },
+  ];
+
+  const facts = [
+    "Dragons are mythical creatures",
+    "They can fly",
+    "They breathe fire",
+    "They hoard treasure",
+    "They are often depicted as large reptiles",
+    "They appear in various cultures' folklore",
+    "They can be friendly or hostile",
+    "They are often associated with wisdom",
+    "They can shapeshift in some legends",
+    "They are sometimes guardians of sacred places",
+    "They can be found in literature and movies",
+    "They are often depicted with wings",
+    "They can be of various colors",
+    "They are sometimes associated with knights",
+  ];
+  const rows = facts.map((item) => {
+    return {
+      columns: [
+        { content: item, role: "rowheader" },
+        { content: 1 },
+        { content: "1 GiB" },
+        { content: 2 },
+      ],
+    };
+  });
+
+  return (
+    <div>
+      <h1>Above contents</h1>
+      <ScrollableTable
+        belowIds={args.belowIds}
+        dependencies={[headers, rows]}
+        tableId="facts-about-dragons"
+      >
+        <MainTable headers={headers} rows={rows} id="facts-about-dragons" />
+      </ScrollableTable>
+      <div id="footer">
+        <h2 className="u-no-margin">Below contents</h2>
+        <div>here be dragons.</div>
+      </div>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    belowIds: ["footer"],
+  },
+  render: StoryExample,
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+        </>
+      ),
+    },
+  },
+};

--- a/src/components/ScrollableTable/ScrollableTable.test.tsx
+++ b/src/components/ScrollableTable/ScrollableTable.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import ScrollableTable from "./ScrollableTable";
+import { MainTable } from "../../index";
+
+const headers = [{ content: "Fact" }];
+const rows = [
+  {
+    columns: [{ content: "foo" }],
+  },
+];
+
+it("renders", () => {
+  render(
+    <ScrollableTable dependencies={[]} tableId="test-table">
+      <MainTable headers={headers} rows={rows} id="test-table" />
+    </ScrollableTable>,
+  );
+  expect(screen.getByText("Fact")).toBeInTheDocument();
+});
+
+it("respects above spacing", () => {
+  render(
+    <div role="main">
+      <h1>Above</h1>
+      <ScrollableTable dependencies={[]} tableId="test-table">
+        <MainTable headers={headers} rows={rows} id="test-table" />
+      </ScrollableTable>
+    </div>,
+  );
+  expect(screen.getByRole("main")).toMatchSnapshot();
+});
+
+it("respects below spacing", () => {
+  render(
+    <div role="main">
+      <h1>Above</h1>
+      <ScrollableTable
+        dependencies={[]}
+        belowIds={["footer"]}
+        tableId="test-table"
+      >
+        <MainTable headers={headers} rows={rows} id="test-table" />
+      </ScrollableTable>
+      <div id="footer">
+        <h2>Below</h2>
+      </div>
+    </div>,
+  );
+  expect(screen.getByRole("main")).toMatchSnapshot();
+});

--- a/src/components/ScrollableTable/ScrollableTable.tsx
+++ b/src/components/ScrollableTable/ScrollableTable.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import type { DependencyList, FC, ReactNode } from "react";
+import { useEffect } from "react";
+import { getAbsoluteHeightBelowById, getParentsBottomSpacing } from "utils";
+import "./ScrollableTable.scss";
+import { useListener } from "hooks";
+
+export type Props = {
+  /**
+   * A MainTable that will be made scrollable.
+   */
+  children: ReactNode;
+
+  /**
+   * An array of dependencies that will trigger a re-calculation of the table body height when they change.
+   */
+  dependencies: DependencyList;
+
+  /**
+   * The ID of the table element that contains the `<tbody>` to be made scrollable.
+   */
+  tableId: string;
+
+  /**
+   * An array of element IDs below the table that should be considered when calculating the height.
+   */
+  belowIds?: string[];
+};
+
+/**
+ * This is a [React](https://reactjs.org/) component for use within the [Vanilla framework](https://docs.vanillaframework.io/).
+ *
+ * It is used to make a table scrollable by adjusting the height of the `<tbody>` element based on the viewport height and the heights of elements above and below it. As a result the header is sticky and only the body scrolls
+ */
+const ScrollableTable: FC<Props> = ({
+  dependencies,
+  children,
+  tableId,
+  belowIds = [],
+}) => {
+  const updateTBodyHeight = () => {
+    const table = document.getElementById(tableId);
+    if (!table || table.children.length !== 2) {
+      return;
+    }
+
+    const tBody = table.children[1];
+    const above = tBody.getBoundingClientRect().top + 1;
+    const below = belowIds.reduce(
+      (acc, belowId) => acc + getAbsoluteHeightBelowById(belowId),
+      0,
+    );
+    const parentsBottomSpacing = getParentsBottomSpacing(table);
+    const offset = Math.ceil(above + below + parentsBottomSpacing);
+    const style = `height: calc(100dvh - ${offset}px); min-height: calc(100dvh - ${offset}px)`;
+    tBody.setAttribute("style", style);
+  };
+
+  useListener(window, updateTBodyHeight, "resize", true);
+  useEffect(updateTBodyHeight, [...dependencies, belowIds, tableId]);
+
+  return <div className="scrollable-table">{children}</div>;
+};
+
+export default ScrollableTable;

--- a/src/components/ScrollableTable/__snapshots__/ScrollableTable.test.tsx.snap
+++ b/src/components/ScrollableTable/__snapshots__/ScrollableTable.test.tsx.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`respects above spacing 1`] = `
+<div
+  role="main"
+>
+  <h1>
+    Above
+  </h1>
+  <div
+    class="scrollable-table"
+  >
+    <table
+      class=""
+      id="test-table"
+      role="grid"
+    >
+      <thead>
+        <tr
+          role="row"
+        >
+          <th
+            role="columnheader"
+          >
+            Fact
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        style="height: calc(100dvh - 9px); min-height: calc(100dvh - 9px)"
+      >
+        <tr
+          role="row"
+        >
+          <td
+            aria-hidden="false"
+            class=""
+            role="gridcell"
+          >
+            foo
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`respects below spacing 1`] = `
+<div
+  role="main"
+>
+  <h1>
+    Above
+  </h1>
+  <div
+    class="scrollable-table"
+  >
+    <table
+      class=""
+      id="test-table"
+      role="grid"
+    >
+      <thead>
+        <tr
+          role="row"
+        >
+          <th
+            role="columnheader"
+          >
+            Fact
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        style="height: calc(100dvh - 10px); min-height: calc(100dvh - 10px)"
+      >
+        <tr
+          role="row"
+        >
+          <td
+            aria-hidden="false"
+            class=""
+            role="gridcell"
+          >
+            foo
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div
+    id="footer"
+  >
+    <h2>
+      Below
+    </h2>
+  </div>
+</div>
+`;

--- a/src/components/ScrollableTable/index.ts
+++ b/src/components/ScrollableTable/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ScrollableTable";
+export type { Props as ScrollableTableProps } from "./ScrollableTable";

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -70,7 +70,7 @@ The sidepanel component should be used to show additional information relating t
 
 * **SidePanel.HeaderControls:** To show controls in the header, such as buttons or icons for actions like closing the panel.
 
-* **SidePanel.Sticky:** Can be wrapped around the header or footer to make them sticky when scrolling.
+* **SidePanel.Sticky:** Can be wrapped around the header or footer to make them sticky when scrolling. The scrollbar will use the full area of the side panel, not just the content area. To limit the scrollbar to the content area, use the `ScrollableContainer` component instead of this one.
 
 * **SidePanel.Content:** To show the main content of the side panel.
 

--- a/src/hooks/useId.ts
+++ b/src/hooks/useId.ts
@@ -3,7 +3,7 @@ import { useId as useIdReact } from "react";
 import { IS_DEV } from "utils";
 
 /**
- * @deprecated Code component is deprecated. Use CodeSnippet component or inline `<code>` instead.
+ * @deprecated Code component is deprecated. Use useId from React directly instead.
  */
 export const useId = () => {
   const id = useIdReact();

--- a/src/hooks/useListener.ts
+++ b/src/hooks/useListener.ts
@@ -60,6 +60,19 @@ export const useListener = (
       targetNode.addEventListener(eventType, eventListener.current, options);
       isListening.current = true;
     }
+
+    return () => {
+      // Unattach the listener if the component gets unmounted while
+      // listening.
+      if (targetNode && eventListener.current && isListening.current) {
+        targetNode.removeEventListener(
+          eventType,
+          eventListener.current,
+          options,
+        );
+        isListening.current = false;
+      }
+    };
   }, [
     callback,
     eventType,
@@ -74,19 +87,4 @@ export const useListener = (
     targetNode,
     throttle,
   ]);
-
-  useEffect(
-    () => () => {
-      // Unattach the listener if the component gets unmounted while
-      // listening.
-      if (targetNode && isListening.current) {
-        targetNode.removeEventListener(
-          eventType,
-          eventListener.current,
-          options,
-        );
-      }
-    },
-    [eventType, targetNode, options],
-  );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,8 @@ export { default as Panel } from "./components/Panel";
 export { default as PasswordToggle } from "./components/PasswordToggle";
 export { default as RadioInput } from "./components/RadioInput";
 export { default as Row } from "./components/Row";
+export { default as ScrollableContainer } from "./components/ScrollableContainer";
+export { default as ScrollableTable } from "./components/ScrollableTable";
 export { default as SearchAndFilter } from "./components/SearchAndFilter";
 export { default as SearchBox } from "./components/SearchBox";
 export { default as Select } from "./components/Select";
@@ -167,6 +169,8 @@ export type { PaginationProps } from "./components/Pagination";
 export type { PanelProps } from "./components/Panel";
 export type { RadioInputProps } from "./components/RadioInput";
 export type { RowProps } from "./components/Row";
+export type { ScrollableTableProps } from "./components/ScrollableTable";
+export type { ScrollableContainerProps } from "./components/ScrollableContainer";
 export type { SearchAndFilterProps } from "./components/SearchAndFilter";
 export type { SearchBoxProps } from "./components/SearchBox";
 export type { SelectProps } from "./components/Select";
@@ -211,7 +215,13 @@ export {
 } from "hooks";
 export type { WindowFitment } from "hooks";
 
-export { isNavigationAnchor, isNavigationButton } from "utils";
+export {
+  isNavigationAnchor,
+  isNavigationButton,
+  getElementAbsoluteHeight,
+  getAbsoluteHeightBelowById,
+  getParentsBottomSpacing,
+} from "utils";
 
 export type {
   ClassName,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,3 +52,38 @@ export const isNavigationButton = (link: NavLink): link is NavLinkButton =>
  */
 export const isReactNode = (element: unknown): element is ReactNode =>
   isValidElement(element);
+
+export const getElementAbsoluteHeight = (element: HTMLElement) => {
+  if (!element) {
+    return 0;
+  }
+  const style = window.getComputedStyle(element);
+  const margin = toFloat(style.marginTop) + toFloat(style.marginBottom);
+  const padding = toFloat(style.paddingTop) + toFloat(style.paddingBottom);
+  return element.offsetHeight + margin + padding + 1;
+};
+
+export const getAbsoluteHeightBelowById = (belowId: string): number => {
+  const element = belowId ? document.getElementById(belowId) : undefined;
+  if (!element) {
+    return 0;
+  }
+  return getElementAbsoluteHeight(element);
+};
+
+export const getParentsBottomSpacing = (element: Element): number => {
+  let sum = 0;
+  while (element.parentElement) {
+    element = element.parentElement;
+    const style = window.getComputedStyle(element);
+    const margin = toFloat(style.marginBottom);
+    const padding = toFloat(style.paddingBottom);
+    sum += margin + padding;
+  }
+  return sum;
+};
+
+export const toFloat = (value: string): number => {
+  const result = parseFloat(value);
+  return Number.isNaN(result) ? 0 : result;
+};


### PR DESCRIPTION
## Done

- added [scrollable container](https://react-components-1227.demos.haus/?path=/docs/components-scrollablecontainer--docs)  and [scrollable table](https://react-components-1227.demos.haus/?path=/docs/components-scrollabletable--docs) components

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- check scrollable container and scrollable table in storybook

### Percy steps

- New screens for scrollable container and scrollable table are expected
