### PR TITLE
feat(Modal): assign initial focus

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
+import Button from "components/Button";
 import Modal from "./Modal";
 import { ModalProps } from ".";
 
@@ -78,4 +79,52 @@ export const Default: Story = {
   },
 
   name: "Default",
+};
+
+export const Focus: Story = {
+  render: ({ closeOnOutsideClick }) => {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const [modalOpen, setModalOpen] = useState(true);
+    const buttonRef = useRef<HTMLElement>(null);
+    /* eslint-enable react-hooks/rules-of-hooks */
+
+    const closeHandler = () => setModalOpen(false);
+
+    return (
+      <>
+        <button onClick={() => setModalOpen(true)}>Open modal</button>
+        {modalOpen ? (
+          <Modal
+            close={closeHandler}
+            title="Confirm delete"
+            closeOnOutsideClick={closeOnOutsideClick}
+            buttonRow={
+              <>
+                <button className="u-no-margin--bottom" onClick={closeHandler}>
+                  Cancel
+                </button>
+                <button className="p-button--negative u-no-margin--bottom">
+                  Delete
+                </button>
+              </>
+            }
+            focusRef={buttonRef}
+          >
+            <p>
+              This will permanently delete the user "Simon".
+              <br />
+              You cannot undo this action.
+            </p>
+            <p>
+              <Button appearance="link" ref={buttonRef}>
+                More information
+              </Button>
+            </p>
+          </Modal>
+        ) : null}
+      </>
+    );
+  },
+
+  name: "Focus",
 };

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -85,11 +85,11 @@ describe("Modal ", () => {
     const closeButton = container.querySelector("button.p-modal__close");
     const cancelButton = container.querySelector("button#test-cancel");
 
-    expect(cancelButton).toHaveFocus();
+    expect(closeButton).toHaveFocus();
 
     await user.tab();
 
-    expect(closeButton).toHaveFocus();
+    expect(cancelButton).toHaveFocus();
   });
 
   it("focuses on close button if there are no other focusable elements", async () => {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
+import React, { useId, useRef, useEffect } from "react";
 import type { HTMLProps, ReactNode, RefObject } from "react";
-import React, { useEffect, useId, useRef } from "react";
 import { ClassName, PropsWithSpread } from "types";
 
 export type Props = PropsWithSpread<
@@ -21,6 +21,10 @@ export type Props = PropsWithSpread<
      * Function to handle closing the modal.
      */
     close?: () => void | null;
+    /**
+     * The element that will be focused upon opening the modal.
+     */
+    focusRef?: RefObject<HTMLElement | null>;
     /**
      * The title of the modal.
      */
@@ -47,6 +51,7 @@ export const Modal = ({
   children,
   className,
   close,
+  focusRef,
   title,
   shouldPropagateClickEvent = false,
   closeOnOutsideClick = true,
@@ -98,13 +103,10 @@ export const Modal = ({
     }
   };
 
-  const keyListenersMap = new Map([
-    ["Escape", handleEscKey],
-    ["Tab", handleTabKey],
-  ]);
-
   useEffect(() => {
-    if (closeButtonRef.current) {
+    if (focusRef?.current) {
+      focusRef.current.focus();
+    } else if (closeButtonRef.current) {
       closeButtonRef.current.focus();
     } else {
       modalRef.current.focus();
@@ -113,9 +115,14 @@ export const Modal = ({
     focusableModalElements.current = modalRef.current.querySelectorAll(
       focusableElementSelectors,
     );
-  }, []);
+  }, [focusRef]);
 
   useEffect(() => {
+    const keyListenersMap = new Map([
+      ["Escape", handleEscKey],
+      ["Tab", handleTabKey],
+    ]);
+
     const keyDown = (event: KeyboardEvent) => {
       const listener = keyListenersMap.get(event.code);
       return listener && listener(event);


### PR DESCRIPTION
## Done

`Modal` will focus on the close button instead of choosing the first focusable element.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Ensure that `Modal` focuses on close button, or the modal itself if there is no close button.

### Percy steps

- One new test
