### PR TITLE
ci(percy): Increase resource class for Percy job to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ version: 2
 jobs:
   percy:
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
To prevent out of memory errors and Percy job being killed on CircleCI, we increase the image resources to large (8GB of RAM).

## QA

Pinging @canonical/react-library-maintainers for a review.

### QA steps

- Review the code, check if all CI checks pass

