### PR TITLE
feat(ToastNotification): Add 'caution' to toast notifications

### DIFF
--- a/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
@@ -43,6 +43,7 @@ const PreloadedList = () => {
       new Error("500 Internal Server Error"),
       "Please try again.",
     );
+    toastNotify.caution("You have unsaved changes.");
     toastNotify.toggleListView();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/Notifications/ToastNotification/ToastNotificationProvider.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotificationProvider.tsx
@@ -24,11 +24,19 @@ interface ToastNotificationHelper {
     message: ReactNode,
     actions?: NotificationAction[],
   ) => ToastNotificationType;
-  info: (message: ReactNode, title?: string) => ToastNotificationType;
+  info: (
+    message: ReactNode,
+    title?: string,
+    actions?: NotificationAction[],
+  ) => ToastNotificationType;
   failure: (
     title: string,
     error: unknown,
     message?: ReactNode,
+    actions?: NotificationAction[],
+  ) => ToastNotificationType;
+  caution: (
+    message: ReactNode,
     actions?: NotificationAction[],
   ) => ToastNotificationType;
   clear: (notification?: ToastNotificationType[]) => void;
@@ -54,11 +62,14 @@ const ToastNotificationContext = createContext<ToastNotificationHelper>({
   /** Show a success toast. Optionally pass actions. */
   success: () => initialNotification,
 
-  /** Show an info toast. Optionally pass a custom title. */
+  /** Show an info toast. Optionally pass a custom title and actions. */
   info: () => initialNotification,
 
   /** Show a failure toast with an error and optional message/actions. */
   failure: () => initialNotification,
+
+  /** Show a caution toast. Optionally pass actions. */
+  caution: () => initialNotification,
 
   /** Clear one or more specific toasts, or all if none provided. */
   clear: () => null,
@@ -79,11 +90,12 @@ const ToastNotificationContext = createContext<ToastNotificationHelper>({
 Wrap your application with this provider, and in any child component you can get the helper with `const toastNotify = useToastNotification()` to trigger notifications.
 Notifications automatically dismiss after a delay unless manually dismissed or expanded.
 
-| **Values**                        | **Description**                                                                 |
-|----------------------------------|---------------------------------------------------------------------------------|
+| **Values**                       | **Description**                                                                |
+|----------------------------------|--------------------------------------------------------------------------------|
 | `toastNotify.success()`          | Displays a success toast. Optionally accepts actions.                          |
 | `toastNotify.info()`             | Displays an info toast. Optionally accepts a custom title.                     |
 | `toastNotify.failure()`          | Displays a failure toast with an error and optional message or actions.        |
+| `toastNotify.caution()`          | Displays a caution toast. Optionally accepts actions.                          |
 | `toastNotify.clear()`            | Clears specific toasts, or all toasts if none are specified.                   |
 | `toastNotify.toggleListView()`   | Toggles the notification list view open or closed.                             |
 | `toastNotify.countBySeverity`    | Returns the count of notifications grouped by severity (e.g., success, info).  |
@@ -95,6 +107,7 @@ Some example usages:
 toastNotify.success("Your changes have been saved.");
 toastNotify.success("Your changes have been saved.", [{label: "Undo", onClick: () => console.log("Undo clicked")}]);
 ```
+
 2. **Show an info toast:**
 ```
 toastNotify.info("Your changes are syncing in the background.");
@@ -106,16 +119,25 @@ toastNotify.info("Your changes are syncing in the background.", "Syncing");
 toastNotify.failure("Save failed", new Error("500 Internal Server Error"), "Please try again.");
 toastNotify.failure("Save failed", new Error("500 Internal Server Error"), "Please try again.", [{label: "Retry", onClick: () => console.log("Retry clicked")}]);
 ```
-4. **Clear notifications:**
+
+4. **Show a caution toast:**
+```
+toastNotify.caution("Your changes have not been saved.");
+toastNotify.caution("Your changes have not been saved.", [{label: "Undo", onClick: () => console.log("Undo clicked")}]);
+```
+
+5. **Clear notifications:**
 ```
 toastNotify.clear(); // clears all toast notifications
 toastNotify.clear([notificationId]); // clears specific toast notifications
 ```
-5. **Toggle the notification list view:**
+
+6. **Toggle the notification list view:**
 ```
 toastNotify.toggleListView();
 ```
-6. **Get the count of notifications by severity:**
+
+7. **Get the count of notifications by severity:**
 ```
 const count = toastNotify.countBySeverity;
 console.log(count.positive);
@@ -236,6 +258,12 @@ const ToastNotificationProvider: FC<PropsWithChildren> = ({ children }) => {
         actions,
         type: NotificationSeverity.POSITIVE,
       } as NotificationType),
+    caution: (message, actions) =>
+      addNotification({
+        message,
+        actions,
+        type: NotificationSeverity.CAUTION,
+      }),
     clear,
     toggleListView,
     isListView: showList,


### PR DESCRIPTION
## Done

- Added "caution" severity level to toast notifications
- driveby: added actions to info notifications

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to ToastNotification in docs
- Ensure "Warning" notification is shown in docs
- Ensure caution icon is visible at the bottom
