### PR TITLE
feat(ActionButton): use button component for action button

### DIFF
--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,11 +1,10 @@
 import classNames from "classnames";
 import React, { MouseEventHandler, useEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
 
 import type { ButtonProps } from "../Button";
 import Icon from "../Icon";
 
-import type { ClassName, PropsWithSpread } from "types";
+import type { PropsWithSpread } from "types";
 import Button from "../Button";
 
 export const LOADER_MIN_DURATION = 400; // minimium duration (ms) loader displays
@@ -19,37 +18,12 @@ export enum Label {
 export type Props = PropsWithSpread<
   {
     /**
-     * The appearance of the button.
-     */
-    appearance?: ButtonProps["appearance"];
-    /**
-     * The content of the button.
-     */
-    children?: ReactNode;
-    /**
-     * Optional class(es) to pass to the button element.
-     */
-    className?: ClassName;
-    /**
-     * Whether the button should be disabled.
-     */
-    disabled?: boolean;
-    /**
-     * Whether the button should display inline.
-     */
-    inline?: boolean;
-    /**
      * Whether the button should be in the loading state.
      */
     loading?: boolean;
     /**
-     * Function for handling button click event.
-     */
-    onClick?: MouseEventHandler<HTMLButtonElement>;
-    /**
      * Whether the button should be in the success state.
      */
-
     success?: boolean;
   },
   ButtonProps
@@ -63,12 +37,9 @@ export type Props = PropsWithSpread<
  * props table:
  */
 const ActionButton = ({
-  appearance,
   children,
   className,
-  onClick,
   disabled = null,
-  inline = false,
   loading = false,
   success = false,
   ...buttonProps
@@ -154,36 +125,25 @@ const ActionButton = ({
   const buttonClasses = classNames(
     className,
     "p-action-button",
-    appearance ? `p-button--${appearance}` : "p-button",
     {
       "is-processing": showLoader || showSuccess,
-      "is-disabled": disabled === null ? showLoader : disabled,
-      "is-inline": inline,
     },
   );
   const showIcon = showLoader || showSuccess;
-  const isDisabled = disabled === null ? showLoader : disabled;
   const icon = (showLoader && "spinner") || (showSuccess && "success") || null;
-  const iconLight = appearance === "positive" || appearance === "negative";
-  const onClickDisabled: MouseEventHandler<HTMLButtonElement> = (e) =>
-    e.preventDefault();
+  const iconLight = buttonProps.appearance === "positive" || buttonProps.appearance === "negative";
 
-  // This component uses the base button element instead of the Button component
-  // as the button requires a ref and Button would have to be updated to use
-  // forwardRef which is not currently supported by components that use
-  // typescript generics.
   return (
     <Button
       className={buttonClasses}
       ref={ref}
-      onClick={isDisabled ? onClickDisabled : onClick}
-      aria-disabled={isDisabled || undefined}
+      disabled={disabled === null ? showLoader : disabled}
       style={
         height && width
           ? {
-            height: `${height}px`,
-            width: `${width}px`,
-          }
+              height: `${height}px`,
+              width: `${width}px`,
+            }
           : undefined
       }
       {...buttonProps}

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { MouseEventHandler, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import type { ButtonProps } from "../Button";
 import Icon from "../Icon";
@@ -122,16 +122,14 @@ const ActionButton = ({
     return () => window.clearTimeout(successTimeout);
   }, [showSuccess]);
 
-  const buttonClasses = classNames(
-    className,
-    "p-action-button",
-    {
-      "is-processing": showLoader || showSuccess,
-    },
-  );
+  const buttonClasses = classNames(className, "p-action-button", {
+    "is-processing": showLoader || showSuccess,
+  });
   const showIcon = showLoader || showSuccess;
   const icon = (showLoader && "spinner") || (showSuccess && "success") || null;
-  const iconLight = buttonProps.appearance === "positive" || buttonProps.appearance === "negative";
+  const iconLight =
+    buttonProps.appearance === "positive" ||
+    buttonProps.appearance === "negative";
 
   return (
     <Button

--- a/src/components/ActionButton/ActionButton.tsx
+++ b/src/components/ActionButton/ActionButton.tsx
@@ -1,11 +1,12 @@
 import classNames from "classnames";
 import React, { MouseEventHandler, useEffect, useRef, useState } from "react";
-import type { ButtonHTMLAttributes, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import type { ButtonProps } from "../Button";
 import Icon from "../Icon";
 
 import type { ClassName, PropsWithSpread } from "types";
+import Button from "../Button";
 
 export const LOADER_MIN_DURATION = 400; // minimium duration (ms) loader displays
 export const SUCCESS_DURATION = 2000; // duration (ms) success tick is displayed
@@ -51,7 +52,7 @@ export type Props = PropsWithSpread<
 
     success?: boolean;
   },
-  ButtonHTMLAttributes<HTMLButtonElement>
+  ButtonProps
 >;
 
 /**
@@ -172,7 +173,7 @@ const ActionButton = ({
   // forwardRef which is not currently supported by components that use
   // typescript generics.
   return (
-    <button
+    <Button
       className={buttonClasses}
       ref={ref}
       onClick={isDisabled ? onClickDisabled : onClick}
@@ -180,9 +181,9 @@ const ActionButton = ({
       style={
         height && width
           ? {
-              height: `${height}px`,
-              width: `${width}px`,
-            }
+            height: `${height}px`,
+            width: `${width}px`,
+          }
           : undefined
       }
       {...buttonProps}
@@ -197,7 +198,7 @@ const ActionButton = ({
       ) : (
         children
       )}
-    </button>
+    </Button>
   );
 };
 

--- a/src/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
+++ b/src/components/ActionButton/__snapshots__/ActionButton.test.tsx.snap
@@ -1,9 +1,9 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActionButton matches loading snapshot 1`] = `
 <button
   aria-disabled="true"
-  class="p-action-button p-button is-processing is-disabled"
+  class="p-button is-disabled p-action-button is-processing"
 >
   <i
     aria-label="Waiting for action to complete"
@@ -14,7 +14,7 @@ exports[`ActionButton matches loading snapshot 1`] = `
 
 exports[`ActionButton matches success snapshot 1`] = `
 <button
-  class="p-action-button p-button is-processing"
+  class="p-button p-action-button is-processing"
 >
   <i
     aria-label="Action completed"

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,6 +6,7 @@ import type {
   ElementType,
   MouseEventHandler,
   ReactNode,
+  Ref,
 } from "react";
 
 import type { ClassName, ValueOf } from "types";
@@ -64,6 +65,10 @@ export type Props<P = null> = {
    * Whether the button should be small.
    */
   small?: boolean;
+  /**
+   * A ref to the button.
+   */
+  ref?: Ref<HTMLButtonElement>;
 } & (Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> | P);
 
 /**

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -6,7 +6,7 @@ import ConfirmationModal from "./ConfirmationModal";
 import Input from "../Input";
 import Icon from "components/Icon";
 
-const doNothing = () => { };
+const doNothing = () => {};
 
 const meta: Meta<typeof ConfirmationModal> = {
   component: ConfirmationModal,
@@ -35,7 +35,7 @@ export const Default: Story = {
             onConfirm={doNothing}
             close={closeHandler}
             confirmButtonProps={{
-              hasIcon: true
+              hasIcon: true,
             }}
           >
             <p>

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -31,7 +31,12 @@ export const Default: Story = {
         {modalOpen ? (
           <ConfirmationModal
             title="Confirm delete"
-            confirmButtonLabel={<><Icon name="delete" light /><span>Delete</span></>}
+            confirmButtonLabel={
+              <>
+                <Icon name="delete" light />
+                <span>Delete</span>
+              </>
+            }
             onConfirm={doNothing}
             close={closeHandler}
             confirmButtonProps={{

--- a/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.stories.tsx
@@ -4,8 +4,9 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import ConfirmationModal from "./ConfirmationModal";
 import Input from "../Input";
+import Icon from "components/Icon";
 
-const doNothing = () => {};
+const doNothing = () => { };
 
 const meta: Meta<typeof ConfirmationModal> = {
   component: ConfirmationModal,
@@ -30,9 +31,12 @@ export const Default: Story = {
         {modalOpen ? (
           <ConfirmationModal
             title="Confirm delete"
-            confirmButtonLabel="Delete"
+            confirmButtonLabel={<><Icon name="delete" light /><span>Delete</span></>}
             onConfirm={doNothing}
             close={closeHandler}
+            confirmButtonProps={{
+              hasIcon: true
+            }}
           >
             <p>
               This will permanently delete the user "Simon".

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -85,7 +85,7 @@ export const Focus: Story = {
   render: ({ closeOnOutsideClick }) => {
     /* eslint-disable react-hooks/rules-of-hooks */
     const [modalOpen, setModalOpen] = useState(true);
-    const buttonRef = useRef<HTMLElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
     /* eslint-enable react-hooks/rules-of-hooks */
 
     const closeHandler = () => setModalOpen(false);

--- a/src/components/SummaryButton/__snapshots__/SummaryButton.test.tsx.snap
+++ b/src/components/SummaryButton/__snapshots__/SummaryButton.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SummaryButton /> renders and matches the snapshot 1`] = `
 <small>
@@ -8,7 +8,7 @@ exports[`<SummaryButton /> renders and matches the snapshot 1`] = `
     Showing some items
   </span>
   <button
-    class="is-small is-dense is-inline p-action-button p-button"
+    class="p-button is-small is-dense is-inline p-action-button"
   >
     Show more
   </button>


### PR DESCRIPTION
## Done

I changed `ActionButton` to use the `Button` component instead of the default HTML `button`, allowing for the extra props.

I made a change to one of the `ConfirmationModal` stories showing this off. We needed to include an icon for a confirmation button, but the button couldn't be styled with the `hasIcon` prop before. 

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- No visual changes expected.
