### PR TITLE
feat(ToastNotification)!: Use named props and allow passing IDs in notify functions

### DIFF
--- a/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
@@ -36,14 +36,14 @@ const PreloadedList = () => {
   const toastNotify = useToastNotification();
 
   useEffect(() => {
-    toastNotify.success("Settings saved successfully");
-    toastNotify.info("Your changes are syncing in the background");
-    toastNotify.failure(
-      "Save failed",
-      new Error("500 Internal Server Error"),
-      "Please try again.",
-    );
-    toastNotify.caution("You have unsaved changes.");
+    toastNotify.success({ message: "Settings saved successfully" });
+    toastNotify.info({ message: "Your changes are syncing in the background" });
+    toastNotify.failure({
+      title: "Save failed",
+      error: new Error("500 Internal Server Error"),
+      message: "Please try again.",
+    });
+    toastNotify.caution({ message: "You have unsaved changes." });
     toastNotify.toggleListView();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -61,31 +61,36 @@ const PreloadedList = () => {
     >
       <Button
         onClick={() =>
-          toastNotify.success("Your changes have been saved.", [
-            { label: "Undo", onClick: () => console.log("Undo clicked") },
-          ])
+          toastNotify.success({
+            message: "Your changes have been saved.",
+            actions: [
+              { label: "Undo", onClick: () => console.log("Undo clicked") },
+            ],
+          })
         }
       >
         Add Success
       </Button>
       <Button
         onClick={() =>
-          toastNotify.info(
-            "Your changes are syncing in the background.",
-            "Syncing",
-          )
+          toastNotify.info({
+            message: "Your changes are syncing in the background.",
+            title: "Syncing",
+          })
         }
       >
         Add Info
       </Button>
       <Button
         onClick={() =>
-          toastNotify.failure(
-            "Save failed",
-            new Error("500 Internal Server Error"),
-            "Please try again.",
-            [{ label: "Retry", onClick: () => console.log("Retry clicked") }],
-          )
+          toastNotify.failure({
+            title: "Save failed",
+            error: new Error("500 Internal Server Error"),
+            message: "Please try again.",
+            actions: [
+              { label: "Retry", onClick: () => console.log("Retry clicked") },
+            ],
+          })
         }
       >
         Add Error


### PR DESCRIPTION
# ⚠️⚠️ BREAKING CHANGE ⚠️⚠️

## Done

- Use a common set of named props for notify (`success()`, `failure()` etc.) functions
  - Added an extra `error` prop to error notifications to preserve functionality
- Allow passing an ID in notify functions (needed when notifications from backends have IDs used for dismissing)

### Migration steps for notify functions

Let's say we have a success notification like so:

```tsx
const notify = useToastNotifications();

notify.success("Your settings were updated.", [() => goToSettingsPage()], "Success")
```

Using the new named props, it would look like this after migration:

```tsx
const notify = useToastNotifications();

notify.success({ message: "Your settings were updated.", actions: [() => goToSettingsPage()], title: "Success" })
```

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- In your own project, try giving a notification an ID, and `console.log()` it in the onDismiss callback
- Make sure the logged ID is correct.

### Percy steps

- No visual changes expected here
