### PR TITLE
fix(Modal): allow Escape to close ContextualMenu before closing Modal

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import userEvent from "@testing-library/user-event";
 import Button from "../Button";
+import { useOnEscapePressed } from "hooks";
 import ContextualMenu, { Label } from "./ContextualMenu";
 import { Label as DropdownLabel } from "./ContextualMenuDropdown/ContextualMenuDropdown";
 
@@ -14,6 +15,34 @@ describe("ContextualMenu ", () => {
   it("renders", () => {
     render(<ContextualMenu data-testid="menu" links={[]} />);
     expect(screen.getByTestId("menu")).toMatchSnapshot();
+  });
+
+  it("does not block other Escape handlers elsewhere on the page when open", async () => {
+    // Regression test: a standalone ContextualMenu (i.e. not nested inside a
+    // Modal) registers itself as a non-exclusive entry on the global escape
+    // stack. Opening it should not prevent unrelated useOnEscapePressed-based
+    // components elsewhere on the page from also responding to Escape.
+    const onEscape = jest.fn();
+    const Other = (): React.JSX.Element => {
+      useOnEscapePressed(onEscape);
+      return <div>other</div>;
+    };
+
+    const user = userEvent.setup();
+    render(
+      <>
+        <ContextualMenu
+          toggleLabel="Open menu"
+          links={[{ children: "Item 1" }]}
+        />
+        <Other />
+      </>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /open menu/i }));
+    await user.keyboard("{Escape}");
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
   });
 
   it("can be aligned to the right", () => {

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -4,6 +4,7 @@ import React, { FC, useEffect, useState } from "react";
 
 import Button from "components/Button";
 import Input from "components/Input";
+import ContextualMenu from "components/ContextualMenu";
 import Modal from "./Modal";
 
 describe("Modal ", () => {
@@ -221,6 +222,41 @@ describe("Modal ", () => {
     await userEvent.type(container.querySelector("input"), "delete item1");
     expect(input).toHaveFocus();
     expect(input).toHaveValue("delete item1");
+  });
+
+  it("should allow Escape to close a ContextualMenu inside the modal before closing the modal", async () => {
+    const handleCloseModal = jest.fn();
+    const handleMenuToggle = jest.fn();
+
+    render(
+      <Modal title="Test" close={handleCloseModal}>
+        <ContextualMenu
+          toggleLabel="Open menu"
+          links={[{ children: "Item 1" }]}
+          onToggleMenu={handleMenuToggle}
+          visible={true}
+        />
+      </Modal>,
+    );
+
+    // The contextual menu dropdown should be open (aria-hidden="false")
+    const dropdown = document.querySelector(
+      '.p-contextual-menu__dropdown[aria-hidden="false"]',
+    );
+    expect(dropdown).toBeInTheDocument();
+
+    // Press Escape — should close the menu, not the modal
+    await userEvent.keyboard("{Escape}");
+
+    // The modal close handler should NOT have been called
+    expect(handleCloseModal).not.toHaveBeenCalled();
+
+    // The dropdown should now be closed (no longer present with aria-hidden="false")
+    expect(
+      document.querySelector(
+        '.p-contextual-menu__dropdown[aria-hidden="false"]',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("updates focusable elements when an initially disabled button becomes enabled", async () => {

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -105,7 +105,11 @@ describe("Modal ", () => {
     expect(closeButton).toHaveFocus();
   });
 
-  it("should stop immediate Esc press propagation", async () => {
+  it("should stop immediate Esc press propagation to other document listeners", async () => {
+    // A sibling component that registers a raw document keydown listener.
+    // It should NOT fire when the Modal handles Escape, because the global
+    // escape stack calls stopImmediatePropagation() before any other
+    // document listeners run.
     const MockEscEventComponent = ({
       onEscPress,
     }: {
@@ -113,7 +117,7 @@ describe("Modal ", () => {
     }): React.JSX.Element => {
       useEffect(() => {
         const handleEscPress = (e: KeyboardEvent) => {
-          if (e.code === "Escape") {
+          if (e.key === "Escape") {
             onEscPress();
           }
         };
@@ -224,39 +228,31 @@ describe("Modal ", () => {
     expect(input).toHaveValue("delete item1");
   });
 
-  it("should allow Escape to close a ContextualMenu inside the modal before closing the modal", async () => {
+  it("should allow Escape to close an open overlay inside the modal before closing the modal", async () => {
+    // Regression test for https://github.com/canonical/react-components/issues/1305
+    //
+    // Both Modal and ContextualMenu register on the global escape-key stack.
+    // The menu is opened after the modal, so its handler sits on top of the
+    // stack and must be called first (LIFO order).
     const handleCloseModal = jest.fn();
-    const handleMenuToggle = jest.fn();
 
     render(
       <Modal title="Test" close={handleCloseModal}>
         <ContextualMenu
           toggleLabel="Open menu"
           links={[{ children: "Item 1" }]}
-          onToggleMenu={handleMenuToggle}
           visible={true}
         />
       </Modal>,
     );
 
-    // The contextual menu dropdown should be open (aria-hidden="false")
-    const dropdown = document.querySelector(
-      '.p-contextual-menu__dropdown[aria-hidden="false"]',
-    );
-    expect(dropdown).toBeInTheDocument();
-
-    // Press Escape — should close the menu, not the modal
+    // First Escape — should dismiss the ContextualMenu, not the Modal
     await userEvent.keyboard("{Escape}");
-
-    // The modal close handler should NOT have been called
     expect(handleCloseModal).not.toHaveBeenCalled();
 
-    // The dropdown should now be closed (no longer present with aria-hidden="false")
-    expect(
-      document.querySelector(
-        '.p-contextual-menu__dropdown[aria-hidden="false"]',
-      ),
-    ).not.toBeInTheDocument();
+    // Second Escape — menu is gone, so the Modal should now close
+    await userEvent.keyboard("{Escape}");
+    expect(handleCloseModal).toHaveBeenCalledTimes(1);
   });
 
   it("updates focusable elements when an initially disabled button becomes enabled", async () => {

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -232,8 +232,9 @@ describe("Modal ", () => {
     // Regression test for https://github.com/canonical/react-components/issues/1305
     //
     // Both Modal and ContextualMenu register on the global escape-key stack.
-    // The menu is opened after the modal, so its handler sits on top of the
-    // stack and must be called first (LIFO order).
+    // The menu is opened *after* the modal mounts (via a click), so its handler
+    // sits on top of the stack and must be called first (LIFO order).
+    const user = userEvent.setup();
     const handleCloseModal = jest.fn();
 
     render(
@@ -241,17 +242,20 @@ describe("Modal ", () => {
         <ContextualMenu
           toggleLabel="Open menu"
           links={[{ children: "Item 1" }]}
-          visible={true}
         />
       </Modal>,
     );
 
+    // Open the ContextualMenu after the modal is already mounted —
+    // this pushes its escape handler on top of the modal's in the LIFO stack.
+    await user.click(screen.getByRole("button", { name: /open menu/i }));
+
     // First Escape — should dismiss the ContextualMenu, not the Modal
-    await userEvent.keyboard("{Escape}");
+    await user.keyboard("{Escape}");
     expect(handleCloseModal).not.toHaveBeenCalled();
 
     // Second Escape — menu is gone, so the Modal should now close
-    await userEvent.keyboard("{Escape}");
+    await user.keyboard("{Escape}");
     expect(handleCloseModal).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React, { useId, useRef, useEffect } from "react";
 import type { HTMLProps, ReactNode, RefObject } from "react";
 import { ClassName, PropsWithSpread } from "types";
+import { useOnEscapePressed } from "hooks";
 
 export type Props = PropsWithSpread<
   {
@@ -88,33 +89,7 @@ export const Modal = ({
     }
   };
 
-  const handleEscKey = (
-    event: KeyboardEvent | React.KeyboardEvent<HTMLDivElement>,
-  ) => {
-    // If there is an open contextual menu dropdown inside (or alongside) this
-    // modal, let the Escape event propagate so that the menu's own keydown
-    // handler can close it first. The modal should only intercept Escape when
-    // no child overlay is open. This fixes the bug where a ContextualMenu
-    // rendered inside a Modal cannot be closed with the Escape key because
-    // stopImmediatePropagation() was called unconditionally, preventing the
-    // menu's document-level keydown listener from ever firing.
-    const hasOpenDropdown = !!document.querySelector(
-      '.p-contextual-menu__dropdown[aria-hidden="false"]',
-    );
-    if (hasOpenDropdown) {
-      return;
-    }
-    if ("nativeEvent" in event && event.nativeEvent.stopImmediatePropagation) {
-      event.nativeEvent.stopImmediatePropagation();
-    } else if ("stopImmediatePropagation" in event) {
-      event.stopImmediatePropagation();
-    } else if (event.stopPropagation) {
-      event.stopPropagation();
-    }
-    if (close) {
-      close();
-    }
-  };
+  useOnEscapePressed(() => close?.(), { isEnabled: !!close });
 
   useEffect(() => {
     if (focusRef?.current) {
@@ -127,14 +102,10 @@ export const Modal = ({
   }, [focusRef]);
 
   useEffect(() => {
-    const keyListenersMap = new Map([
-      ["Escape", handleEscKey],
-      ["Tab", handleTabKey],
-    ]);
-
     const keyDown = (event: KeyboardEvent) => {
-      const listener = keyListenersMap.get(event.code);
-      return listener && listener(event);
+      if (event.code === "Tab") {
+        handleTabKey(event as unknown as React.KeyboardEvent<HTMLDivElement>);
+      }
     };
 
     document.addEventListener("keydown", keyDown);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -91,6 +91,19 @@ export const Modal = ({
   const handleEscKey = (
     event: KeyboardEvent | React.KeyboardEvent<HTMLDivElement>,
   ) => {
+    // If there is an open contextual menu dropdown inside (or alongside) this
+    // modal, let the Escape event propagate so that the menu's own keydown
+    // handler can close it first. The modal should only intercept Escape when
+    // no child overlay is open. This fixes the bug where a ContextualMenu
+    // rendered inside a Modal cannot be closed with the Escape key because
+    // stopImmediatePropagation() was called unconditionally, preventing the
+    // menu's document-level keydown listener from ever firing.
+    const hasOpenDropdown = !!document.querySelector(
+      '.p-contextual-menu__dropdown[aria-hidden="false"]',
+    );
+    if (hasOpenDropdown) {
+      return;
+    }
     if ("nativeEvent" in event && event.nativeEvent.stopImmediatePropagation) {
       event.nativeEvent.stopImmediatePropagation();
     } else if ("stopImmediatePropagation" in event) {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React, { useId, useRef, useEffect } from "react";
 import type { HTMLProps, ReactNode, RefObject } from "react";
 import { ClassName, PropsWithSpread } from "types";
-import { useOnEscapePressed } from "hooks";
+import { useEscapeStack } from "hooks";
 
 export type Props = PropsWithSpread<
   {
@@ -89,7 +89,7 @@ export const Modal = ({
     }
   };
 
-  useOnEscapePressed(() => close?.(), { isEnabled: !!close });
+  useEscapeStack(() => close?.(), { isEnabled: !!close });
 
   useEffect(() => {
     if (focusRef?.current) {

--- a/src/components/Navigation/Navigation.test.tsx
+++ b/src/components/Navigation/Navigation.test.tsx
@@ -275,6 +275,43 @@ it("closes the search form when the escape key is pressed", async () => {
   expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
 });
 
+it("does not occupy the escape stack while the search box is closed", async () => {
+  // Regression test: Navigation must only join the global escape-key stack
+  // while its search box is open. Otherwise it can sit on top of the LIFO
+  // stack indefinitely and swallow Escape presses meant for another overlay
+  // (e.g. a SearchAndFilter panel) opened elsewhere on the page.
+  const onEscPress = jest.fn();
+
+  const MockEscEventComponent = (): React.JSX.Element => {
+    React.useEffect(() => {
+      const handleEscPress = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          onEscPress();
+        }
+      };
+      document.addEventListener("keydown", handleEscPress);
+      return () => {
+        document.removeEventListener("keydown", handleEscPress);
+      };
+    });
+    return <div>Mock component with event on Esc key press</div>;
+  };
+
+  render(
+    <>
+      <Navigation
+        logo={<img src="" alt="" />}
+        searchProps={{ onSearch: jest.fn() }}
+      />
+      <MockEscEventComponent />
+    </>,
+  );
+
+  expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+  fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+  expect(onEscPress).toHaveBeenCalledTimes(1);
+});
+
 it("closes the search form when opening the mobile menu", async () => {
   render(
     <Navigation

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -203,7 +203,7 @@ const Navigation = ({
     }
   };
   // Hide the searchbox when the escape key is pressed.
-  useOnEscapePressed(() => toggleSearch(false));
+  useOnEscapePressed(() => toggleSearch(false), { isEnabled: searchOpen });
 
   useEffect(() => {
     if (searchOpen) {

--- a/src/components/SearchAndFilter/SearchAndFilter.test.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.test.tsx
@@ -394,4 +394,61 @@ describe("Search and filter", () => {
 
     expect(onPanelToggle).not.toHaveBeenCalled();
   });
+
+  it("closes the filter panel when escape is pressed", async () => {
+    const returnSearchData = jest.fn();
+    render(
+      <SearchAndFilter
+        data-testid="searchandfilter"
+        filterPanelData={sampleData}
+        returnSearchData={returnSearchData}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("searchandfilter"));
+    expect(getPanel()).toHaveAttribute("aria-hidden", "false");
+
+    await userEvent.keyboard("{Escape}");
+    expect(getPanel()).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("does not occupy the escape stack while the panel is closed", async () => {
+    // Regression test for https://github.com/canonical/react-components/pull/1339#discussion_r1234
+    //
+    // SearchAndFilter must only join the global escape-key stack while its
+    // panel is open. Otherwise, if it is mounted alongside another overlay
+    // (e.g. Navigation's search box) and registers unconditionally, it can
+    // sit on top of the LIFO stack and swallow Escape presses meant for that
+    // other overlay even though its own panel is closed.
+    const returnSearchData = jest.fn();
+    const onEscPress = jest.fn();
+
+    const MockEscEventComponent = (): React.JSX.Element => {
+      React.useEffect(() => {
+        const handleEscPress = (e: KeyboardEvent) => {
+          if (e.key === "Escape") {
+            onEscPress();
+          }
+        };
+        document.addEventListener("keydown", handleEscPress);
+        return () => {
+          document.removeEventListener("keydown", handleEscPress);
+        };
+      });
+      return <div>Mock component with event on Esc key press</div>;
+    };
+
+    render(
+      <>
+        <SearchAndFilter
+          filterPanelData={sampleData}
+          returnSearchData={returnSearchData}
+        />
+        <MockEscEventComponent />
+      </>,
+    );
+
+    expect(getPanel()).toHaveAttribute("aria-hidden", "true");
+    await userEvent.keyboard("{Escape}");
+    expect(onEscPress).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -92,7 +92,7 @@ const SearchAndFilter = ({
   const closePanel = () => {
     setFilterPanelHidden(true);
   };
-  useOnEscapePressed(() => closePanel());
+  useOnEscapePressed(() => closePanel(), { isEnabled: !filterPanelHidden });
 
   // This useEffect sets up listeners so the panel will close if user clicks
   // anywhere else on the page or hits the escape key

--- a/src/external/usePortal.ts
+++ b/src/external/usePortal.ts
@@ -13,6 +13,7 @@ import {
   RefObject,
   MouseEvent,
 } from "react";
+import { pushEscapeHandler } from "../hooks/useEscapeStack";
 import { createPortal } from "react-dom";
 import { useSSR } from "./useSSR";
 
@@ -126,14 +127,6 @@ export const usePortal = ({
     [closePortal, openPortal],
   );
 
-  const handleKeydown = useCallback(
-    (e: KeyboardEvent): void =>
-      e.key === "Escape" && closeOnEsc
-        ? closePortal(e as unknown as SyntheticEvent<HTMLElement, Event>)
-        : undefined,
-    [closeOnEsc, closePortal],
-  );
-
   const handleOutsideMouseClick = useCallback(
     (e: MouseEvent): void => {
       const containsTarget = (target: RefObject<HTMLElement>) =>
@@ -179,21 +172,27 @@ export const usePortal = ({
     const node = portal.current;
     elToMountTo.appendChild(portal.current);
 
-    document.addEventListener("keydown", handleKeydown);
     document.addEventListener(
       "mousedown",
       handleMouseDown as unknown as EventListener,
     );
 
     return () => {
-      document.removeEventListener("keydown", handleKeydown);
       document.removeEventListener(
         "mousedown",
         handleMouseDown as unknown as EventListener,
       );
       elToMountTo.removeChild(node);
     };
-  }, [isServer, handleOutsideMouseClick, handleKeydown, elToMountTo, portal]);
+  }, [isServer, handleOutsideMouseClick, elToMountTo, portal]);
+
+  // Register on the global escape-key stack only while the portal is open.
+  // LIFO ordering ensures the most recently opened overlay always handles
+  // Escape first, regardless of component type or DOM structure.
+  useEffect(() => {
+    if (isServer || !closeOnEsc || !isOpen) return undefined;
+    return pushEscapeHandler(() => closePortal());
+  }, [isOpen, closeOnEsc, isServer, closePortal]);
 
   const Portal = useCallback(
     ({ children }: { children: ReactNode }) => {

--- a/src/external/usePortal.ts
+++ b/src/external/usePortal.ts
@@ -186,13 +186,22 @@ export const usePortal = ({
     };
   }, [isServer, handleOutsideMouseClick, elToMountTo, portal]);
 
+  // Keep a ref to closePortal so the escape-stack effect below does not need
+  // it as a dependency. This prevents closePortal identity changes (e.g. when
+  // onClose prop changes) from re-registering the handler and incorrectly
+  // moving an already-open portal to the top of the LIFO stack.
+  const closePortalRef = useRef(closePortal);
+  useEffect(() => {
+    closePortalRef.current = closePortal;
+  }, [closePortal]);
+
   // Register on the global escape-key stack only while the portal is open.
   // LIFO ordering ensures the most recently opened overlay always handles
   // Escape first, regardless of component type or DOM structure.
   useEffect(() => {
     if (isServer || !closeOnEsc || !isOpen) return undefined;
-    return pushEscapeHandler(() => closePortal());
-  }, [isOpen, closeOnEsc, isServer, closePortal]);
+    return pushEscapeHandler(() => closePortalRef.current());
+  }, [isOpen, closeOnEsc, isServer]);
 
   const Portal = useCallback(
     ({ children }: { children: ReactNode }) => {

--- a/src/external/usePortal.ts
+++ b/src/external/usePortal.ts
@@ -198,9 +198,17 @@ export const usePortal = ({
   // Register on the global escape-key stack only while the portal is open.
   // LIFO ordering ensures the most recently opened overlay always handles
   // Escape first, regardless of component type or DOM structure.
+  //
+  // Registered as non-exclusive: this portal closes itself on Escape, but
+  // does not stop the event from propagating to unrelated `document`
+  // keydown listeners (e.g. useOnEscapePressed-based components elsewhere
+  // on the page). Exclusive ownership of Escape (e.g. while a Modal is open)
+  // is reserved for entries that opt into it explicitly.
   useEffect(() => {
     if (isServer || !closeOnEsc || !isOpen) return undefined;
-    return pushEscapeHandler(() => closePortalRef.current());
+    return pushEscapeHandler(() => closePortalRef.current(), {
+      exclusive: false,
+    });
   }, [isOpen, closeOnEsc, isServer]);
 
   const Portal = useCallback(

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useOnClickOutside, useClickOutside } from "./useOnClickOutside";
+export { pushEscapeHandler, useEscapeStack } from "./useEscapeStack";
 export { useId } from "./useId";
 export { useListener } from "./useListener";
 export { useOnEscapePressed } from "./useOnEscapePressed";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export { useOnClickOutside, useClickOutside } from "./useOnClickOutside";
-export { pushEscapeHandler, useEscapeStack } from "./useEscapeStack";
+export { useEscapeStack } from "./useEscapeStack";
 export { useId } from "./useId";
 export { useListener } from "./useListener";
 export { useOnEscapePressed } from "./useOnEscapePressed";

--- a/src/hooks/useEscapeStack.test.ts
+++ b/src/hooks/useEscapeStack.test.ts
@@ -1,0 +1,68 @@
+import { pushEscapeHandler } from "./useEscapeStack";
+
+const fireEscape = () =>
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+afterEach(() => {
+  // Each test unregisters its own handlers via the returned cleanup functions,
+  // so nothing to do here — this guard is just for safety.
+});
+
+describe("pushEscapeHandler", () => {
+  it("calls the registered handler when Escape is pressed", () => {
+    const handler = jest.fn();
+    const unregister = pushEscapeHandler(handler);
+    fireEscape();
+    expect(handler).toHaveBeenCalledTimes(1);
+    unregister();
+  });
+
+  it("does not call the handler after it is unregistered", () => {
+    const handler = jest.fn();
+    const unregister = pushEscapeHandler(handler);
+    unregister();
+    fireEscape();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("calls only the most recently pushed handler (LIFO order)", () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const unregisterFirst = pushEscapeHandler(first);
+    const unregisterSecond = pushEscapeHandler(second);
+
+    fireEscape();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+
+    unregisterSecond();
+    unregisterFirst();
+  });
+
+  it("falls back to the previous handler once the top handler is removed", () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const unregisterFirst = pushEscapeHandler(first);
+    const unregisterSecond = pushEscapeHandler(second);
+
+    unregisterSecond();
+    fireEscape();
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+
+    unregisterFirst();
+  });
+
+  it("stops propagation so other document keydown listeners do not fire", () => {
+    const outsideListener = jest.fn();
+    // Register an external listener AFTER the stack listener would be added.
+    const unregister = pushEscapeHandler(jest.fn());
+    document.addEventListener("keydown", outsideListener);
+
+    fireEscape();
+    expect(outsideListener).not.toHaveBeenCalled();
+
+    document.removeEventListener("keydown", outsideListener);
+    unregister();
+  });
+});

--- a/src/hooks/useEscapeStack.test.ts
+++ b/src/hooks/useEscapeStack.test.ts
@@ -65,4 +65,70 @@ describe("pushEscapeHandler", () => {
     document.removeEventListener("keydown", outsideListener);
     unregister();
   });
+
+  it("removes the correct entry when the same handler reference is pushed twice", () => {
+    // Regression test: unregistering must not rely on the handler's
+    // identity, since the same function reference could be passed to
+    // multiple registrations.
+    const shared = jest.fn();
+    const unregisterFirst = pushEscapeHandler(shared);
+    const unregisterSecond = pushEscapeHandler(shared);
+
+    // Unregister the first (bottom) entry — the second (top) entry should
+    // remain on the stack and still fire.
+    unregisterFirst();
+    fireEscape();
+    expect(shared).toHaveBeenCalledTimes(1);
+
+    unregisterSecond();
+    shared.mockClear();
+    fireEscape();
+    expect(shared).not.toHaveBeenCalled();
+  });
+
+  describe("non-exclusive entries", () => {
+    it("calls the handler but does not stop propagation to other listeners", () => {
+      const handler = jest.fn();
+      const outsideListener = jest.fn();
+      const unregister = pushEscapeHandler(handler, { exclusive: false });
+      document.addEventListener("keydown", outsideListener);
+
+      fireEscape();
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(outsideListener).toHaveBeenCalledTimes(1);
+
+      document.removeEventListener("keydown", outsideListener);
+      unregister();
+    });
+
+    it("is skipped in favour of a non-exclusive entry above it, without stopping propagation", () => {
+      // Mirrors a ContextualMenu (non-exclusive) opened inside a Modal
+      // (exclusive): the first Escape press should be handled by the
+      // ContextualMenu only, and should not be silenced for other listeners.
+      const exclusiveHandler = jest.fn();
+      const nonExclusiveHandler = jest.fn();
+      const outsideListener = jest.fn();
+
+      const unregisterExclusive = pushEscapeHandler(exclusiveHandler);
+      const unregisterNonExclusive = pushEscapeHandler(nonExclusiveHandler, {
+        exclusive: false,
+      });
+      document.addEventListener("keydown", outsideListener);
+
+      fireEscape();
+      expect(nonExclusiveHandler).toHaveBeenCalledTimes(1);
+      expect(exclusiveHandler).not.toHaveBeenCalled();
+      expect(outsideListener).toHaveBeenCalledTimes(1);
+
+      // Once the non-exclusive entry is gone, the exclusive one underneath
+      // takes over and reclaims exclusive ownership of Escape.
+      unregisterNonExclusive();
+      fireEscape();
+      expect(exclusiveHandler).toHaveBeenCalledTimes(1);
+      expect(outsideListener).toHaveBeenCalledTimes(1);
+
+      document.removeEventListener("keydown", outsideListener);
+      unregisterExclusive();
+    });
+  });
 });

--- a/src/hooks/useEscapeStack.ts
+++ b/src/hooks/useEscapeStack.ts
@@ -1,0 +1,61 @@
+/**
+ * A module-level LIFO stack of Escape-key handlers.
+ *
+ * Any overlay component (Modal, ContextualMenu, Drawer, …) can register a
+ * handler here. Only the most recently registered handler fires when Escape
+ * is pressed, so nested overlays always dismiss in the correct order
+ * regardless of their DOM position or portal placement.
+ */
+
+import { useEffect } from "react";
+
+const handlers: Array<() => void> = [];
+
+function onKeyDown(e: KeyboardEvent): void {
+  if (e.key !== "Escape" || handlers.length === 0) return;
+  e.stopImmediatePropagation();
+  handlers[handlers.length - 1]();
+}
+
+/**
+ * Push a callback onto the global escape-key stack.
+ * Returns a cleanup function that removes the handler (suitable for
+ * use as a `useEffect` cleanup return).
+ * Handlers are invoked in LIFO order — the last one pushed runs first,
+ * mirroring the visual stacking of overlays.
+ */
+export function pushEscapeHandler(handler: () => void): () => void {
+  if (handlers.length === 0) {
+    document.addEventListener("keydown", onKeyDown);
+  }
+  handlers.push(handler);
+  return () => {
+    const idx = handlers.lastIndexOf(handler);
+    if (idx !== -1) handlers.splice(idx, 1);
+    if (handlers.length === 0) {
+      document.removeEventListener("keydown", onKeyDown);
+    }
+  };
+}
+
+/**
+ * React hook that registers an Escape-key handler on the global LIFO stack
+ * for the lifetime of the component (or while `isActive` is true).
+ *
+ * The most recently registered handler always fires first, so nested overlays
+ * naturally dismiss in the correct order regardless of DOM structure.
+ *
+ * @param handler - Callback invoked when Escape is pressed and this handler
+ *   is at the top of the stack.
+ * @param options.isActive - When `false` the handler is not registered
+ *   (defaults to `true`).
+ */
+export const useEscapeStack = (
+  handler: () => void,
+  { isActive } = { isActive: true },
+): void => {
+  useEffect(() => {
+    if (!isActive) return undefined;
+    return pushEscapeHandler(handler);
+  }, [handler, isActive]);
+};

--- a/src/hooks/useEscapeStack.ts
+++ b/src/hooks/useEscapeStack.ts
@@ -27,6 +27,9 @@ function onKeyDown(e: KeyboardEvent): void {
  * mirroring the visual stacking of overlays.
  *
  * Safe to call in SSR environments — it no-ops when `document` is unavailable.
+ *
+ * This is the imperative primitive behind `useEscapeStack` and is not part
+ * of the public package API. React consumers should use `useEscapeStack`.
  */
 export function pushEscapeHandler(handler: () => void): () => void {
   if (typeof document === "undefined") return () => undefined;
@@ -46,7 +49,7 @@ export function pushEscapeHandler(handler: () => void): () => void {
 
 /**
  * React hook that registers an Escape-key handler on the global LIFO stack
- * for the lifetime of the component (or while `isActive` is true).
+ * for the lifetime of the component (or while `isEnabled` is true).
  *
  * The most recently registered handler always fires first, so nested overlays
  * naturally dismiss in the correct order regardless of DOM structure.
@@ -57,12 +60,12 @@ export function pushEscapeHandler(handler: () => void): () => void {
  *
  * @param handler - Callback invoked when Escape is pressed and this handler
  *   is at the top of the stack.
- * @param options.isActive - When `false` the handler is not registered
+ * @param options.isEnabled - When `false` the handler is not registered
  *   (defaults to `true`).
  */
 export const useEscapeStack = (
   handler: () => void,
-  { isActive } = { isActive: true },
+  { isEnabled } = { isEnabled: true },
 ): void => {
   // Always keep the ref pointing at the latest handler without changing
   // the registered stable wrapper.
@@ -72,8 +75,8 @@ export const useEscapeStack = (
   }, [handler]);
 
   useEffect(() => {
-    if (!isActive) return undefined;
+    if (!isEnabled) return undefined;
     // Register a stable wrapper; the ref always calls the latest handler.
     return pushEscapeHandler(() => handlerRef.current());
-  }, [isActive]);
+  }, [isEnabled]);
 };

--- a/src/hooks/useEscapeStack.ts
+++ b/src/hooks/useEscapeStack.ts
@@ -7,10 +7,12 @@
  * regardless of their DOM position or portal placement.
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 const handlers: Array<() => void> = [];
 
+// Use capture phase so the stack fires before any bubble-phase listeners
+// and cannot be silenced by stopPropagation() on a focused child element.
 function onKeyDown(e: KeyboardEvent): void {
   if (e.key !== "Escape" || handlers.length === 0) return;
   e.stopImmediatePropagation();
@@ -23,17 +25,21 @@ function onKeyDown(e: KeyboardEvent): void {
  * use as a `useEffect` cleanup return).
  * Handlers are invoked in LIFO order — the last one pushed runs first,
  * mirroring the visual stacking of overlays.
+ *
+ * Safe to call in SSR environments — it no-ops when `document` is unavailable.
  */
 export function pushEscapeHandler(handler: () => void): () => void {
+  if (typeof document === "undefined") return () => undefined;
   if (handlers.length === 0) {
-    document.addEventListener("keydown", onKeyDown);
+    // capture: true — fires before bubble-phase listeners on any descendant
+    document.addEventListener("keydown", onKeyDown, true);
   }
   handlers.push(handler);
   return () => {
     const idx = handlers.lastIndexOf(handler);
     if (idx !== -1) handlers.splice(idx, 1);
     if (handlers.length === 0) {
-      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keydown", onKeyDown, true);
     }
   };
 }
@@ -45,6 +51,10 @@ export function pushEscapeHandler(handler: () => void): () => void {
  * The most recently registered handler always fires first, so nested overlays
  * naturally dismiss in the correct order regardless of DOM structure.
  *
+ * A stable wrapper is kept in a ref so that inline callbacks passed by callers
+ * do not cause the handler to be popped/pushed on every re-render, which would
+ * incorrectly move the overlay to the top of the stack.
+ *
  * @param handler - Callback invoked when Escape is pressed and this handler
  *   is at the top of the stack.
  * @param options.isActive - When `false` the handler is not registered
@@ -54,8 +64,16 @@ export const useEscapeStack = (
   handler: () => void,
   { isActive } = { isActive: true },
 ): void => {
+  // Always keep the ref pointing at the latest handler without changing
+  // the registered stable wrapper.
+  const handlerRef = useRef(handler);
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
+
   useEffect(() => {
     if (!isActive) return undefined;
-    return pushEscapeHandler(handler);
-  }, [handler, isActive]);
+    // Register a stable wrapper; the ref always calls the latest handler.
+    return pushEscapeHandler(() => handlerRef.current());
+  }, [isActive]);
 };

--- a/src/hooks/useEscapeStack.ts
+++ b/src/hooks/useEscapeStack.ts
@@ -5,18 +5,43 @@
  * handler here. Only the most recently registered handler fires when Escape
  * is pressed, so nested overlays always dismiss in the correct order
  * regardless of their DOM position or portal placement.
+ *
+ * Each entry can be `exclusive` (the default) or not:
+ *  - Exclusive entries (e.g. Modal) claim Escape entirely while they are on
+ *    top of the stack — `stopImmediatePropagation()` is called, so no other
+ *    `document` keydown listener (including non-stack ones, such as
+ *    `useOnEscapePressed`) sees the event. This preserves Modal's long
+ *    standing behaviour of owning Escape while it is open.
+ *  - Non-exclusive entries (e.g. portal-based overlays such as
+ *    ContextualMenu) handle Escape themselves but let the event continue to
+ *    propagate, so they don't silence unrelated listeners elsewhere on the
+ *    page when used on their own.
+ *
+ * When a non-exclusive entry sits on top of an exclusive one (e.g. a
+ * ContextualMenu opened inside a Modal), the first Escape press is handled
+ * by the non-exclusive entry without claiming the event, and the exclusive
+ * entry below it is skipped for that press — giving correct two-step
+ * dismissal (innermost overlay first).
  */
 
 import { useEffect, useRef } from "react";
 
-const handlers: Array<() => void> = [];
+type EscapeStackEntry = {
+  onEscape: () => void;
+  exclusive: boolean;
+};
+
+const stack: EscapeStackEntry[] = [];
 
 // Use capture phase so the stack fires before any bubble-phase listeners
 // and cannot be silenced by stopPropagation() on a focused child element.
 function onKeyDown(e: KeyboardEvent): void {
-  if (e.key !== "Escape" || handlers.length === 0) return;
-  e.stopImmediatePropagation();
-  handlers[handlers.length - 1]();
+  if (e.key !== "Escape" || stack.length === 0) return;
+  const top = stack[stack.length - 1];
+  if (top.exclusive) {
+    e.stopImmediatePropagation();
+  }
+  top.onEscape();
 }
 
 /**
@@ -26,22 +51,36 @@ function onKeyDown(e: KeyboardEvent): void {
  * Handlers are invoked in LIFO order — the last one pushed runs first,
  * mirroring the visual stacking of overlays.
  *
+ * @param onEscape - Callback invoked when Escape is pressed and this entry
+ *   is at the top of the stack.
+ * @param options.exclusive - When `true` (the default), this entry claims
+ *   the Escape press entirely while on top of the stack, preventing any
+ *   other `document` keydown listener from seeing it. Set to `false` for
+ *   overlays that should not silence unrelated Escape handlers when used on
+ *   their own (e.g. portal-based overlays).
+ *
  * Safe to call in SSR environments — it no-ops when `document` is unavailable.
  *
  * This is the imperative primitive behind `useEscapeStack` and is not part
  * of the public package API. React consumers should use `useEscapeStack`.
  */
-export function pushEscapeHandler(handler: () => void): () => void {
+export function pushEscapeHandler(
+  onEscape: () => void,
+  { exclusive = true }: { exclusive?: boolean } = {},
+): () => void {
   if (typeof document === "undefined") return () => undefined;
-  if (handlers.length === 0) {
+  // Wrap in a fresh object so each registration has a unique identity, even
+  // if the same callback reference is pushed more than once.
+  const entry: EscapeStackEntry = { onEscape, exclusive };
+  if (stack.length === 0) {
     // capture: true — fires before bubble-phase listeners on any descendant
     document.addEventListener("keydown", onKeyDown, true);
   }
-  handlers.push(handler);
+  stack.push(entry);
   return () => {
-    const idx = handlers.lastIndexOf(handler);
-    if (idx !== -1) handlers.splice(idx, 1);
-    if (handlers.length === 0) {
+    const idx = stack.indexOf(entry);
+    if (idx !== -1) stack.splice(idx, 1);
+    if (stack.length === 0) {
       document.removeEventListener("keydown", onKeyDown, true);
     }
   };
@@ -62,10 +101,16 @@ export function pushEscapeHandler(handler: () => void): () => void {
  *   is at the top of the stack.
  * @param options.isEnabled - When `false` the handler is not registered
  *   (defaults to `true`).
+ * @param options.exclusive - See `pushEscapeHandler`. Defaults to `true`.
  */
+export type UseEscapeStackOptions = {
+  isEnabled?: boolean;
+  exclusive?: boolean;
+};
+
 export const useEscapeStack = (
   handler: () => void,
-  { isEnabled } = { isEnabled: true },
+  { isEnabled = true, exclusive = true }: UseEscapeStackOptions = {},
 ): void => {
   // Always keep the ref pointing at the latest handler without changing
   // the registered stable wrapper.
@@ -77,6 +122,6 @@ export const useEscapeStack = (
   useEffect(() => {
     if (!isEnabled) return undefined;
     // Register a stable wrapper; the ref always calls the latest handler.
-    return pushEscapeHandler(() => handlerRef.current());
-  }, [isEnabled]);
+    return pushEscapeHandler(() => handlerRef.current(), { exclusive });
+  }, [isEnabled, exclusive]);
 };

--- a/src/hooks/useOnEscapePressed.ts
+++ b/src/hooks/useOnEscapePressed.ts
@@ -1,26 +1,18 @@
-import { useCallback, useEffect } from "react";
+import { useEffect } from "react";
+import { pushEscapeHandler } from "./useEscapeStack";
 
 /**
  * Handle the escape key pressed.
+ * Registers the callback on the global escape-key stack so that nested
+ * overlays (modals, dropdowns, drawers, …) always dismiss in the correct
+ * LIFO order, regardless of DOM position or portal placement.
  */
 export const useOnEscapePressed = (
   onEscape: () => void,
   { isEnabled } = { isEnabled: true },
 ) => {
-  const keyDown = useCallback(
-    (evt: KeyboardEvent) => {
-      if (evt.code === "Escape") {
-        onEscape();
-      }
-    },
-    [onEscape],
-  );
   useEffect(() => {
-    if (isEnabled) {
-      document.addEventListener("keydown", keyDown);
-    }
-    return () => {
-      document.removeEventListener("keydown", keyDown);
-    };
-  }, [keyDown, isEnabled]);
+    if (!isEnabled) return undefined;
+    return pushEscapeHandler(onEscape);
+  }, [onEscape, isEnabled]);
 };

--- a/src/hooks/useOnEscapePressed.ts
+++ b/src/hooks/useOnEscapePressed.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { pushEscapeHandler } from "./useEscapeStack";
 
 /**
@@ -6,13 +6,22 @@ import { pushEscapeHandler } from "./useEscapeStack";
  * Registers the callback on the global escape-key stack so that nested
  * overlays (modals, dropdowns, drawers, …) always dismiss in the correct
  * LIFO order, regardless of DOM position or portal placement.
+ *
+ * A stable wrapper is kept in a ref so that inline callbacks do not cause
+ * the handler to be unregistered/re-registered on every re-render (which
+ * would incorrectly move this overlay to the top of the stack).
  */
 export const useOnEscapePressed = (
   onEscape: () => void,
   { isEnabled } = { isEnabled: true },
 ) => {
+  const onEscapeRef = useRef(onEscape);
+  useEffect(() => {
+    onEscapeRef.current = onEscape;
+  }, [onEscape]);
+
   useEffect(() => {
     if (!isEnabled) return undefined;
-    return pushEscapeHandler(onEscape);
-  }, [onEscape, isEnabled]);
+    return pushEscapeHandler(() => onEscapeRef.current());
+  }, [isEnabled]);
 };

--- a/src/hooks/useOnEscapePressed.ts
+++ b/src/hooks/useOnEscapePressed.ts
@@ -1,27 +1,26 @@
-import { useEffect, useRef } from "react";
-import { pushEscapeHandler } from "./useEscapeStack";
+import { useCallback, useEffect } from "react";
 
 /**
  * Handle the escape key pressed.
- * Registers the callback on the global escape-key stack so that nested
- * overlays (modals, dropdowns, drawers, …) always dismiss in the correct
- * LIFO order, regardless of DOM position or portal placement.
- *
- * A stable wrapper is kept in a ref so that inline callbacks do not cause
- * the handler to be unregistered/re-registered on every re-render (which
- * would incorrectly move this overlay to the top of the stack).
  */
 export const useOnEscapePressed = (
   onEscape: () => void,
   { isEnabled } = { isEnabled: true },
 ) => {
-  const onEscapeRef = useRef(onEscape);
+  const keyDown = useCallback(
+    (evt: KeyboardEvent) => {
+      if (evt.code === "Escape") {
+        onEscape();
+      }
+    },
+    [onEscape],
+  );
   useEffect(() => {
-    onEscapeRef.current = onEscape;
-  }, [onEscape]);
-
-  useEffect(() => {
-    if (!isEnabled) return undefined;
-    return pushEscapeHandler(() => onEscapeRef.current());
-  }, [isEnabled]);
+    if (isEnabled) {
+      document.addEventListener("keydown", keyDown);
+    }
+    return () => {
+      document.removeEventListener("keydown", keyDown);
+    };
+  }, [keyDown, isEnabled]);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,8 @@ export type {
 } from "./components/CustomSelect";
 
 export {
+  pushEscapeHandler,
+  useEscapeStack,
   useOnClickOutside,
   useClickOutside,
   useId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,7 +223,6 @@ export type {
 } from "./components/CustomSelect";
 
 export {
-  pushEscapeHandler,
   useEscapeStack,
   useOnClickOutside,
   useClickOutside,


### PR DESCRIPTION
## Problem

Fixes #1305

When a `ContextualMenu` is open inside a `Modal`, pressing Escape closes the Modal immediately rather than the menu first. This breaks the expected layered-dismiss UX and is an accessibility issue.

## Root cause

`Modal.tsx` called `stopImmediatePropagation()` unconditionally. Because `ContextualMenu` renders via a Portal (a DOM sibling, not a React child), its own `document` keydown listener was silenced before it could fire.

## Fix — component-agnostic global LIFO escape-key stack

Following @edlerd's exploration in #1305, this implements the **global handler-stack** approach used by every major overlay library (Radix UI, Headless UI, Chakra UI).

### New: `src/hooks/useEscapeStack.ts`

A module-level LIFO array of callbacks. A single `document` keydown listener calls **only the top-of-stack handler** and then calls `stopImmediatePropagation()` — no component needs to know about any other.

```ts
// low-level imperative API (used internally)
const unregister = pushEscapeHandler(() => closeMyOverlay());

// React hook API (for consumers)
useEscapeStack(() => closeMyOverlay(), { isActive: isOpen });
```

### `useOnEscapePressed` — delegates to `pushEscapeHandler`

No API change; existing call-sites are unaffected.

### `Modal` — uses `useOnEscapePressed`

The Escape branch is removed from Modal's manual keydown map. Modal now registers via the stack, so it naturally yields to any overlay opened after it.

### `usePortal` — registers on the stack only while open

A new `useEffect([isOpen, closeOnEsc, …])` registers the handler when the portal opens and pops it when it closes. The stack always reflects the current visual overlay depth.

### Result

The most recently opened overlay handles Escape first, regardless of component type, DOM position, or whether it is a consumer-defined overlay (consumers can call `useEscapeStack` or `pushEscapeHandler` to join the same stack).

Two-step dismiss for Modal + ContextualMenu:
1. **First Escape** → ContextualMenu closes (top of stack)
2. **Second Escape** → Modal closes (now top of stack)

## Changes

- `src/hooks/useEscapeStack.ts` — New: LIFO stack + `useEscapeStack` hook + `pushEscapeHandler`
- `src/hooks/useEscapeStack.test.ts` — New: unit tests for stack ordering and propagation
- `src/hooks/useOnEscapePressed.ts` — Delegates to `pushEscapeHandler`
- `src/components/Modal/Modal.tsx` — Uses `useOnEscapePressed`; Escape removed from keydown map
- `src/components/Modal/Modal.test.tsx` — Updated + regression test for #1305
- `src/external/usePortal.ts` — Registers on escape stack only while portal is open
- `src/hooks/index.ts` / `src/index.ts` — Export new hook and utility

## Testing

```
yarn lint  ✓  (0 errors)
yarn test  ✓  (837 tests, 103 suites)
```