### PR TITLE
feat(ConfirmationModal): introduce portal prop for DOM relocation

### DIFF
--- a/src/components/ConfirmationButton/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton/ConfirmationButton.tsx
@@ -55,7 +55,7 @@ export const ConfirmationButton = ({
   preModalOpenHook,
   ...actionButtonProps
 }: Props): React.JSX.Element => {
-  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { openPortal, closePortal, isOpen } = usePortal();
 
   const handleCancelModal = () => {
     closePortal();
@@ -90,22 +90,21 @@ export const ConfirmationButton = ({
   return (
     <>
       {isOpen && (
-        <Portal>
-          <ConfirmationModal
-            {...confirmationModalProps}
-            close={handleCancelModal}
-            confirmButtonLabel={confirmationModalProps.confirmButtonLabel}
-            onConfirm={handleConfirmModal}
-          >
-            {confirmationModalProps.children}
-            {showShiftClickHint && (
-              <p className="p-text--small u-text--muted u-hide--small">
-                Next time, you can skip this confirmation by holding{" "}
-                <code>SHIFT</code> and clicking the action.
-              </p>
-            )}
-          </ConfirmationModal>
-        </Portal>
+        <ConfirmationModal
+          {...confirmationModalProps}
+          close={handleCancelModal}
+          confirmButtonLabel={confirmationModalProps.confirmButtonLabel}
+          onConfirm={handleConfirmModal}
+          renderInPortal={true}
+        >
+          {confirmationModalProps.children}
+          {showShiftClickHint && (
+            <p className="p-text--small u-text--muted u-hide--small">
+              Next time, you can skip this confirmation by holding{" "}
+              <code>SHIFT</code> and clicking the action.
+            </p>
+          )}
+        </ConfirmationModal>
       )}
       <ActionButton
         {...actionButtonProps}

--- a/src/components/ConfirmationModal/ConfirmationModal.test.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.tsx
@@ -150,4 +150,35 @@ describe("ConfirmationModal ", () => {
       "submit",
     );
   });
+
+  it("renders without portal by default", () => {
+    const { container } = render(
+      <ConfirmationModal confirmButtonLabel="Proceed" onConfirm={jest.fn()}>
+        Test default rendering
+      </ConfirmationModal>,
+    );
+
+    const modal = container.querySelector(".p-modal");
+    expect(modal).toBeInTheDocument();
+    expect(container.contains(modal)).toBe(true);
+  });
+
+  it("renders inside a portal when renderInPortal is true", () => {
+    const { container } = render(
+      <ConfirmationModal
+        confirmButtonLabel="Proceed"
+        onConfirm={jest.fn()}
+        renderInPortal={true}
+      >
+        Test portal rendering
+      </ConfirmationModal>,
+    );
+
+    const modal = document.querySelector(".p-modal");
+    expect(modal).toBeInTheDocument();
+
+    expect(container.contains(modal)).toBe(false);
+
+    expect(document.body.contains(modal)).toBe(true);
+  });
 });

--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -4,6 +4,7 @@ import { PropsWithSpread, ValueOf } from "types";
 import Button, { ButtonAppearance, ButtonProps } from "components/Button";
 import Modal, { ModalProps } from "components/Modal";
 import ActionButton, { ActionButtonProps } from "components/ActionButton";
+import { usePortal } from "external";
 
 export type Props = PropsWithSpread<
   {
@@ -47,6 +48,10 @@ export type Props = PropsWithSpread<
      * Whether the confirm button should be disabled.
      */
     confirmButtonDisabled?: boolean;
+    /**
+     * Whether to render the modal inside a Portal component.
+     */
+    renderInPortal?: boolean;
   },
   Omit<ModalProps, "buttonRow">
 >;
@@ -65,8 +70,11 @@ export const ConfirmationModal = ({
   confirmButtonLoading,
   confirmButtonDisabled,
   confirmButtonProps,
+  renderInPortal = false,
   ...props
 }: Props): React.JSX.Element => {
+  const { Portal } = usePortal();
+
   const handleClick =
     <A extends Function>( // eslint-disable-line @typescript-eslint/no-unsafe-function-type
       action: A | null | undefined,
@@ -80,7 +88,7 @@ export const ConfirmationModal = ({
       }
     };
 
-  return (
+  const ModalElement = (
     <Modal
       buttonRow={
         <>
@@ -110,6 +118,8 @@ export const ConfirmationModal = ({
       {children}
     </Modal>
   );
+
+  return renderInPortal ? <Portal>{ModalElement}</Portal> : ModalElement;
 };
 
 export default ConfirmationModal;


### PR DESCRIPTION
`ConfirmationButton` always renders its modal inside a portal, while `ConfirmationModal` did not.
This inconsistency caused:
- unpredictable z-index stacking when multiple layered components are open
- difficulty debugging and forcing stacking contexts
- different behaviour depending on whether a developer used the modal directly or via ConfirmationButton

This PR introduces an explicit `renderInPortal` option and makes both components behave consistently.

## Done
- Added `renderInPortal` prop to `ConfirmationModal`, allowing consumers to opt-into portal rendering.
- Changed `ConfirmationButton` to rely on ConfirmationModal's portal behaviour instead of managing its own <Portal> wrapper.

#### Updated and expanded unit tests for:
- portal / non-portal rendering


No visual changes to the modal itself.

## QA

Pinging @canonical/react-library-maintainers for a review.

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open ConfirmationModal with and without renderInPortal
- Inspect the DOM using dev tools:
   - When `renderInPortal={true}`, the modal should appear outside the app root inside a dynamically created portal node.
   - When `renderInPortal={false}`, the modal should appear inline where it is rendered.

### Percy steps
No visual changes expected
