### PR TITLE
fix(modal): fix bug where the list of focus-able elements was not re-computed when the state of certain children has changed [AC-4105]

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -222,4 +222,44 @@ describe("Modal ", () => {
     expect(input).toHaveFocus();
     expect(input).toHaveValue("delete item1");
   });
+
+  it("updates focusable elements when an initially disabled button becomes enabled", async () => {
+    const user = userEvent.setup();
+
+    const DynamicButtonModal: FC = () => {
+      const [enabled, setEnabled] = useState(false);
+
+      return (
+        <Modal
+          title="Test"
+          close={jest.fn()}
+          buttonRow={<button disabled={!enabled}>Proceed</button>}
+        >
+          <p>Content</p>
+          <Button onClick={() => setEnabled(true)}>Enable proceed</Button>
+        </Modal>
+      );
+    };
+
+    const { container } = render(<DynamicButtonModal />);
+
+    const closeButton = container.querySelector("button.p-modal__close");
+
+    await user.tab();
+    const enableButton = screen.getByRole("button", {
+      name: /enable proceed/i,
+    });
+    expect(enableButton).toHaveFocus();
+
+    await user.tab();
+    expect(closeButton).toHaveFocus();
+    await user.tab();
+    expect(enableButton).toHaveFocus();
+
+    await user.click(enableButton);
+
+    await user.tab();
+    const proceedButton = screen.getByRole("button", { name: /^proceed$/i });
+    expect(proceedButton).toHaveFocus();
+  });
 });

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -67,14 +67,14 @@ export const Modal = ({
 
   const modalRef: RefObject<HTMLDivElement> = useRef(null);
   const closeButtonRef: RefObject<HTMLButtonElement> = useRef(null);
-  const focusableModalElements = useRef(null);
   const handleTabKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (focusableModalElements.current.length > 0) {
-      const firstElement = focusableModalElements.current[0];
+    const focusableModalElements = modalRef.current.querySelectorAll(
+      focusableElementSelectors,
+    );
+    if (focusableModalElements.length > 0) {
+      const firstElement = focusableModalElements[0];
       const lastElement =
-        focusableModalElements.current[
-          focusableModalElements.current.length - 1
-        ];
+        focusableModalElements[focusableModalElements.length - 1];
 
       if (!event.shiftKey && document.activeElement === lastElement) {
         (firstElement as HTMLElement).focus();
@@ -111,10 +111,6 @@ export const Modal = ({
     } else {
       modalRef.current.focus();
     }
-
-    focusableModalElements.current = modalRef.current.querySelectorAll(
-      focusableElementSelectors,
-    );
   }, [focusRef]);
 
   useEffect(() => {


### PR DESCRIPTION
## Done

- Fix bug where the list of focus-able elements was not re-computed when the state of certain children has changed
- This was done by using a Mutation Observer that checks for specific changes in the following attributes in the children of the modal : ``` attributeFilter: ["disabled", "tabindex", "contentEditable"], ```

## QA

Pinging @canonical/react-library-maintainers for a review.
- Just use the modal component with a disabled button and start tabbing: you must not reach the button
- Now enable the button programatically and start tabbing: you should reach the enabled button (previously impossible)
- For example: Create a disabled button and an input field. If you fill the input field with a specific string, you must enable the button. Now you should also be able to tab to the button 
- Simple example:

<img width="436" height="351" alt="image" src="https://github.com/user-attachments/assets/629e94c1-3fea-498a-9188-925c4cb0c979" />
<img width="436" height="351" alt="image" src="https://github.com/user-attachments/assets/a808dd4c-b9e2-46ec-a4bd-e572eb53b759" />


## Fixes

Fixes: # [AC-4105](https://warthogs.atlassian.net/browse/AC-4105)


[AC-4105]: https://warthogs.atlassian.net/browse/AC-4105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ