### PR TITLE
fix: Remove global background override for `is-paper` class name

### DIFF
--- a/src/components/LoginPageLayout/LoginPageLayout.scss
+++ b/src/components/LoginPageLayout/LoginPageLayout.scss
@@ -8,10 +8,6 @@
   .page-card {
     border: 0;
   }
-
-  .is-paper {
-    background-color: #fff;
-  }
 }
 
 .page-inner {


### PR DESCRIPTION
## Done

- Removes unnecessary global CSS override for `is-paper` class name that was conflicting with default Vanilla background for that theme.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Check if LoginPageLayout displays as expected

### Percy steps

No visual changes expected

