### PR TITLE
feat(MultiSelect): implement help

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -131,3 +131,14 @@ export const Disabled: Story = {
     disabled: true,
   },
 };
+
+export const HelpText: Story = {
+  args: {
+    ...CondensedExample.args,
+    help: (
+      <span>
+        This is a help text, that should appear underneath the component.
+      </span>
+    ),
+  },
+};

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -321,3 +321,40 @@ it("can render without sorting selected items first", async () => {
       ),
   );
 });
+
+it("can render help", async () => {
+  const { container } = render(
+    <MultiSelect
+      items={items}
+      selectedItems={[items[1]]}
+      help={<span>This is a help text</span>}
+    />,
+  );
+
+  const helpTextList = container.querySelectorAll(".p-form-help-text");
+  expect(helpTextList).toHaveLength(1);
+  const helpText = helpTextList[0];
+  expect(helpText).toBeVisible();
+});
+
+it("doesn't render help", async () => {
+  const { container } = render(
+    <MultiSelect items={items} selectedItems={[items[1]]} />,
+  );
+  expect(container.querySelectorAll(".p-form-help-text")).toHaveLength(0);
+});
+
+it("can add additional classes to help", () => {
+  const { container } = render(
+    <MultiSelect
+      items={items}
+      selectedItems={[items[1]]}
+      help={<span>This is a help text</span>}
+      helpClassName="additional-help-text-class"
+    />,
+  );
+  expect(container.querySelectorAll(".p-form-help-text")).toHaveLength(1);
+  expect(container.querySelector(".p-form-help-text")).toHaveClass(
+    "additional-help-text-class",
+  );
+});


### PR DESCRIPTION
## Done

- feat(MultiSelect): implement help as a helper text underneath the component

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check that MultiSelect with help displays a helper text
- Check that MultiSelect without help remains unchanged

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

