### PR TITLE
feat(ColumnSelector): create a component that can toggle columns of a table

### DIFF
--- a/src/components/ColumnSelector/ColumnSelector.scss
+++ b/src/components/ColumnSelector/ColumnSelector.scss
@@ -1,0 +1,15 @@
+@import "vanilla-framework";
+@include vf-b-placeholders;
+@include vf-p-icon-settings;
+
+.column-selector-column-list {
+  min-width: 12rem;
+
+  .p-checkbox {
+    margin-left: 1rem;
+  }
+
+  .size-hidden > * {
+    opacity: 0.33;
+  }
+}

--- a/src/components/ColumnSelector/ColumnSelector.stories.tsx
+++ b/src/components/ColumnSelector/ColumnSelector.stories.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import ColumnSelector from "./ColumnSelector";
+import MainTable from "components/MainTable";
+import {
+  getRows,
+  FILESYSTEM,
+  SNAPSHOTS,
+  USER_HIDEABLE_COLUMNS,
+  DESCRIPTION,
+  CLUSTER_MEMBER,
+  COLUMN_HEADERS,
+} from "./ColumnSelectorStoriesHelper";
+import {
+  visibleHeaderColumns,
+  visibleRowColumns,
+} from "./columnSelectorHelper";
+
+const meta: Meta<typeof ColumnSelector> = {
+  component: ColumnSelector,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ColumnSelector>;
+
+export const Default: Story = {
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [userHidden, setUserHidden] = useState<string[]>([
+      FILESYSTEM,
+      SNAPSHOTS,
+      CLUSTER_MEMBER,
+    ]);
+
+    const sizeHidden = [DESCRIPTION];
+
+    const hiddenColumns = userHidden.concat(sizeHidden);
+    const ROWS = getRows();
+
+    const setUserHiddenAndSaveInLocalStorage = (columns: string[]) => {
+      setUserHidden(columns);
+    };
+
+    const displayedRows = visibleRowColumns(ROWS, hiddenColumns);
+    const displayedHeaders = visibleHeaderColumns(
+      COLUMN_HEADERS.map((t) => {
+        return {
+          content: t,
+          sortKey: t,
+        };
+      }),
+      hiddenColumns,
+    );
+
+    return (
+      <>
+        <ColumnSelector
+          columns={USER_HIDEABLE_COLUMNS}
+          userHidden={userHidden}
+          sizeHidden={sizeHidden}
+          setUserHidden={setUserHiddenAndSaveInLocalStorage}
+        />
+        <MainTable rows={displayedRows} headers={displayedHeaders} />
+      </>
+    );
+  },
+  name: "Default",
+};

--- a/src/components/ColumnSelector/ColumnSelector.test.tsx
+++ b/src/components/ColumnSelector/ColumnSelector.test.tsx
@@ -1,0 +1,313 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import ColumnSelector, { Props as ColumnSelectorProps } from "./ColumnSelector";
+import { MainTableHeader, MainTableRow } from "components/MainTable/MainTable";
+import {
+  visibleHeaderColumns,
+  visibleRowColumns,
+} from "./columnSelectorHelper";
+
+// Child components are mocked here to test the ColumnSelector in isolation.
+jest.mock("classnames", () =>
+  jest.fn((...args) => args.filter(Boolean).join(" ")),
+);
+
+jest.mock("../Tooltip", () => {
+  return ({
+    children,
+    message,
+  }: {
+    children: React.ReactElement;
+    message: string;
+  }) => (
+    <div data-testid="tooltip">
+      <div data-testid="tooltip-message">{message}</div>
+      {children}
+    </div>
+  );
+});
+
+jest.mock("../ContextualMenu", () => {
+  return ({
+    children,
+    title,
+    toggleLabel,
+  }: {
+    children: React.ReactNode;
+    title: string;
+    toggleLabel: React.ReactNode;
+  }) => (
+    <div data-testid="contextual-menu">
+      <div data-testid="contextual-menu-toggle">{toggleLabel}</div>
+      <h1 data-testid="contextual-menu-title">{title}</h1>
+      {children}
+    </div>
+  );
+});
+
+jest.mock("../Icon", () => {
+  return ({ name }: { name: string }) => <span data-testid="icon">{name}</span>;
+});
+
+jest.mock("../CheckboxInput", () => {
+  return ({
+    label,
+    checked,
+    indeterminate,
+    onChange,
+    disabled,
+    "aria-label": ariaLabel,
+  }: {
+    label: string;
+    checked: boolean;
+    indeterminate: boolean;
+    onChange: () => void;
+    disabled: boolean;
+    "aria-label": string;
+  }) => (
+    <label>
+      <input
+        type="checkbox"
+        aria-label={ariaLabel || label}
+        checked={!!checked}
+        data-indeterminate={indeterminate ? "true" : "false"}
+        onChange={onChange}
+        disabled={!!disabled}
+      />
+      {label}
+    </label>
+  );
+});
+
+describe("ColumnSelector", () => {
+  const mockSetUserHidden = jest.fn();
+  const defaultProps: ColumnSelectorProps = {
+    columns: ["Name", "Status", "Role", "Last Seen"],
+    userHidden: [],
+    sizeHidden: [],
+    setUserHidden: mockSetUserHidden,
+  };
+
+  beforeEach(() => {
+    mockSetUserHidden.mockClear();
+  });
+
+  it("should render the toggle icon and menu title", () => {
+    render(<ColumnSelector {...defaultProps} />);
+    expect(screen.getByTestId("icon")).toHaveTextContent("settings");
+    expect(screen.getByTestId("contextual-menu-title")).toHaveTextContent(
+      "Columns",
+    );
+  });
+
+  it("should display the correct count of selected columns in the main checkbox label", () => {
+    render(<ColumnSelector {...defaultProps} userHidden={["Role"]} />);
+    expect(
+      screen.getByLabelText("3 out of 4 columns selected"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render a checkbox for each column", () => {
+    render(<ColumnSelector {...defaultProps} />);
+    defaultProps.columns.forEach((column) => {
+      expect(screen.getByLabelText(column)).toBeInTheDocument();
+    });
+  });
+
+  describe("Header Checkbox (Toggle All)", () => {
+    it("should be checked when all columns are visible", () => {
+      render(<ColumnSelector {...defaultProps} userHidden={[]} />);
+      const mainCheckbox = screen.getByLabelText("4 out of 4 columns selected");
+      expect(mainCheckbox).toBeChecked();
+      expect(mainCheckbox.getAttribute("data-indeterminate")).toBe("false");
+    });
+
+    it("should be indeterminate when some columns are visible", () => {
+      render(<ColumnSelector {...defaultProps} userHidden={["Name"]} />);
+      const mainCheckbox = screen.getByLabelText("3 out of 4 columns selected");
+      expect(mainCheckbox).not.toBeChecked();
+      expect(mainCheckbox.getAttribute("data-indeterminate")).toBe("true");
+    });
+
+    it("should call setUserHidden with all columns (to hide all) when clicked while all are visible", () => {
+      render(<ColumnSelector {...defaultProps} userHidden={[]} />);
+      const mainCheckbox = screen.getByLabelText("4 out of 4 columns selected");
+      fireEvent.click(mainCheckbox);
+      expect(mockSetUserHidden).toHaveBeenCalledWith(defaultProps.columns);
+    });
+
+    it("should call setUserHidden with an empty array (to show all) when clicked while some columns are hidden", () => {
+      render(
+        <ColumnSelector {...defaultProps} userHidden={["Name", "Status"]} />,
+      );
+      const mainCheckbox = screen.getByLabelText("2 out of 4 columns selected");
+      fireEvent.click(mainCheckbox);
+      expect(mockSetUserHidden).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe("Individual Column Checkboxes", () => {
+    it("should be checked for a visible column and unchecked for a hidden one", () => {
+      render(<ColumnSelector {...defaultProps} userHidden={["Role"]} />);
+      expect(screen.getByLabelText("Name")).toBeChecked();
+      expect(screen.getByLabelText("Role")).not.toBeChecked();
+    });
+
+    it("should call setUserHidden to hide a column when a visible column is clicked", () => {
+      render(<ColumnSelector {...defaultProps} userHidden={[]} />);
+      fireEvent.click(screen.getByLabelText("Role"));
+      expect(mockSetUserHidden).toHaveBeenCalledWith(["Role"]);
+    });
+
+    it("should call setUserHidden to show a column when a hidden column is clicked", () => {
+      render(
+        <ColumnSelector {...defaultProps} userHidden={["Name", "Role"]} />,
+      );
+      fireEvent.click(screen.getByLabelText("Role"));
+      // It should return the array without 'Role'
+      expect(mockSetUserHidden).toHaveBeenCalledWith(["Name"]);
+    });
+  });
+
+  describe("Size-Hidden Columns", () => {
+    it("should disable the checkbox for a size-hidden column", () => {
+      render(<ColumnSelector {...defaultProps} sizeHidden={["Last Seen"]} />);
+      expect(screen.getByLabelText("Last Seen")).toBeDisabled();
+      expect(screen.getByLabelText("Name")).not.toBeDisabled();
+    });
+
+    it("should wrap the size-hidden column in a Tooltip with the correct message", () => {
+      render(<ColumnSelector {...defaultProps} sizeHidden={["Last Seen"]} />);
+      const checkbox = screen.getByLabelText("Last Seen");
+
+      // Check that the checkbox is inside a tooltip mock
+      const tooltip = checkbox.closest('[data-testid="tooltip"]');
+      expect(tooltip).toBeInTheDocument();
+
+      // Check the content of the mocked tooltip message
+      const messageElement = screen.getByTestId("tooltip-message");
+      expect(messageElement).toHaveTextContent(
+        /Screen is too narrow to fit the column/,
+      );
+      expect(messageElement).toHaveTextContent(
+        /Disable columns above or use a bigger screen/,
+      );
+    });
+  });
+});
+
+describe("visibleRowColumns", () => {
+  const mockRows: MainTableRow[] = [
+    {
+      id: "row1",
+      columns: [
+        { "aria-label": "Name", content: "First" },
+        { "aria-label": "Status", content: "Online" },
+        { "aria-label": "Role", content: "Admin" },
+      ],
+    },
+    {
+      id: "row2",
+      columns: [
+        { "aria-label": "Name", content: "Second" },
+        { "aria-label": "Status", content: "Offline" },
+        { "aria-label": "Role", content: "User" },
+      ],
+    },
+  ];
+
+  it("should not remove any columns if hiddenCols is empty", () => {
+    const result = visibleRowColumns(mockRows, []);
+    expect(result).toEqual(mockRows);
+  });
+
+  it("should remove a single specified column from all rows", () => {
+    const hiddenCols = ["Status"];
+    const result = visibleRowColumns(mockRows, hiddenCols);
+
+    expect(result[0].columns).toHaveLength(2);
+    expect(
+      result[0].columns.find((c) => c["aria-label"] === "Status"),
+    ).toBeUndefined();
+    expect(result[1].columns).toHaveLength(2);
+    expect(
+      result[1].columns.find((c) => c["aria-label"] === "Status"),
+    ).toBeUndefined();
+  });
+
+  it("should remove multiple specified columns from all rows", () => {
+    const hiddenCols = ["Name", "Role"];
+    const result = visibleRowColumns(mockRows, hiddenCols);
+
+    expect(result[0].columns).toHaveLength(1);
+    expect(result[0].columns[0]["aria-label"]).toBe("Status");
+    expect(result[1].columns).toHaveLength(1);
+    expect(result[1].columns[0]["aria-label"]).toBe("Status");
+  });
+
+  it("should return rows unchanged if hidden columns are not found", () => {
+    const hiddenCols = ["Location", "Last Seen"];
+    const result = visibleRowColumns(mockRows, hiddenCols);
+    expect(result).toEqual(mockRows);
+  });
+
+  it("should return an empty array if the input rows array is empty", () => {
+    const result = visibleRowColumns([], ["Name"]);
+    expect(result).toEqual([]);
+  });
+
+  it("should handle rows that have no columns", () => {
+    const rowsWithEmptyColumns: MainTableRow[] = [{ id: "row3", columns: [] }];
+    const result = visibleRowColumns(rowsWithEmptyColumns, ["Name"]);
+    expect(result).toEqual(rowsWithEmptyColumns);
+  });
+});
+
+describe("visibleHeaderColumns", () => {
+  const mockHeaders: MainTableHeader[] = [
+    { content: "Name", sortKey: "Name" },
+    { content: "Status", sortKey: "Status" },
+    { content: "Role", sortKey: "Role" },
+    { content: <button>Actions</button>, sortKey: "actions" },
+  ];
+
+  it("should not filter any headers if hiddenCols is empty", () => {
+    const result = visibleHeaderColumns(mockHeaders, []);
+    expect(result).toEqual(mockHeaders);
+  });
+
+  it("should filter out a single specified header", () => {
+    const hiddenCols = ["Status"];
+    const result = visibleHeaderColumns(mockHeaders, hiddenCols);
+    expect(result).toHaveLength(3);
+    expect(result.find((h) => h.content === "Status")).toBeUndefined();
+  });
+
+  it("should filter out multiple specified headers", () => {
+    const hiddenCols = ["Name", "Role"];
+    const result = visibleHeaderColumns(mockHeaders, hiddenCols);
+    expect(result).toHaveLength(2);
+    expect(result.map((h) => h.content)).not.toContain("Name");
+    expect(result.map((h) => h.content)).not.toContain("Role");
+  });
+
+  it("should never filter headers where content is not a string", () => {
+    const hiddenCols = ["Name", "Status", "Role", "actions"];
+    const result = visibleHeaderColumns(mockHeaders, hiddenCols);
+    expect(result).toHaveLength(1);
+    expect(typeof result[0].content).toBe("object");
+  });
+
+  it("should return headers unchanged if hidden columns are not found", () => {
+    const hiddenCols = ["Location", "IP Address"];
+    const result = visibleHeaderColumns(mockHeaders, hiddenCols);
+    expect(result).toEqual(mockHeaders);
+  });
+
+  it("should return an empty array if the input headers array is empty", () => {
+    const result = visibleHeaderColumns([], ["Name"]);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/components/ColumnSelector/ColumnSelector.tsx
+++ b/src/components/ColumnSelector/ColumnSelector.tsx
@@ -1,0 +1,128 @@
+import React, { HTMLProps, ReactElement } from "react";
+import { ClassName, PropsWithSpread } from "types";
+import classnames from "classnames";
+import Tooltip from "components/Tooltip";
+import ContextualMenu from "components/ContextualMenu";
+import Icon from "components/Icon";
+import CheckboxInput from "components/CheckboxInput";
+import "./ColumnSelector.scss";
+
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Optional classes to add to the contextual menu.
+     */
+    className?: ClassName;
+    /**
+     * Columns of the table that can be hidden by the user
+     */
+    columns: string[];
+    /**
+     * Columns of the table hidden by the user
+     */
+    userHidden: string[];
+    /**
+     * Columns of the table hidden because the available space is not sufficient
+     */
+    sizeHidden: string[];
+    /**
+     * Function that sets columns hidden by the user
+     */
+    setUserHidden: (columns: string[]) => void;
+  },
+  HTMLProps<HTMLElement>
+>;
+
+/**
+This is a [React](https://reactjs.org/) component that extends from the Vanilla [Select](https://vanillaframework.io/docs/base/forms#select) element.
+The aim of this component is to provide a dropdown menu to control the visibility of columns within a table.
+This component allows users to customize their view, hiding or showing columns as needed, while also handling columns that are automatically hidden on smaller screens.
+*/
+const ColumnSelector = ({
+  className,
+  columns,
+  userHidden,
+  sizeHidden,
+  setUserHidden,
+}: Props): React.JSX.Element => {
+  const selectedCount = columns.length - userHidden.length;
+
+  const toggleHiddenColumn = (column: string): void => {
+    if (userHidden.includes(column)) {
+      setUserHidden(userHidden.filter((c) => c !== column));
+    } else {
+      setUserHidden([...userHidden, column]);
+    }
+  };
+
+  const wrapTooltip = (element: ReactElement, column: string): ReactElement => {
+    if (!sizeHidden.includes(column)) return element;
+
+    return (
+      <Tooltip
+        message={
+          <>
+            Screen is too narrow to fit the column.
+            <br />
+            Disable columns above or use a bigger screen.
+          </>
+        }
+        position="left"
+      >
+        {element}
+      </Tooltip>
+    );
+  };
+
+  return (
+    <ContextualMenu
+      className={classnames(className, "column-selector-toggle")}
+      dropdownProps={{ "aria-label": "columns menu" }}
+      position="right"
+      toggleClassName="has-icon"
+      toggleProps={{
+        "aria-label": "Columns selection toggle",
+      }}
+      toggleLabel={<Icon name="settings" />}
+      toggleAppearance="base"
+      title="Columns"
+    >
+      <div className="column-selector-column-list">
+        <CheckboxInput
+          checked={userHidden.length === 0}
+          indeterminate={selectedCount > 0 && selectedCount < columns.length}
+          label={`${selectedCount} out of ${columns.length} columns selected`}
+          onChange={() => {
+            if (userHidden.length > 0) {
+              setUserHidden([]);
+            } else {
+              setUserHidden(columns);
+            }
+          }}
+        />
+        <hr />
+        {columns.map((column) => (
+          <div key={column}>
+            {wrapTooltip(
+              <CheckboxInput
+                aria-label={column}
+                labelClassName={classnames({
+                  "size-hidden": sizeHidden.includes(column),
+                })}
+                checked={!userHidden.includes(column)}
+                label={column}
+                onChange={() => {
+                  toggleHiddenColumn(column);
+                }}
+                disabled={sizeHidden.includes(column)}
+              />,
+              column,
+            )}
+          </div>
+        ))}
+      </div>
+    </ContextualMenu>
+  );
+};
+
+export default ColumnSelector;

--- a/src/components/ColumnSelector/ColumnSelectorStoriesHelper.tsx
+++ b/src/components/ColumnSelector/ColumnSelectorStoriesHelper.tsx
@@ -1,0 +1,190 @@
+import React from "react";
+import { MainTableRow } from "components/MainTable/MainTable";
+
+export const STATUS = "Status";
+export const NAME = "Name";
+export const TYPE = "Type";
+export const CLUSTER_MEMBER = "Cluster member";
+export const DESCRIPTION = "Description";
+export const MEMORY = "Memory";
+export const FILESYSTEM = "Root filesystem";
+export const IPV4 = "IPv4";
+export const IPV6 = "IPv6";
+export const SNAPSHOTS = "Snapshots";
+export const PROJECT = "Project";
+
+export const COLUMN_HEADERS = [
+  NAME,
+  TYPE,
+  PROJECT,
+  CLUSTER_MEMBER,
+  MEMORY,
+  FILESYSTEM,
+  DESCRIPTION,
+  IPV4,
+  IPV6,
+  SNAPSHOTS,
+  STATUS,
+];
+
+// All columns except name and status
+export const USER_HIDEABLE_COLUMNS = [
+  TYPE,
+  PROJECT,
+  CLUSTER_MEMBER,
+  MEMORY,
+  FILESYSTEM,
+  DESCRIPTION,
+  IPV4,
+  IPV6,
+  SNAPSHOTS,
+];
+
+const INSTANCES = [
+  {
+    name: "darling-bunny",
+    type: "VM",
+    project: "default",
+    clusterMember: "-",
+    memory: "1.4 GiB of 1.9 GiB",
+    fileSystem: "3.3 GiB of 9.5 GiB",
+    description:
+      "Meet darling-bunny, a speedy little instance hopping along with your latest project. It's got the ears for listening to your commands and the nose for sniffing out the best performance. Handle with care, and remember to feed it plenty of CPU.",
+    ipv4: ["10.138.32.6"],
+    ipv6: [
+      "fd42:6a38:859a:587d:216:3eff:fe43:167e",
+      "fe80::216:3eff:fe43:167e",
+      "fe80::1050:62ff:feb2:964c",
+    ],
+    status: "Running",
+  },
+  {
+    name: "sassy-salamander",
+    type: "VM",
+    project: "default",
+    clusterMember: "-",
+    memory: "1.4 GiB of 1.9 GiB",
+    fileSystem: "3.3 GiB of 9.5 GiB",
+    description:
+      "sassy-salamander is a resilient and feisty instance, perfectly at home in any environment—from the scorching heat of a web server to the damp coolness of a database. Don't let its size fool you; it's quick, adaptable, and not afraid to tackle complex tasks.",
+    ipv4: ["10.138.32.6"],
+    ipv6: [
+      "fd42:6a38:859a:587d:216:3eff:fe43:167e",
+      "fe80::216:3eff:fe43:167e",
+      "fe80::1050:62ff:feb2:964c",
+    ],
+    status: "Running",
+  },
+  {
+    name: "fun-feline",
+    type: "Container",
+    project: "default",
+    clusterMember: "-",
+    memory: "0.7 GiB of 1.9 GiB",
+    fileSystem: "1.1 GiB of 9.5 GiB",
+    description:
+      "fun-feline is a purr-fectly agile and independent instance. It’s got nine lives for all your testing needs and a mischievous spirit for tackling the toughest tasks. Just be sure to give it enough RAM—it loves to stretch out.",
+    ipv4: ["10.138.32.6"],
+    ipv6: [
+      "fd42:6a38:859a:587d:216:3eff:fe43:167e",
+      "fe80::216:3eff:fe43:167e",
+      "fe80::1050:62ff:feb2:964c",
+    ],
+    snapshots: ["1", "2"],
+    status: "Stopped",
+  },
+];
+
+export const getRows = (): MainTableRow[] => {
+  const instanceRows: MainTableRow[] = INSTANCES.map((instance) => {
+    return {
+      key: instance.name,
+      name: instance.name,
+      columns: [
+        {
+          content: instance.name,
+          className: "u-truncate",
+          title: `Instance ${instance.name}`,
+          role: "rowheader",
+          "aria-label": NAME, // needed
+          onClick: () => console.log("Click on instance", instance.name),
+        },
+        {
+          content: <span>{instance.type}</span>,
+          className: "clickable-cell",
+          role: "cell",
+          "aria-label": TYPE, // needed
+          onClick: () => console.log("Click on instance", instance.type),
+        },
+        {
+          content: <a>{instance.project}</a>,
+          role: "cell",
+          "aria-label": PROJECT, // needed
+        },
+        {
+          content: <a>{instance.clusterMember}</a>,
+          role: "cell",
+          "aria-label": CLUSTER_MEMBER, // needed
+        },
+        {
+          content: instance.memory,
+          className: "clickable-cell",
+          role: "cell",
+          "aria-label": MEMORY, // needed
+          onClick: () => console.log("Click on instance", instance.memory),
+        },
+        {
+          content: instance.fileSystem,
+          className: "clickable-cell",
+          role: "cell",
+          "aria-label": FILESYSTEM, // needed
+          onClick: () => console.log("Click on instance", instance.fileSystem),
+        },
+        {
+          content: (
+            <div className="u-truncate" title={instance.description}>
+              {instance.description}
+            </div>
+          ),
+          className: "clickable-cell",
+          role: "cell",
+          "aria-label": DESCRIPTION, // needed
+          onClick: () => console.log("Click on instance", instance.description),
+        },
+        {
+          key: `ipv4-${instance.ipv4.length}`,
+          content: instance.ipv4.join(", "),
+          className: "u-align--right clickable-cell",
+          role: "cell",
+          "aria-label": IPV4, // needed
+          onClick: () => console.log("Click on instance", instance.ipv4),
+        },
+        {
+          key: `ipv6-${instance.ipv6.length}`,
+          content: instance.ipv6.join(", "),
+          className: "clickable-cell",
+          role: "cell",
+          "aria-label": IPV6, // needed
+          onClick: () => console.log("Click on instance", instance.ipv6),
+        },
+        {
+          content: instance.snapshots?.length ?? "0",
+          className: "u-align--right clickable-cell",
+          role: "cell",
+          "aria-label": SNAPSHOTS, // needed
+          onClick: () =>
+            console.log("Click on instance", instance.snapshots?.length),
+        },
+        {
+          content: instance.status,
+          role: "cell",
+          className: "clickable-cell",
+          "aria-label": STATUS, // needed
+          onClick: () => console.log("Click on instance", instance.status),
+        },
+      ],
+    };
+  });
+
+  return instanceRows;
+};

--- a/src/components/ColumnSelector/columnSelectorHelper.ts
+++ b/src/components/ColumnSelector/columnSelectorHelper.ts
@@ -1,0 +1,24 @@
+import { MainTableHeader, MainTableRow } from "components/MainTable/MainTable";
+
+export const visibleRowColumns = (
+  rows: MainTableRow[],
+  hiddenCols: string[],
+): MainTableRow[] => {
+  return rows.map((row) => {
+    return {
+      ...row,
+      columns: row.columns.filter(
+        (item) => !hiddenCols.includes(item["aria-label"]),
+      ),
+    };
+  });
+};
+
+export const visibleHeaderColumns = (
+  headers: MainTableHeader[],
+  hiddenCols: string[],
+): MainTableHeader[] =>
+  headers.filter(
+    (item) =>
+      typeof item.content !== "string" || !hiddenCols.includes(item.content),
+  );

--- a/src/components/ColumnSelector/index.ts
+++ b/src/components/ColumnSelector/index.ts
@@ -1,0 +1,6 @@
+export { default } from "./ColumnSelector";
+export {
+  visibleHeaderColumns,
+  visibleRowColumns,
+} from "./columnSelectorHelper";
+export type { Props as ColumnSelectorProps } from "./ColumnSelector";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,11 @@ export {
   CodeSnippetBlockAppearance,
 } from "./components/CodeSnippet";
 export { default as Col } from "./components/Col";
+export {
+  default as ColumnSelector,
+  visibleHeaderColumns,
+  visibleRowColumns,
+} from "./components/ColumnSelector";
 export { default as ConfirmationButton } from "./components/ConfirmationButton";
 export { default as ConfirmationModal } from "./components/ConfirmationModal";
 export { default as ContextualMenu } from "./components/ContextualMenu";
@@ -125,6 +130,7 @@ export type {
   CodeSnippetDropdownProps,
 } from "./components/CodeSnippet";
 export type { ColProps, ColSize } from "./components/Col";
+export type { ColumnSelectorProps } from "./components/ColumnSelector";
 export type { ConfirmationButtonProps } from "./components/ConfirmationButton";
 export type { ConfirmationModalProps } from "./components/ConfirmationModal";
 export type {


### PR DESCRIPTION
## Done

- Create ColumnSelector component that toggles/untoggles columns of a table

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- In Storybook, check that toggling/untoggling columns in the ColumnSelector makes them appear/disappear in the associated table
- Columns hidden because of size should be disabled

### Percy steps

- UI should look like in LXD UI, see screenshots below

<img width="1914" height="894" alt="Screenshot from 2025-10-01 17-39-10" src="https://github.com/user-attachments/assets/87a0ea96-483f-486a-b25e-58a6658eac1f" />
<img width="714" height="550" alt="image" src="https://github.com/user-attachments/assets/7f5be91f-24c3-4fa3-a609-eebb8b15d620" />

Screenshot after Cluster Member column was untoggled:
<img width="1604" height="593" alt="image" src="https://github.com/user-attachments/assets/7858ddf4-25fd-4287-810a-da4b6d157a86" />
