### PR TITLE
fix(prefixedIpInput): bug in immutable and editable calculation WD-35568

### DIFF
--- a/src/components/PrefixedIpInput/PrefixedIpInput.test.tsx
+++ b/src/components/PrefixedIpInput/PrefixedIpInput.test.tsx
@@ -80,14 +80,14 @@ describe("PrefixedIpInput", () => {
   it("displays the editable portion of IPv6 address", () => {
     const { container } = render(
       <PrefixedIpInput
-        cidr="2001:db8::/32"
+        cidr="2001:db8::/31"
         ip="2001:db8::1"
         name="ip"
         onIpChange={jest.fn()}
       />,
     );
     const input = container.querySelector("input");
-    expect(input).toHaveValue(":1");
+    expect(input).toHaveValue("db8::1");
   });
 
   it("renders default help text for IPv4", () => {
@@ -111,7 +111,7 @@ describe("PrefixedIpInput", () => {
         onIpChange={jest.fn()}
       />,
     );
-    expect(container).toContainHTML("The available IPV6 address range is");
+    expect(container).toContainHTML("The subnet CIDR is");
   });
 
   it("renders custom help text when provided", () => {
@@ -192,7 +192,7 @@ describe("PrefixedIpInput", () => {
     const input = container.querySelector("input") as HTMLInputElement;
 
     await userEvent.click(input);
-    await userEvent.paste("2001:db8::5");
+    await userEvent.paste(":5");
 
     expect(onIpChange).toHaveBeenCalledWith("2001:db8::5");
   });

--- a/src/components/PrefixedIpInput/PrefixedIpInput.tsx
+++ b/src/components/PrefixedIpInput/PrefixedIpInput.tsx
@@ -93,11 +93,7 @@ const PrefixedIpInput = ({
             ) : (
               <>
                 {" "}
-                The available IPV6 address range is{" "}
-                <code>
-                  {immutable}
-                  {editable}{" "}
-                </code>
+                The subnet CIDR is <code>{cidr}</code>
               </>
             )}
             .

--- a/src/components/PrefixedIpInput/utils.test.ts
+++ b/src/components/PrefixedIpInput/utils.test.ts
@@ -12,11 +12,16 @@ describe("isIPv4", () => {
     expect(isIPv4("255.255.255.255")).toBe(true);
     expect(isIPv4("0.0.0.0")).toBe(true);
   });
+
   it("returns false for invalid IPv4 addresses", () => {
     expect(isIPv4("256.256.256.256")).toBe(false);
     expect(isIPv4("192.168.1")).toBe(false);
     expect(isIPv4("abc.def.ghi.jkl")).toBe(false);
     expect(isIPv4("1234.123.123.123")).toBe(false);
+    expect(isIPv4("01.2.3.4")).toBe(false);
+    expect(isIPv4("1.2.3.4 ")).toBe(false);
+    expect(isIPv4(" 1.2.3.4")).toBe(false);
+    expect(isIPv4("1.2.3.-1")).toBe(false);
   });
 });
 
@@ -47,6 +52,20 @@ describe("getIpRangeFromCidr", () => {
       "10.0.3.254",
     ]);
   });
+
+  it("normalizes non-network input addresses to the subnet network", () => {
+    expect(getIpRangeFromCidr("10.0.0.42/24")).toEqual([
+      "10.0.0.1",
+      "10.0.0.254",
+    ]);
+  });
+
+  it("handles narrow subnet masks", () => {
+    expect(getIpRangeFromCidr("192.168.10.0/30")).toEqual([
+      "192.168.10.1",
+      "192.168.10.2",
+    ]);
+  });
 });
 
 describe("isIpInSubnet", () => {
@@ -72,6 +91,11 @@ describe("isIpInSubnet", () => {
     expect(isIpInSubnet("10.0.0.0", "10.0.0.0/24")).toBe(false);
     expect(isIpInSubnet("10.0.0.255", "10.0.0.0/24")).toBe(false);
   });
+
+  it("supports subnets where CIDR input uses a non-network host address", () => {
+    expect(isIpInSubnet("10.0.0.1", "10.0.0.42/24")).toBe(true);
+    expect(isIpInSubnet("10.0.1.1", "10.0.0.42/24")).toBe(false);
+  });
 });
 
 describe("getImmutableAndEditableOctets", () => {
@@ -91,6 +115,12 @@ describe("getImmutableAndEditableOctets", () => {
       ["", "[10-20].[0-255].[0-255].[1-254]"],
     );
   });
+
+  it("returns an empty editable portion when start and end are identical", () => {
+    expect(getImmutableAndEditableOctets("10.10.10.10", "10.10.10.10")).toEqual(
+      ["10.10.10.10", ""],
+    );
+  });
 });
 
 describe("getImmutableAndEditable", () => {
@@ -99,7 +129,7 @@ describe("getImmutableAndEditable", () => {
       "10.0.0",
       "[1-254]",
     ]);
-    expect(getImmutableAndEditable("192.168.1.0/24")).toEqual([
+    expect(getImmutableAndEditable("192.168.1.10/24")).toEqual([
       "192.168.1",
       "[1-254]",
     ]);
@@ -115,16 +145,40 @@ describe("getImmutableAndEditable", () => {
 
   it("returns the immutable and editable parts of an IPv6 subnet", () => {
     expect(getImmutableAndEditable("2001:0db8:85a3::/64")).toEqual([
-      "2001:0db8:85a3:",
-      "0000:0000:0000:0000:0000",
+      "2001:0db8:85a3:0:",
+      "0:0:0:0",
+    ]);
+    expect(getImmutableAndEditable("2001::dabc:1234/32")).toEqual([
+      "2001:0:",
+      "0:0:0:0:0:0",
+    ]);
+    expect(getImmutableAndEditable("2001:0db8:85a3::/64")).toEqual([
+      "2001:0db8:85a3:0:",
+      "0:0:0:0",
+    ]);
+    expect(getImmutableAndEditable("2001:0db8:85a3:1111::/64")).toEqual([
+      "2001:0db8:85a3:1111:",
+      "0:0:0:0",
     ]);
     expect(getImmutableAndEditable("fd00:1234:5678::/48")).toEqual([
       "fd00:1234:5678:",
-      "0000:0000:0000:0000:0000",
+      "0:0:0:0:0",
     ]);
     expect(getImmutableAndEditable("fe80::/10")).toEqual([
-      "fe80:",
-      "0000:0000:0000:0000:0000:0000:0000",
+      "",
+      "fe80:0:0:0:0:0:0:0",
+    ]);
+  });
+
+  it("handles IPv6 edge prefixes and normalization", () => {
+    expect(getImmutableAndEditable("2001:db8:1:2:3:4:5:6/128")).toEqual([
+      "2001:db8:1:2:3:4:5:6",
+      "",
+    ]);
+    expect(getImmutableAndEditable("::/0")).toEqual(["", "0:0:0:0:0:0:0:0"]);
+    expect(getImmutableAndEditable("2001:db8:abcd::/33")).toEqual([
+      "2001:db8:",
+      "abcd:0:0:0:0:0",
     ]);
   });
 });

--- a/src/components/PrefixedIpInput/utils.ts
+++ b/src/components/PrefixedIpInput/utils.ts
@@ -21,8 +21,13 @@ export const getIpRangeFromCidr = (cidr: string): string[] => {
   // https://gist.github.com/binarymax/6114792
 
   // Get start IP and number of valid addresses
-  const [startIp, mask] = cidr.split("/");
-  const numberOfAddresses = (1 << (32 - parseInt(mask))) - 1;
+  const [unmaskedStartIp, mask] = cidr.split("/");
+  const maskBits = parseInt(mask, 10);
+  const subnetMask = maskBits === 0 ? 0 : (0xffffffff << (32 - maskBits)) >>> 0;
+  const startIp = convertUint32ToIp(
+    convertIpToUint32(unmaskedStartIp) & subnetMask,
+  );
+  const numberOfAddresses = (1 << (32 - maskBits)) - 1;
 
   // IPv4 can be represented by an unsigned 32-bit integer, so we can use a Uint32Array to store the IP
   const buffer = new ArrayBuffer(4); //4 octets
@@ -62,6 +67,14 @@ export const convertIpToUint32 = (ip: string) => {
   int32[0] =
     (octets[0] << 24) + (octets[1] << 16) + (octets[2] << 8) + octets[3];
   return int32[0];
+};
+
+export const convertUint32ToIp = (ipAsUint32: number) => {
+  const buffer = new ArrayBuffer(4); //4 octets
+  const int32 = new Uint32Array(buffer);
+  int32[0] = ipAsUint32;
+  const octets = Array.from(new Uint8Array(buffer));
+  return octets.reverse().join(".");
 };
 
 /**
@@ -110,10 +123,47 @@ export const getImmutableAndEditableOctets = (
 };
 
 /**
+ * Separates the immutable and editable parts of an IPv6 subnet range.
+ * For simplcity, if the prefix is not on a group boundary, the entire last group is considered editable.
+ *
+ * @param cidr The CIDR notation of the subnet
+ * @returns The immutable and editable parts as two strings in a list
+ */
+export const getImmutableAndEditableIPv6 = (cidr: string): string[] => {
+  const [address, prefix] = cidr.split("/");
+  const prefixLength = parseInt(prefix, 10);
+
+  const [left = "", right = ""] = address.split("::");
+  const leftGroups = left ? left.split(":").filter(Boolean) : [];
+  const rightGroups = right ? right.split(":").filter(Boolean) : [];
+  const missingGroups = Math.max(
+    0,
+    8 - (leftGroups.length + rightGroups.length),
+  );
+
+  const expandedGroups: string[] = [
+    ...leftGroups,
+    ...Array(missingGroups).fill("0"),
+    ...Array(rightGroups.length).fill("0"),
+  ];
+
+  const immutableGroupCount = Math.floor(prefixLength / 16);
+  let immutableIPV6 =
+    immutableGroupCount > 0
+      ? `${expandedGroups.slice(0, immutableGroupCount).join(":")}`
+      : "";
+  if (immutableGroupCount < 8) {
+    immutableIPV6 += immutableIPV6 ? ":" : "";
+  }
+  const editableIPV6 = `${expandedGroups.slice(immutableGroupCount).join(":")}`;
+  return [immutableIPV6, editableIPV6];
+};
+
+/**
  * Get the immutable and editable parts of an IPv4 or IPv6 subnet.
  *
  * @param cidr The CIDR notation of the subnet
- * @returns The immutable and editable  as two strings in a list
+ * @returns The immutable and editable as two strings in a list
  */
 export const getImmutableAndEditable = (cidr: string) => {
   const isIPV4 = isIPv4(cidr.split("/")[0]);
@@ -121,14 +171,5 @@ export const getImmutableAndEditable = (cidr: string) => {
     const [startIp, endIp] = getIpRangeFromCidr(cidr);
     return getImmutableAndEditableOctets(startIp, endIp);
   }
-
-  const [networkAddress] = cidr.split("/");
-  const immutableIPV6 = networkAddress.substring(
-    0,
-    networkAddress.lastIndexOf(":"),
-  );
-  const ipv6PlaceholderColons = 7 - (immutableIPV6.match(/:/g) || []).length; // 7 is the maximum number of colons in an IPv6 address
-  const editableIPV6 = `${"0000:".repeat(ipv6PlaceholderColons)}0000`;
-
-  return [immutableIPV6, editableIPV6];
+  return getImmutableAndEditableIPv6(cidr);
 };


### PR DESCRIPTION
## Done

- Fix bug in immutable and editable calculation where starting ip did not consider subnet mask.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- N/A
