### PR TITLE
feat(MultiSelect): add id in props

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -58,6 +58,7 @@ export const SearchExample: Story = {
         group: i % 2 === 0 ? "Group 1" : "Group 2",
       })),
     ],
+    id: "search-id",
   },
 };
 
@@ -120,5 +121,6 @@ export const WithoutSorting: Story = {
     variant: "condensed",
     isSortedAlphabetically: false,
     hasSelectedItemsFirst: false,
+    id: "external-id",
   },
 };

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -34,6 +34,7 @@ export type MultiSelectProps = {
   scrollOverflow?: boolean;
   isSortedAlphabetically?: boolean;
   hasSelectedItemsFirst?: boolean;
+  id?: string;
 };
 
 type ValueSet = Set<MultiSelectItem["value"]>;
@@ -203,6 +204,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   scrollOverflow = false,
   isSortedAlphabetically = true,
   hasSelectedItemsFirst = true,
+  id,
 }: MultiSelectProps) => {
   const buttonRef = useRef(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -286,7 +288,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
             externallyControlled
             aria-controls={dropdownId}
             aria-expanded={isDropdownOpen}
-            id={inputId}
+            id={id ?? inputId}
             role="combobox"
             aria-label={label || placeholder || "Search"}
             disabled={disabled}
@@ -328,6 +330,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               }
             }}
             ref={buttonRef}
+            id={id}
           >
             <span className="multi-select__condensed-text">
               {listSelected && selectedItems.length > 0


### PR DESCRIPTION
## Done

- Add id in props, set id on SearchBox or button depending on variant.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check that the id is set correctly when existing.
- Check that useId is used on SearchBox when id is not set if variant is search.
- Check that no id is set on button when id is not set if variant is not search.

### Percy steps

- No visual changes expected

