### PR TITLE
feat(ToastNotifications): Allow id to be overwritten by notify functions

### DIFF
--- a/src/components/NotificationProvider/index.ts
+++ b/src/components/NotificationProvider/index.ts
@@ -3,7 +3,7 @@ export {
   NotificationProvider,
   useNotify,
 } from "./NotificationProvider";
-export { info, success, failure, queue } from "./messageBuilder";
+export { info, success, failure, caution, queue } from "./messageBuilder";
 export type {
   NotificationAction,
   NotificationType,

--- a/src/components/NotificationProvider/messageBuilder.tsx
+++ b/src/components/NotificationProvider/messageBuilder.tsx
@@ -10,10 +10,15 @@ export const queue = (notification: NotificationType): QueuedNotification => {
   return { state: { queuedNotification: notification } };
 };
 
-export const info = (message: ReactNode, title?: string): NotificationType => {
+export const info = (
+  message: ReactNode,
+  title?: string,
+  actions?: NotificationAction[],
+): NotificationType => {
   return {
     message,
     title,
+    actions,
     type: NotificationSeverity.INFORMATION,
   };
 };
@@ -21,10 +26,12 @@ export const info = (message: ReactNode, title?: string): NotificationType => {
 export const success = (
   message: ReactNode,
   title?: string,
+  actions?: NotificationAction[],
 ): NotificationType => {
   return {
     message,
     title,
+    actions,
     type: NotificationSeverity.POSITIVE,
   };
 };
@@ -37,15 +44,33 @@ export const failure = (
 ): NotificationType => {
   return {
     actions,
-    message:
-      error && error instanceof Error ? (
-        <>
-          {message} {error.message}
-        </>
-      ) : (
-        message
-      ),
+    message: formatErrorMessage(message, error),
     title,
     type: NotificationSeverity.NEGATIVE,
   };
+};
+
+export const caution = (
+  message: ReactNode,
+  title?: string,
+  actions?: NotificationAction[],
+): NotificationType => {
+  return {
+    message,
+    actions,
+    title,
+    type: NotificationSeverity.CAUTION,
+  };
+};
+
+export const formatErrorMessage = (message?: ReactNode, error?: unknown) => {
+  if (error && error instanceof Error) {
+    return (
+      <>
+        {message} {error.message}
+      </>
+    );
+  } else {
+    return message;
+  }
 };

--- a/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
@@ -90,6 +90,9 @@ const PreloadedList = () => {
       >
         Add Error
       </Button>
+      <Button onClick={() => toastNotify.caution("You have unsaved changes")}>
+        Add Warning
+      </Button>
       <Button onClick={toastNotify.toggleListView}>Toggle List View</Button>
     </div>
   );

--- a/src/components/Notifications/ToastNotification/ToastNotificationProvider.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotificationProvider.tsx
@@ -3,7 +3,12 @@ import type {
   NotificationType,
 } from "components/NotificationProvider";
 import type { ValueOf } from "types";
-import { failure } from "components/NotificationProvider";
+import {
+  failure,
+  info,
+  caution,
+  success,
+} from "components/NotificationProvider";
 import { NotificationSeverity } from "components/Notifications";
 import ToastNotification from "./ToastNotification";
 import ToastNotificationList from "./ToastNotificationList";
@@ -28,22 +33,26 @@ interface ToastNotificationHelper {
     message: ReactNode,
     actions?: NotificationAction[],
     title?: string,
+    id?: ToastNotificationType["id"],
   ) => ToastNotificationType;
   info: (
     message: ReactNode,
     title?: string,
     actions?: NotificationAction[],
+    id?: ToastNotificationType["id"],
   ) => ToastNotificationType;
   failure: (
     title: string,
     error: unknown,
     message?: ReactNode,
     actions?: NotificationAction[],
+    id?: ToastNotificationType["id"],
   ) => ToastNotificationType;
   caution: (
     message: ReactNode,
     actions?: NotificationAction[],
     title?: string,
+    id?: ToastNotificationType["id"],
   ) => ToastNotificationType;
   clear: (notification?: ToastNotificationType[]) => void;
   toggleListView: () => void;
@@ -199,12 +208,16 @@ const ToastNotificationProvider: FC<PropsWithChildren<Props>> = ({
   };
 
   const addNotification = (
-    notification: NotificationType & { error?: unknown },
+    notification: NotificationType & { error?: unknown } & {
+      id?: ToastNotificationType["id"];
+    },
   ) => {
     const notificationToAdd = {
       ...notification,
       timestamp: new Date().toLocaleString(),
-      id: Date.now().toString() + (Math.random() + 1).toString(36).substring(7),
+      id:
+        notification.id ??
+        Date.now().toString() + (Math.random() + 1).toString(36).substring(7),
     };
 
     setNotifications((prev) => {
@@ -262,29 +275,14 @@ const ToastNotificationProvider: FC<PropsWithChildren<Props>> = ({
 
   const helper: ToastNotificationHelper = {
     notifications,
-    failure: (title, error, message, actions) =>
-      addNotification(failure(title, error, message, actions)),
-    info: (message, title, actions) =>
-      addNotification({
-        message,
-        actions,
-        title,
-        type: NotificationSeverity.INFORMATION,
-      }),
-    success: (message, actions, title) =>
-      addNotification({
-        message,
-        actions,
-        title,
-        type: NotificationSeverity.POSITIVE,
-      } as NotificationType),
-    caution: (message, actions, title) =>
-      addNotification({
-        message,
-        actions,
-        title,
-        type: NotificationSeverity.CAUTION,
-      }),
+    failure: (title, error, message, actions, id) =>
+      addNotification({ ...failure(title, error, message, actions), id }),
+    info: (message, title, actions, id) =>
+      addNotification({ ...info(message, title, actions), id }),
+    success: (message, actions, title, id) =>
+      addNotification({ ...success(message, title, actions), id }),
+    caution: (message, actions, title, id) =>
+      addNotification({ ...caution(message, title, actions), id }),
     clear,
     toggleListView,
     isListView: showList,


### PR DESCRIPTION
## Done

- Added id prop to `success`, `failure`, `info`, and `caution` methods from `ToastNotificationProvider`
- (driveby) Use `messageBuilder` functions when adding toast notifications
- (driveby) extract error message formatting from `failure` message builder
- (driveby) add button to storybook to add a warning notification

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### Percy steps

- Go to toast notifications
- Click "Add warning"
- Ensure a caution/warning notification is added to the list
- Ensure the counter for warnings is incremented by 1

