### PR TITLE
docs: remove dead links and use relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # React components for Vanilla Framework
+
 ![CI](https://github.com/canonical/react-components/workflows/CI/badge.svg?branch=main)
 
 This is a collection of components designed to be the way to consume [Vanilla Framework](http://vanillaframework.io) when using React. The library exposes both a CJS and an ESM build.
@@ -33,9 +34,7 @@ Please file any issues at [GitHub](https://github.com/canonical/react-components
 You might want to:
 
 - [View the source](https://github.com/canonical/react-components) on GitHub.
-- Read about [developing components](https://github.com/canonical/react-components/blob/main/HACKING.md).
-- Find out how to [publish to NPM](https://github.com/canonical/react-components/blob/main/PUBLISH-NPM-PACKAGE.md).
-- Know how to [publish the docs](https://github.com/canonical/react-components/blob/main/PUBLISHING-DOCS.md) to GitHub Pages.
+- Read about [developing components](HACKING.md).
 
 ## Developing locally using this repository
 


### PR DESCRIPTION
## Done

- Removed dead links in readme
- Changed remaining link to a relative link, according to [GitHub best practices](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#relative-links:~:text=Relative%20links%20are%20easier%20for%20users%20who%20clone%20your%20repository.%20Absolute%20links%20may%20not%20work%20in%20clones%20of%20your%20repository%20%2D%20we%20recommend%20using%20relative%20links%20to%20refer%20to%20other%20files%20within%20your%20repository.)

## QA

Pinging @canonical/react-library-maintainers for a review.

### QA steps

- Verify that the `HACKING.md` link works in both GitHub and a local repository.

### Percy steps

- No visual changes expected.