### PR TITLE
feat(WD-30161): ToastNotificationProvider customizable delay

### DIFF
--- a/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotification.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof ToastNotificationProvider> = {
   component: ToastNotificationProvider,
   tags: ["autodocs"],
   argTypes: {
-    hideDelay: {
+    autoDismissDelay: {
       control: {
         type: "select",
       },
@@ -25,7 +25,7 @@ const meta: Meta<typeof ToastNotificationProvider> = {
     },
   },
   args: {
-    hideDelay: 5000,
+    autoDismissDelay: 5000,
   },
 };
 
@@ -35,15 +35,15 @@ type Story = StoryObj<typeof ToastNotificationProvider>;
 
 export const Default: Story = {
   name: "Default",
-  render: (args: { hideDelay?: number }) => (
+  render: (args: { autoDismissDelay?: number }) => (
     <ToastNotificationStoryWrapper {...args} />
   ),
 };
 
 const ToastNotificationStoryWrapper = ({
-  hideDelay,
+  autoDismissDelay,
 }: {
-  hideDelay?: number;
+  autoDismissDelay?: number;
 }) => {
   useEffect(() => {
     const root = document.getElementById("storybook-root");
@@ -53,7 +53,7 @@ const ToastNotificationStoryWrapper = ({
   }, []);
 
   return (
-    <ToastNotificationProvider hideDelay={hideDelay}>
+    <ToastNotificationProvider autoDismissDelay={autoDismissDelay}>
       <PreloadedList />
     </ToastNotificationProvider>
   );

--- a/src/components/Notifications/ToastNotification/ToastNotificationProvider.tsx
+++ b/src/components/Notifications/ToastNotification/ToastNotificationProvider.tsx
@@ -25,7 +25,7 @@ export type ToastNotificationType = NotificationType & {
 
 interface Props {
   onDismiss?: (notifications?: ToastNotificationType[]) => void;
-  hideDelay?: number;
+  autoDismissDelay?: number;
 }
 
 interface ToastNotificationHelper {
@@ -106,7 +106,7 @@ const ToastNotificationContext = createContext<ToastNotificationHelper>({
 Wrap your application with this provider, and in any child component you can get the helper with `const toastNotify = useToastNotification()` to trigger notifications.
 Notifications automatically dismiss after a delay unless manually dismissed or expanded.
 
-To make the notification persistent (i.e., not auto-dismiss), set the `hideDelay` prop to `0` when using the provider: `<ToastNotificationProvider hideDelay={0}>`
+To make the notification persistent (i.e., not auto-dismiss), set the `autoDismissDelay` prop to `0` when using the provider: `<ToastNotificationProvider autoDismissDelay={0}>`
 
 | **Values**                       | **Description**                                                                |
 |----------------------------------|--------------------------------------------------------------------------------|
@@ -167,7 +167,7 @@ Alternatively, you can use the `ToastNotification` and `ToastNotificationList` c
 const ToastNotificationProvider: FC<PropsWithChildren<Props>> = ({
   children,
   onDismiss,
-  hideDelay = HIDE_NOTIFICATION_DELAY,
+  autoDismissDelay = HIDE_NOTIFICATION_DELAY,
 }) => {
   const [notifications, setNotifications] = useState<ToastNotificationType[]>(
     [],
@@ -194,14 +194,14 @@ const ToastNotificationProvider: FC<PropsWithChildren<Props>> = ({
       }
 
       if (!showList) {
-        // If hideDelay is 0, make notification persistent (no auto-hide)
-        if (!hideDelay) {
+        // If autoDismissDelay is 0, make notification persistent (no auto-hide)
+        if (!autoDismissDelay) {
           return true; // Set a truthy value to indicate notification should show
         }
 
         return setTimeout(() => {
           setNotificationTimer(null);
-        }, hideDelay);
+        }, autoDismissDelay);
       }
 
       return null;


### PR DESCRIPTION
## Done

- Added `autoDismissDelay` prop to `ToastNotificationProvider` which can be used to:
  - provide custom delays to automatically dismiss notification
  - disable automatically dismissing notifications

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check out this pull request
- Run the project using dotrun
- Visit http://localhost:8403/?path=/docs/components-notifications-toastnotification--docs
- Disable list view by clicking on `Toggle list view` button
- In the controls under notifications, use different values from `autoDismissDelay` from the dropdown, and trigger notifcations
- Make sure the notifications are persistent, when `autoDismissDelay` is set to `0`

### Percy steps

- Updated `ToastNotification` docs page

## Fixes

Fixes: #1271, [WD-30161](https://warthogs.atlassian.net/browse/WD-30161)


[WD-30161]: https://warthogs.atlassian.net/browse/WD-30161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ