### PR TITLE
fix: a11y bug aria-expanded not supported here [AC-4117]

### DIFF
--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -41,7 +41,7 @@ describe("Chip ", () => {
     );
     expect(
       within(screen.getByTestId("chip")).getByRole("button", {
-        name: Label.Dismiss,
+        name: `${Label.Dismiss} Bob`,
       }),
     ).toBeInTheDocument();
   });
@@ -59,7 +59,7 @@ describe("Chip ", () => {
     const dismissButton = within(screen.getByTestId("chip")).getByRole(
       "button",
       {
-        name: Label.Dismiss,
+        name: `${Label.Dismiss} Bob`,
       },
     );
     await userEvent.click(dismissButton);
@@ -209,7 +209,7 @@ describe("Chip ", () => {
     const dismissButton = within(screen.getByTestId("chip")).getByRole(
       "button",
       {
-        name: Label.Dismiss,
+        name: `${Label.Dismiss} Bob`,
       },
     );
     await userEvent.click(dismissButton);

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -150,8 +150,15 @@ const Chip = ({
     return (
       <span {...props} className={chipClassName}>
         {chipContent}
-        <button className="p-chip__dismiss" onClick={onDismiss} type="button">
-          <i className="p-icon--close">{Label.Dismiss}</i>
+        <button
+          className="p-chip__dismiss"
+          onClick={onDismiss}
+          type="button"
+          aria-label={`Dismiss ${value}`}
+        >
+          <i className="p-icon--close" aria-hidden="true">
+            {Label.Dismiss}
+          </i>
         </button>
       </span>
     );

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.tsx
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.test.tsx
@@ -10,6 +10,11 @@ const sampleData = {
   chips: [{ value: "us-east1" }, { value: "us-east2" }, { value: "us-east3" }],
 };
 
+const manyChipsData = {
+  ...sampleData,
+  chips: Array.from({ length: 30 }, (_, i) => ({ value: `us-east${i + 1}` })),
+};
+
 describe("Filter panel section", () => {
   it("renders", () => {
     render(
@@ -100,25 +105,45 @@ describe("Filter panel section", () => {
   });
 
   it("all chips are shown when counter is clicked", async () => {
+    // Jest is unaware of layout so we must mock the offsetTop and offsetHeight
+    // of the chips to force the overflow counter to show.
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 40,
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetTop", {
+      configurable: true,
+      value: 100,
+    });
     render(
       <FilterPanelSection
         searchData={[]}
         searchTerm=""
         toggleSelected={jest.fn()}
-        data={sampleData}
+        data={manyChipsData}
         sectionHidden={false}
       />,
     );
+
+    const counter = document.querySelector(
+      ".p-filter-panel-section__counter",
+    ) as HTMLElement;
+    expect(counter).toBeInTheDocument();
+
+    await userEvent.click(counter);
+
     expect(
-      document.querySelector(".p-filter-panel-section__chips"),
-    ).toHaveAttribute("aria-expanded", "false");
-    await userEvent.click(
-      // Use a query selector because the element's text is split up over
-      // multiple elements so it can't be selected by its content.
-      document.querySelector(".p-filter-panel-section__counter") as HTMLElement,
-    );
+      document.querySelector(".p-filter-panel-section__counter"),
+    ).not.toBeInTheDocument();
+
     expect(
-      document.querySelector(".p-filter-panel-section__chips"),
-    ).toHaveAttribute("aria-expanded", "true");
+      screen.getByRole("button", { name: "us-east1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "us-east15" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "us-east30" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.tsx
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.tsx
@@ -104,11 +104,7 @@ const FilterPanelSection = ({
               }}
             />
           )}
-          <div
-            className="p-filter-panel-section__chips"
-            aria-expanded={expanded}
-            ref={chipWrapper}
-          >
+          <div className="p-filter-panel-section__chips" ref={chipWrapper}>
             {chips?.map((chip) => {
               // If search term has been added to input, only matching chips
               // should display

--- a/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.tsx.snap
+++ b/src/components/SearchAndFilter/FilterPanelSection/__snapshots__/FilterPanelSection.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`Filter panel section renders 1`] = `
     Regions
   </h3>
   <div
-    aria-expanded="false"
     class="p-filter-panel-section__chips"
   >
     <button

--- a/src/components/SearchAndFilter/SearchAndFilter.test.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.tsx
@@ -28,9 +28,6 @@ const sampleData = [
 ];
 const getPanel = () => document.querySelector(".p-search-and-filter__panel");
 
-const getSearchContainer = () =>
-  document.querySelector(".p-search-and-filter__search-container");
-
 describe("Search and filter", () => {
   it("renders", async () => {
     const returnSearchData = jest.fn();
@@ -155,14 +152,27 @@ describe("Search and filter", () => {
         returnSearchData={returnSearchData}
       />,
     );
-    expect(getSearchContainer()).toHaveAttribute("aria-expanded", "false");
     await userEvent.click(
       screen.getByRole("searchbox", { name: Label.SearchAndFilter }),
     );
     await userEvent.click(screen.getByRole("button", { name: "us-east1" }));
-    await userEvent.click(screen.getByRole("button", { name: "+1" }));
+    const counter = screen.getByRole("button", { name: "+1" });
+    await userEvent.click(counter);
 
-    expect(getSearchContainer()).toHaveAttribute("aria-expanded", "true");
+    // After expanding, the container should indicate it is expanded.
+    expect(
+      document.querySelector(".p-search-and-filter__search-container"),
+    ).toHaveAttribute("data-expanded", "true");
+
+    expect(
+      screen.getByRole("button", { name: "us-east1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "us-east2" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "us-east3" }),
+    ).toBeInTheDocument();
   });
 
   it("search prompt appears when search field has search term", async () => {
@@ -388,7 +398,7 @@ describe("Search and filter", () => {
     // Dismiss the Cloud: Google filter chip
     const cloudChip: HTMLElement = screen.getByText("CLOUD").closest(".p-chip");
     const dismissButton = within(cloudChip).getByRole("button", {
-      name: "Dismiss",
+      name: "Dismiss Google",
     });
     await userEvent.click(dismissButton);
 

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef, KeyboardEvent } from "react";
-
 import FilterPanelSection from "./FilterPanelSection";
 import Chip from "../Chip";
 import { overflowingChipsCount, isChipInArray } from "./utils";
@@ -241,7 +240,7 @@ const SearchAndFilter = ({
     >
       <div
         className="p-search-and-filter__search-container"
-        aria-expanded={searchBoxExpanded}
+        data-expanded={searchBoxExpanded}
         data-active={searchContainerActive || searchData.length === 0}
         data-empty={searchData.length <= 0}
         ref={searchContainerRef}

--- a/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.tsx.snap
+++ b/src/components/SearchAndFilter/__snapshots__/SearchAndFilter.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Search and filter renders 1`] = `
   data-testid="searchandfilter"
 >
   <div
-    aria-expanded="false"
     class="p-search-and-filter__search-container"
     data-active="true"
     data-empty="true"
+    data-expanded="false"
   >
     <form
       class="p-search-and-filter__box"


### PR DESCRIPTION
## Done

- Fixed a11y error highlighted in this screenshot:
<img width="3713" height="574" alt="image" src="https://github.com/user-attachments/assets/a4807659-fcbd-4ae5-8ca9-25bfe4072a3e" />

- The ```aria-expanded``` attribute is not allowed on a div.
- Following a MM discussion we think it is best to remove aria-expanded because in this case it doesn't really make sense:
- - Firstly, we can't put it on the outer div, but we can't make that div a button or anything else that supports the attribute. We have to make a sacrifice somehow.
- - Secondly, the +N overflow component is a span with a role of a button and it would make sense to have it use th aria-expanded attr, but when you keyboard navigate the component, you will see the +N overflow component disappears making space for the actual overflowing chips, so it adds no value to keyboard navigation hence we believe it is best to remove aria-expanded.
- The big problem is that vanilla uses the aria-expanded attribute to determine when to expand the search bar, but it was wrongly used on the search bar for historical reason. This is why, this PR is **closely related to** [this](https://github.com/canonical/vanilla-framework/pull/5776) vanilla PR.
- The a11y error is now gone

## QA

Pinging @canonical/react-library-maintainers for a review.

We can run axe-core quickly like so: ```npx @axe-core/cli http://localhost:5173/ --verbose```
I used the following ```App.tsx``` file to test:
```
import React, { useMemo, useState } from "react";
import { SearchAndFilter } from "./index";
import type { SearchAndFilterChip } from "./components/SearchAndFilter/types";

const App = (): React.JSX.Element => {
  const [returnedData, setReturnedData] = useState<SearchAndFilterChip[]>([]);

  // Seed a bunch of chips so the input overflows and shows the "+N" expander.
  const existingSearchData = useMemo<SearchAndFilterChip[]>(
    () => [
      { value: "owner:me", quoteValue: false },
      { value: "status:open", quoteValue: false },
      { value: "tag:frontend", quoteValue: false },
      { value: "tag:ui", quoteValue: false },
      { value: "tag:accessibility", quoteValue: false },
      { value: "priority:high", quoteValue: false },
      { value: "env:prod", quoteValue: false },
      { value: "region:eu", quoteValue: false },
      { value: "type:bug", quoteValue: false },
      { value: "team:design-systems", quoteValue: false },
      { value: "component:search", quoteValue: false },
      { value: "component:filter", quoteValue: false },
    ],
    [],
  );

  const filterPanelData = useMemo(
    () => [
      {
        id: 1,
        heading: "Status",
        chips: [
          { value: "status:open", quoteValue: false },
          { value: "status:closed", quoteValue: false },
          { value: "status:review", quoteValue: false },
        ],
      },
      {
        id: 2,
        heading: "Priority",
        chips: [
          { value: "priority:low", quoteValue: false },
          { value: "priority:medium", quoteValue: false },
          { value: "priority:high", quoteValue: false },
        ],
      },
      {
        id: 3,
        heading: "Tags",
        chips: [
          { value: "tag:frontend", quoteValue: false },
          { value: "tag:backend", quoteValue: false },
          { value: "tag:accessibility", quoteValue: false },
          { value: "tag:performance", quoteValue: false },
          { value: "tag:ui", quoteValue: false },
        ],
      },
    ],
    [],
  );

  return (
    <div style={{ padding: 24, maxWidth: 720 }}>
      <h1 style={{ marginTop: 0 }}>Search and filter demo</h1>
      <p style={{ marginTop: 0, opacity: 0.85 }}>
        The control will overflow with the seeded chips. Click the{" "}
        <code>+N</code> indicator to expand and see all chips.
      </p>

      <SearchAndFilter
        existingSearchData={existingSearchData}
        filterPanelData={filterPanelData}
        returnSearchData={setReturnedData}
      />

      <div style={{ marginTop: 16 }}>
        <h2 style={{ marginBottom: 8 }}>Returned search data</h2>
        <pre style={{ margin: 0, padding: 12, background: "rgba(0,0,0,0.15)" }}>
          {JSON.stringify(returnedData, null, 2)}
        </pre>
      </div>
    </div>
  );
};

export default App;

```
## REFS:
- [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded) says: "The aria-expanded attribute is applied to a focusable, interactive control that toggles the visibility of another element."
- Example from the same MDN link:
```
<button aria-expanded="false" aria-controls="menu">
  Menu
</button>
```
- w3 [here](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) says: "When the combobox popup is not visible, the element with role combobox has aria-expanded set to false. When the popup element is visible, aria-expanded is set to true." In our case the "element with role combobox " is the one that triggers the panel to open i.e: the input tag
- MDN [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-expanded) says: "The aria-expanded attribute is applied to a focusable, interactive control that toggles the visibility of another element."
- w3 [here](https://www.w3.org/TR/wai-aria-1.2/#combobox) says: 

"Required States and Properties:	
[aria-controls](https://www.w3.org/TR/wai-aria-1.2/#aria-controls)
[aria-expanded](https://www.w3.org/TR/wai-aria-1.2/#aria-expanded)" for combobox

## Fixes

Fixes: #[AC-4117](https://warthogs.atlassian.net/browse/AC-4117).


[AC-4117]: https://warthogs.atlassian.net/browse/AC-4117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ