### PR TITLE
fix(MultiSelect): disabled for non search variant

### DIFF
--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -149,4 +149,9 @@ $dropdown-max-height: 20rem;
       transform: translateY(-50%) rotate(0);
     }
   }
+
+  &[disabled],
+  &[disabled="disabled"] {
+    border-top: 0;
+  }
 }

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -124,3 +124,10 @@ export const WithoutSorting: Story = {
     id: "external-id",
   },
 };
+
+export const Disabled: Story = {
+  args: {
+    ...CondensedExample.args,
+    disabled: true,
+  },
+};

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -331,6 +331,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
             }}
             ref={buttonRef}
             id={id}
+            disabled={disabled}
           >
             <span className="multi-select__condensed-text">
               {listSelected && selectedItems.length > 0


### PR DESCRIPTION
## Done

- fix(MultiSelect): disabled for non search variant

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Existing stories should be unchanged
- New story with disabled: true should render a disabled button

### Percy steps

- When MultiSelect is disabled and variant is not search, button is disabled 
- No visual changes expected for search variant

