### PR TITLE
fix: Textarea and Select ignore required prop

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -152,6 +152,7 @@ const Select = ({
         id={selectId}
         onChange={(evt) => onChange && onChange(evt)}
         ref={selectRef}
+        required={required}
         {...selectProps}
       >
         {generateOptions(options)}

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -190,6 +190,7 @@ const Textarea = ({
           }) ||
           style
         }
+        required={required}
         {...props}
         value={props.value ?? innerValue}
       />


### PR DESCRIPTION
## Done

- `required` attribute forwarded to `<Select>` and `<Textarea>` components

## Fixes

Fixes:  [Issue #1263](https://github.com/canonical/react-components/issues/1263)


## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Tested locally by adding `<Select>` and `<Textarea>` with a required prop to a story in Form.stories.tsx.



