### PR TITLE
fix(contextual-menu): prevent keyboard from opening and closing again in mobile chrome with input as child of the contextual menu

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -260,11 +260,18 @@ const ContextualMenu = <L,>({
       // becomes smaller.
       closePortal();
     } else {
-      // Update the coordinates so that the menu stays relative to the
-      // toggle button.
-      updatePositionCoords();
+      // Only update if the coordinates have changed.
+      // The check fixes a bug with chrome, where an input receiving focus and
+      // opening the keyboard causes a resize and the keyboard closes right after
+      // opening.
+      const coords = parent.getBoundingClientRect();
+      if (JSON.stringify(coords) !== JSON.stringify(positionCoords)) {
+        // Update the coordinates so that the menu stays relative to the
+        // toggle button.
+        updatePositionCoords();
+      }
     }
-  }, [closePortal, positionNode, updatePositionCoords]);
+  }, [closePortal, positionNode, positionCoords, updatePositionCoords]);
 
   const onScroll = useCallback(
     (e: Event) => {


### PR DESCRIPTION
## Done

- fix(contextual-menu) prevent keyboard from opening and closing again in mobile chrome with input as child of the contextual menu

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- not needed

### Percy steps

- no changes expected

## Fixes

Relates to https://github.com/canonical/lxd-ui/issues/1483

> When I open the menu and then open the project selection dropdown, the focus goes to the search bar and my keyboard opens/closes 20-30 times before it stops and shows my keyboard.

> On Chrome the behavior is different. The focus goes to the search bar and immediately goes away. So does the keyboard. When I then click on the search input, this behavior repeats itself.

> After waiting for the 20-30 keyboard flashes the search function is usable on Edge. It's never usable on Chrome.