### PR TITLE
fix(MainTable): Add keyboard controls to sortable tables

### DIFF
--- a/src/components/MainTable/MainTable.test.tsx
+++ b/src/components/MainTable/MainTable.test.tsx
@@ -197,7 +197,9 @@ describe("MainTable", () => {
       );
 
       await userEvent.click(
-        screen.getByRole("columnheader", { name: "Status" }),
+        within(screen.getByRole("columnheader", { name: "Status" })).getByRole(
+          "button",
+        ),
       );
       // The status should now be ascending.
       expect(within(rowItems[1]).getByRole("rowheader").textContent).toBe(
@@ -213,7 +215,9 @@ describe("MainTable", () => {
       );
 
       await userEvent.click(
-        screen.getByRole("columnheader", { name: "Status" }),
+        within(screen.getByRole("columnheader", { name: "Status" })).getByRole(
+          "button",
+        ),
       );
       // The status should now be descending.
       expect(within(rowItems[1]).getByRole("rowheader").textContent).toBe(
@@ -229,7 +233,9 @@ describe("MainTable", () => {
       );
 
       await userEvent.click(
-        screen.getByRole("columnheader", { name: "Status" }),
+        within(screen.getByRole("columnheader", { name: "Status" })).getByRole(
+          "button",
+        ),
       );
       // The status be back to the original order.
       expect(within(rowItems[1]).getByRole("rowheader").textContent).toBe(
@@ -249,7 +255,9 @@ describe("MainTable", () => {
       render(<MainTable headers={headers} rows={rows} sortable={true} />);
       const rowItems = screen.getAllByRole("row");
       await userEvent.click(
-        screen.getByRole("columnheader", { name: "Status" }),
+        within(screen.getByRole("columnheader", { name: "Status" })).getByRole(
+          "button",
+        ),
       );
 
       const expectedOrder = ["Idle", "Ready", "Waiting"];
@@ -260,6 +268,14 @@ describe("MainTable", () => {
         );
       }
 
+      // Non-sortable columns don't have sort buttons.
+      expect(
+        within(screen.getByRole("columnheader", { name: "RAM" })).queryByRole(
+          "button",
+        ),
+      ).not.toBeInTheDocument();
+
+      // Clicking a column header, not a sort button.
       await userEvent.click(screen.getByRole("columnheader", { name: "RAM" }));
       // The status should not change
       for (let i = 1; i < 4; i++) {
@@ -275,6 +291,46 @@ describe("MainTable", () => {
           expectedOrder[i - 1],
         );
       }
+    });
+
+    it("can be sorted with the keyboard", async () => {
+      render(<MainTable headers={headers} rows={rows} sortable={true} />);
+      const rowItems = screen.getAllByRole("row");
+      // Check the initial status order.
+      expect(within(rowItems[1]).getByRole("rowheader").textContent).toBe(
+        "Ready",
+      );
+
+      expect(within(rowItems[2]).getByRole("rowheader").textContent).toBe(
+        "Waiting",
+      );
+
+      expect(within(rowItems[3]).getByRole("rowheader").textContent).toBe(
+        "Idle",
+      );
+
+      await userEvent.tab();
+      expect(
+        within(screen.getByRole("columnheader", { name: "Status" })).getByRole(
+          "button",
+        ),
+      ).toHaveFocus();
+      await userEvent.keyboard("{Enter}");
+      // The status should now be ascending.
+      expect(within(rowItems[1]).getByRole("rowheader").textContent).toBe(
+        "Idle",
+      );
+      // You should also be able to sort with the Spacebar.
+      await userEvent.keyboard(" ");
+      // The status should now be descending.
+      expect(within(rowItems[1]).getByRole("rowheader").textContent).toBe(
+        "Waiting",
+      );
+      await userEvent.keyboard("{Enter}");
+      // The status be back to the original order.
+      expect(within(rowItems[1]).getByRole("rowheader").textContent).toBe(
+        "Ready",
+      );
     });
 
     it("can set a default sort", () => {

--- a/src/components/MainTable/MainTable.tsx
+++ b/src/components/MainTable/MainTable.tsx
@@ -167,7 +167,7 @@ const generateHeaders = (
       <TableHeader
         key={index}
         sort={sortDirection}
-        onClick={
+        onSort={
           sortable && sortKey
             ? updateSort.bind(
                 this,

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -12,6 +12,8 @@ export type Props = PropsWithSpread<
      * The direction of sorting, if applicable.
      */
     sort?: SortDirection;
+    /** Function to call when the sort button is clicked. */
+    onSort?: () => void;
   },
   HTMLProps<HTMLTableHeaderCellElement>
 >;
@@ -19,11 +21,21 @@ export type Props = PropsWithSpread<
 const TableHeader = ({
   children,
   sort,
+  onSort,
   ...props
 }: Props): React.JSX.Element => {
+  const headerContents = () =>
+    sort && onSort ? (
+      <button className="p-table__sort-button" onClick={onSort}>
+        {children}
+      </button>
+    ) : (
+      children
+    );
+
   return (
     <th role="columnheader" aria-sort={sort} {...props}>
-      {children}
+      {headerContents()}
     </th>
   );
 };


### PR DESCRIPTION
## Done

- Pursuant to https://github.com/canonical/vanilla-framework/pull/5736 , wraps table headers in sort buttons to enable using the keyboard to sort the table.
- Note: requires [Vanilla 4.41.0](https://github.com/canonical/vanilla-framework/releases/tag/v4.41.0). Blocked by https://github.com/canonical/react-components/pull/1306 .

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open all stories with sortable tables.
  - [MainTable](https://react-components-1309.demos.haus/?path=/story/components-maintable--sortable)
  - [ModularTable](https://react-components-1309.demos.haus/?path=/story/components-modulartable--sortable)
- For each table:
  - Sort the table with a mouse and verify no functional changes have occurred - sorting still works.
  - Use the keyboard to sort the table. You can use TAB / SHIFT+TAB to cycle between headers, and ENTER or SPACE to toggle that header's sort. Verify sorting works identically to with a mouse.
  - Using a screen reader like ORCA or VoiceOver, sort the table and verify that the sort direction change is announced.

### Percy steps

- No visual changes expected.
