### PR TITLE
fix: The responsive behaviour of the `MainTable` wrapped inside a `ScrollableTable` is not equivalent to the default case

### DIFF
--- a/src/components/ScrollableTable/ScrollableTable.scss
+++ b/src/components/ScrollableTable/ScrollableTable.scss
@@ -45,12 +45,12 @@
         display: block;
       }
 
-      tbody tr {
-        display: block;
+      tbody {
+        display: grid;
       }
 
-      tbody tr:first-child {
-        margin-top: $spv--x-large;
+      tbody tr {
+        display: block;
       }
     }
   }

--- a/src/components/ScrollableTable/ScrollableTable.stories.tsx
+++ b/src/components/ScrollableTable/ScrollableTable.stories.tsx
@@ -104,5 +104,10 @@ export const Responsive: Story = {
         </>
       ),
     },
+    // Percy settings to capture at multiple widths
+    percy: {
+      responsiveSnapshotCapture: true,
+      widths: [768, 1280],
+    },
   },
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,8 +59,7 @@ export const getElementAbsoluteHeight = (element: HTMLElement) => {
   }
   const style = window.getComputedStyle(element);
   const margin = toFloat(style.marginTop) + toFloat(style.marginBottom);
-  const padding = toFloat(style.paddingTop) + toFloat(style.paddingBottom);
-  return element.offsetHeight + margin + padding + 1;
+  return element.offsetHeight + margin + 1;
 };
 
 export const getAbsoluteHeightBelowById = (belowId: string): number => {


### PR DESCRIPTION
## Done

- Fixes linked issue (#1245).
- Fixes a bug that causes padding to be added twice in `getElementAbsoluteHeight` helper function.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to "ScrollableTable" -> "Responsive" example in Storybook.
- Resize the window width and check that the issue described in #1245 is solved.

### Percy steps

The only visual change expected is the capture of two snapshots of the "Responsive" story for the `ScrollableTable`, at 768px and 1280px width.

## Fixes

Fixes: #1245