### PR TITLE
fix(column-selector): allow filtering of headers with no content, but existing aria label

### DIFF
--- a/src/components/ColumnSelector/ColumnSelector.test.tsx
+++ b/src/components/ColumnSelector/ColumnSelector.test.tsx
@@ -270,7 +270,7 @@ describe("visibleHeaderColumns", () => {
     { content: "Name", sortKey: "Name" },
     { content: "Status", sortKey: "Status" },
     { content: "Role", sortKey: "Role" },
-    { content: <button>Actions</button>, sortKey: "actions" },
+    { "aria-label": "Actions", sortKey: "actions" },
   ];
 
   it("should not filter any headers if hiddenCols is empty", () => {
@@ -293,11 +293,18 @@ describe("visibleHeaderColumns", () => {
     expect(result.map((h) => h.content)).not.toContain("Role");
   });
 
-  it("should never filter headers where content is not a string", () => {
-    const hiddenCols = ["Name", "Status", "Role", "actions"];
+  it("should filter headers based on aria label, where content is not a string", () => {
+    const hiddenCols = ["Name", "Status", "Role", "Actions"];
+    const result = visibleHeaderColumns(mockHeaders, hiddenCols);
+    expect(result).toHaveLength(0);
+  });
+
+  it("should return headers based on aria label, where content is not a string", () => {
+    const hiddenCols = ["Name", "Status", "Role"];
     const result = visibleHeaderColumns(mockHeaders, hiddenCols);
     expect(result).toHaveLength(1);
-    expect(typeof result[0].content).toBe("object");
+    expect(result[0]["aria-label"]).toBe("Actions");
+    expect(result[0].content).toBe(undefined);
   });
 
   it("should return headers unchanged if hidden columns are not found", () => {

--- a/src/components/ColumnSelector/columnSelectorHelper.ts
+++ b/src/components/ColumnSelector/columnSelectorHelper.ts
@@ -18,7 +18,9 @@ export const visibleHeaderColumns = (
   headers: MainTableHeader[],
   hiddenCols: string[],
 ): MainTableHeader[] =>
-  headers.filter(
-    (item) =>
-      typeof item.content !== "string" || !hiddenCols.includes(item.content),
-  );
+  headers.filter((item) => {
+    if (typeof item.content === "string") {
+      return !hiddenCols.includes(item.content);
+    }
+    return !hiddenCols.includes(item["aria-label"]);
+  });


### PR DESCRIPTION
## Done

- fix(column-selector) allow filtering of headers with no content, but existing aria label

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- not needed

### Percy steps

- no changes expected