### PR TITLE
fix(login-page-story): fix wrong URL for the Anbox Cloud logo

### DIFF
--- a/src/components/LoginPageLayout/LoginPageLayout.stories.tsx
+++ b/src/components/LoginPageLayout/LoginPageLayout.stories.tsx
@@ -57,7 +57,7 @@ export const RegistrationPage: Story = {
       </>
     ),
     logo: {
-      src: "https://anbox-cloud.io/static/logo.svg",
+      src: "https://assets.ubuntu.com/v1/04242fd4-anbox-cloud-logo.svg",
       title: "Anbox Cloud",
       url: "/",
     },


### PR DESCRIPTION
## Done

- Fixed wrong Anbox URL in Percy testing

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- The logo should load now
