### PR TITLE
feat(tooltip): when tooltip position is left or right, auto adjust its position

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -135,13 +135,38 @@ const getPositionStyle = (
 export const adjustForWindow = (
   position: Position,
   fitsWindow: WindowFitment,
+  messageHeight: number = 0,
 ): Position => {
   let newPosition: string = position;
   if (!fitsWindow.fromLeft.fitsLeft && newPosition === "left") {
     newPosition = "top-right";
   }
+  if (
+    fitsWindow.fromTop.spaceAbove < messageHeight / 2 &&
+    newPosition === "left"
+  ) {
+    newPosition = "btm-left";
+  }
+  if (
+    fitsWindow.fromBottom.spaceBelow < messageHeight / 2 &&
+    newPosition === "left"
+  ) {
+    newPosition = "top-left";
+  }
   if (!fitsWindow.fromRight.fitsRight && newPosition === "right") {
     newPosition = "top-left";
+  }
+  if (
+    fitsWindow.fromTop.spaceAbove < messageHeight / 2 &&
+    newPosition === "right"
+  ) {
+    newPosition = "btm-right";
+  }
+  if (
+    fitsWindow.fromBottom.spaceBelow < messageHeight / 2 &&
+    newPosition === "right"
+  ) {
+    newPosition = "top-right";
   }
   if (!fitsWindow.fromRight.fitsLeft && newPosition.endsWith("-right")) {
     newPosition = newPosition.replace("right", "left");
@@ -242,7 +267,9 @@ const Tooltip = ({
 
   const onUpdateWindowFitment = useCallback(
     (fitsWindow: WindowFitment) => {
-      setAdjustedPosition(adjustForWindow(position, fitsWindow));
+      const messageHeight =
+        messageRef.current?.getBoundingClientRect().height ?? 0;
+      setAdjustedPosition(adjustForWindow(position, fitsWindow, messageHeight));
     },
     [setAdjustedPosition, position],
   );


### PR DESCRIPTION
## Done

- feat(tooltip) when tooltip position is left or right, auto adjust its position considering the above or below space being too small

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- check tooltip positioning in storybook

### Percy steps

- no change expected