### PR TITLE
fix(modal): fix bug where the action button would set disabled to true

### DIFF
--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useEffect, useRef, useState } from "react";
+import React, { MouseEventHandler, useEffect, useRef, useState } from "react";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 import type { ButtonProps } from "../Button";
@@ -42,8 +42,13 @@ export type Props = PropsWithSpread<
      */
     loading?: boolean;
     /**
+     * Function for handling button click event.
+     */
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    /**
      * Whether the button should be in the success state.
      */
+
     success?: boolean;
   },
   ButtonHTMLAttributes<HTMLButtonElement>
@@ -60,6 +65,7 @@ const ActionButton = ({
   appearance,
   children,
   className,
+  onClick,
   disabled = null,
   inline = false,
   loading = false,
@@ -155,8 +161,11 @@ const ActionButton = ({
     },
   );
   const showIcon = showLoader || showSuccess;
+  const isDisabled = disabled === null ? showLoader : disabled;
   const icon = (showLoader && "spinner") || (showSuccess && "success") || null;
   const iconLight = appearance === "positive" || appearance === "negative";
+  const onClickDisabled: MouseEventHandler<HTMLButtonElement> = (e) =>
+    e.preventDefault();
 
   // This component uses the base button element instead of the Button component
   // as the button requires a ref and Button would have to be updated to use
@@ -165,8 +174,9 @@ const ActionButton = ({
   return (
     <button
       className={buttonClasses}
-      disabled={disabled === null ? showLoader : disabled}
       ref={ref}
+      onClick={isDisabled ? onClickDisabled : onClick}
+      aria-disabled={isDisabled || undefined}
       style={
         height && width
           ? {

--- a/src/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
+++ b/src/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`ActionButton matches loading snapshot 1`] = `
 <button
+  aria-disabled="true"
   class="p-action-button p-button is-processing is-disabled"
-  disabled=""
 >
   <i
     aria-label="Waiting for action to complete"


### PR DESCRIPTION
## Done

- Removed disabled property from the action button
- This makes it align with the regular ```Button``` by not setting disabled=true but rather using ```aria-disabled```

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Use a ```ActionButton``` component and disable it. It should still be focus-able via keyboard

