### PR TITLE
fix(contextual-menu): allow Escape key to close menu inside modal (#1…

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -301,4 +301,16 @@ describe("ContextualMenu ", () => {
     await userEvent.click(screen.getByTestId("child-span"));
     expect(screen.getByLabelText(DropdownLabel.Dropdown)).toBeInTheDocument();
   });
+  it("closes the menu on Escape key", async () => {
+    render(<ContextualMenu links={[]} toggleLabel="Toggle" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Toggle" }));
+    expect(screen.getByLabelText(DropdownLabel.Dropdown)).toBeInTheDocument();
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(
+      screen.queryByLabelText(DropdownLabel.Dropdown),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -215,7 +215,25 @@ const ContextualMenu = <L,>({
     },
     programmaticallyOpen: true,
   });
+  // Listens for Escape key while the menu is open.
+  // Closes the portal when Escape is pressed.
+  // Added in capture phase so it still works even if
+  // a nested component stops event propagation.
+  useEffect(() => {
+    if (!isOpen) return undefined;
 
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        closePortal?.();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [isOpen, closePortal]);
   const previousVisible = usePrevious(visible);
   const labelNode =
     toggleLabel && typeof toggleLabel === "string" ? (


### PR DESCRIPTION
…305)

## Done

- ContextualMenu now closes when pressing Escape inside a Modal.
- Added handleKeyDown logic and ensured focus handling works with portals.
- Updated tests to cover ESC key behavior inside Modals.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Open a Modal with a ContextualMenu inside.
- Open the menu and press ESC.
- Ensure the menu closes and focus returns to the trigger button.

### Percy steps

- No visual changes expected.

## Fixes

Fixes: # .
