### PR TITLE
fix(release): Remove NPM_TOKEN from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Remove NPM_TOKEN from the release workflow environment as part of using OIDC authentication for release to npm.

Context: 
https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/
https://docs.npmjs.com/trusted-publishers

## Done

- Itemised list of what was changed by this PR.

## QA

Pinging @canonical/react-library-maintainers for a review.

