### PR TITLE
feat: [WD-35438] Upstream OutputField component to React

### DIFF
--- a/src/components/OutputField/OutputField.scss
+++ b/src/components/OutputField/OutputField.scss
@@ -1,0 +1,11 @@
+@import "vanilla-framework";
+
+.output-field {
+  .p-form-help-text {
+    margin-top: -0.65rem;
+  }
+
+  .p-form__control {
+    margin-top: 0.25rem;
+  }
+}

--- a/src/components/OutputField/OutputField.stories.tsx
+++ b/src/components/OutputField/OutputField.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from "@storybook/react";
+import OutputField from "./OutputField";
+
+const meta: Meta<typeof OutputField> = {
+  component: OutputField,
+  tags: ["autodocs"],
+
+  argTypes: {
+    label: {
+      control: {
+        type: "text",
+      },
+    },
+    id: {
+      control: {
+        type: "text",
+      },
+    },
+    value: {
+      control: {
+        type: "text",
+      },
+    },
+    help: {
+      control: {
+        type: "text",
+      },
+    },
+    required: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+
+  args: {
+    label: "Label",
+    id: "output-field",
+    value: "Output value",
+    help: "",
+    required: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OutputField>;
+
+export const Default: Story = {
+  name: "Default",
+};
+
+export const HelpText: Story = {
+  name: "Help Text",
+  args: {
+    help: "This is an output field with text",
+  },
+};
+
+export const Required: Story = {
+  name: "Required",
+  args: {
+    required: true,
+  },
+};

--- a/src/components/OutputField/OutputField.test.tsx
+++ b/src/components/OutputField/OutputField.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import OutputField from "./OutputField";
+
+it("renders an OutputField", () => {
+  render(
+    <OutputField
+      label="Label"
+      id="output-field"
+      value="Output value"
+      help="Help text"
+      required
+    />,
+  );
+  expect(screen.getByRole("status", { name: "Label" })).toBeInTheDocument();
+});

--- a/src/components/OutputField/OutputField.tsx
+++ b/src/components/OutputField/OutputField.tsx
@@ -1,0 +1,55 @@
+import React, { FC, ReactNode } from "react";
+import Field from "../Field";
+import "./OutputField.scss";
+
+export type Props = {
+  /**
+   * The id of the output element. This is used to associate the label with the output element for form or accessibility purposes.
+   */
+  id: string;
+  /**
+   * The label for the output field.
+   */
+  label: string;
+  /**
+   * The value to be displayed in the output field.
+   */
+  value: string;
+  /**
+   * Optional help text to provide additional information about the output field.
+   */
+  help?: ReactNode;
+  /**
+   * Whether the output field is required.
+   */
+  required?: boolean;
+};
+
+/**
+ *
+ * Use output fields to display read-only information with a label and optional help text. Output fields are ideal for displaying calculated values or results of user input in a consistent format.
+ */
+export const OutputField: FC<Props> = ({
+  id,
+  label,
+  value,
+  help,
+  required,
+}) => {
+  return (
+    <Field
+      forId={id}
+      label={label}
+      help={help}
+      labelClassName="u-no-margin--bottom"
+      className="output-field"
+      required={required}
+    >
+      <output id={id} className="mono-font u-sv2">
+        <b>{value}</b>
+      </output>
+    </Field>
+  );
+};
+
+export default OutputField;

--- a/src/components/OutputField/index.ts
+++ b/src/components/OutputField/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./OutputField";
+export type { Props as OutputFieldProps } from "./OutputField";

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export {
   queue,
 } from "./components/NotificationProvider";
 export { default as LoginPageLayout } from "./components/LoginPageLayout";
+export { default as OutputField } from "./components/OutputField";
 export { default as Pagination } from "./components/Pagination";
 export { default as Panel } from "./components/Panel";
 export { default as PasswordToggle } from "./components/PasswordToggle";
@@ -182,6 +183,7 @@ export type {
   NotificationHelper,
 } from "./components/NotificationProvider";
 export type { LoginPageLayoutProps } from "./components/LoginPageLayout";
+export type { OutputFieldProps } from "./components/OutputField";
 export type { PaginationProps } from "./components/Pagination";
 export type { PanelProps } from "./components/Panel";
 export type { PrefixedInputProps } from "./components/PrefixedInput";


### PR DESCRIPTION
## Done
This component provides a label for Read Only I/O where disabled input fields cannot be used for Design/UI reasons.

Example usage within LXD UI:
<img width="945" height="230" alt="image" src="https://github.com/user-attachments/assets/ee1d451d-a93f-4547-9cad-ec9e7e5988fa" />

- Upstream OutputField component to React
- Added test

## QA

Pinging @/canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- Observe the OutputField component within Storybook.
- View the different attributes and controls.

## Fixes

Fixes: Lack of read only global component.
