### PR TITLE
chore(CI): Bump Dockerfile Node to v24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:23 AS yarn-dependencies
+FROM node:24 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
 ADD yarn.lock .


### PR DESCRIPTION
## Done

Bumps our version of Node used for building the docs image to v24.

This is an attempt to fix our demos.haus jobs failing since upgrading to [semantic-release v25](https://github.com/semantic-release/semantic-release/releases/tag/v25.0.0), which dropped support for node 23 and has been causing build failures for all demos:

```
59.99 error semantic-release@25.0.2: The engine "node" is incompatible with this module. Expected version "^22.14.0 || >= 24.10.0". Got "23.11.1"
```

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Browse around the demo and make sure nothing seems out of place or doesn't work.
