### PR TITLE
fix(sidepanel): default size of sidepanel to be standard, allow for narrow and wide sizes

### DIFF
--- a/src/components/SidePanel/SidePanel.stories.tsx
+++ b/src/components/SidePanel/SidePanel.stories.tsx
@@ -20,7 +20,6 @@ const meta: Meta<typeof SidePanel> = {
         if (el) {
           const wrapper = el?.parentElement?.parentElement?.parentElement;
           const parent = wrapper?.parentElement?.parentElement?.parentElement;
-          console.log(wrapper);
           if (wrapper) {
             wrapper.style.setProperty("border", "0", "important");
           }
@@ -80,7 +79,7 @@ const StoryExample = (args: Story["args"]) => {
           hasError={args.hasError}
           parentId={parentId}
           pinned={args.pinned}
-          wide={args.wide}
+          width={args.width}
           className="u-no-padding--top u-no-padding--bottom"
         >
           <SidePanel.Sticky>
@@ -182,7 +181,7 @@ export const Default: Story = {
     pinned: false,
     loading: false,
     overlay: true,
-    wide: false,
+    width: "",
   },
   render: StoryExample,
 };
@@ -195,7 +194,7 @@ export const Pinned: Story = {
     pinned: true,
     loading: false,
     overlay: false,
-    wide: false,
+    width: "",
   },
   render: StoryExample,
   parameters: {
@@ -213,7 +212,7 @@ export const Loading: Story = {
     pinned: false,
     loading: true,
     overlay: true,
-    wide: false,
+    width: "",
   },
   render: StoryExample,
 };
@@ -226,7 +225,20 @@ export const Error: Story = {
     pinned: false,
     loading: false,
     overlay: true,
-    wide: false,
+    width: "",
+  },
+  render: StoryExample,
+};
+
+export const Narrow: Story = {
+  args: {
+    className: "",
+    hasError: false,
+    parentId: "l-application-narrow",
+    pinned: false,
+    loading: false,
+    overlay: true,
+    width: "narrow",
   },
   render: StoryExample,
 };
@@ -239,7 +251,7 @@ export const Wide: Story = {
     pinned: false,
     loading: false,
     overlay: true,
-    wide: true,
+    width: "wide",
   },
   render: StoryExample,
 };

--- a/src/components/SidePanel/SidePanel.test.tsx
+++ b/src/components/SidePanel/SidePanel.test.tsx
@@ -31,7 +31,7 @@ it("displays as pinned", () => {
 });
 
 it("displays as wide", () => {
-  render(<SidePanel wide>SidePanel</SidePanel>);
+  render(<SidePanel width="wide">SidePanel</SidePanel>);
   expect(screen.getByText("SidePanel")).toHaveClass("is-wide");
 });
 

--- a/src/components/SidePanel/SidePanel.tsx
+++ b/src/components/SidePanel/SidePanel.tsx
@@ -54,9 +54,9 @@ export type Props = {
   pinned?: boolean;
 
   /**
-   * Whether the side panel should be wide.
+   * Width of the side panel, available options are wide and narrow and the default.
    */
-  wide?: boolean;
+  width?: "wide" | "narrow" | "";
 };
 
 /**
@@ -106,7 +106,7 @@ const SidePanelComponent = ({
   loading = false,
   overlay,
   pinned,
-  wide,
+  width = "",
   parentId = "l-application",
 }: Props): React.JSX.Element => {
   const container = document.getElementById(parentId) || document.body;
@@ -120,8 +120,8 @@ const SidePanelComponent = ({
           })}
           aria-label="Side panel"
           pinned={pinned}
-          narrow={!wide}
-          wide={wide}
+          narrow={width === "narrow"}
+          wide={width === "wide"}
         >
           {loading ? (
             <div className="loading">

--- a/src/components/SidePanel/__snapshots__/SidePanel.test.tsx.snap
+++ b/src/components/SidePanel/__snapshots__/SidePanel.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`assembles complex structure 1`] = `
 <aside
   aria-label="Side panel"
-  class="l-aside side-panel is-narrow"
+  class="l-aside side-panel"
 >
   <div
     class="sticky-wrapper sticky-wrapper--top"


### PR DESCRIPTION
## Done

- fix(sidepanel) default size of sidepanel to be standard, allow for narrow and wide sizes

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- check [sidepanel component](https://react-components-1229.demos.haus/?path=/docs/components-sidepanel--docs) default to be standard size, with options for narrow and wide

### Percy steps

- sidepanel width should be a bit more as the narrow is not the default anymore.