### PR TITLE
feat: multiselect improvements

### DIFF
--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -93,6 +93,12 @@ $dropdown-max-height: 20rem;
   }
 }
 
+.multi-select__empty-state {
+  color: $colors--theme--text-muted;
+  margin: 0;
+  padding: $spv--small $sph--large;
+}
+
 .multi-select__dropdown-button {
   border: 0;
   margin-bottom: 0;

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { useState } from "react";
+import { Formik } from "formik";
 import { Meta, StoryObj } from "@storybook/react";
 
+import { FormikField } from "../../index";
 import { MultiSelect, MultiSelectItem, MultiSelectProps } from "./MultiSelect";
 
 const Template = (props: MultiSelectProps) => {
@@ -27,6 +29,13 @@ const meta: Meta<typeof MultiSelect> = {
 export default meta;
 
 type Story = StoryObj<typeof MultiSelect>;
+
+const groupedItems = [
+  { label: "Almond", value: "almond", group: "Nuts" },
+  { label: "Cashew", value: "cashew", group: "Nuts" },
+  { label: "Mango", value: "mango", group: "Fruit" },
+  { label: "Peach", value: "peach", group: "Fruit" },
+];
 
 export const CondensedExample: Story = {
   args: {
@@ -139,6 +148,75 @@ export const HelpText: Story = {
       <span>
         This is a help text, that should appear underneath the component.
       </span>
+    ),
+  },
+};
+
+const FormikControlledSearchAndLifecycleTemplate = () => {
+  const [selectedItems, setSelectedItems] = useState<MultiSelectItem[]>([]);
+  const [searchValue, setSearchValue] = useState("");
+  const [events, setEvents] = useState<string[]>([]);
+
+  const addEvent = (eventName: string) => {
+    setEvents((previousEvents) => [eventName, ...previousEvents].slice(0, 6));
+  };
+
+  return (
+    <div style={{ maxWidth: "28rem" }}>
+      <Formik initialValues={{ ingredients: "" }} onSubmit={() => {}}>
+        <FormikField
+          name="ingredients"
+          component={MultiSelect}
+          label="Ingredients"
+          variant="search"
+          placeholder="Search ingredients"
+          items={groupedItems}
+          selectedItems={selectedItems}
+          onItemsUpdate={setSelectedItems}
+          searchValue={searchValue}
+          onSearchChange={(value: string) => {
+            setSearchValue(value);
+            addEvent(`onSearchChange("${value}")`);
+          }}
+          onOpen={() => addEvent("onOpen()")}
+          onClose={() => addEvent("onClose()")}
+          onResetSearch={() => addEvent("onResetSearch()")}
+          emptyMessage="No ingredients found"
+        />
+      </Formik>
+      <p style={{ marginBottom: "0.5rem" }}>Callback log:</p>
+      <ul style={{ margin: 0, paddingLeft: "1.25rem" }}>
+        {events.map((event, index) => (
+          <li key={`${event}-${index}`}>{event}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export const FormikControlledSearchAndLifecycle: Story = {
+  render: FormikControlledSearchAndLifecycleTemplate,
+};
+
+export const EmptyMessage: Story = {
+  args: {
+    variant: "search",
+    items: groupedItems,
+    emptyMessage: "No matching ingredients.",
+    placeholder: "Try typing kiwi",
+  },
+};
+
+export const EmptyStateNode: Story = {
+  args: {
+    variant: "search",
+    items: groupedItems,
+    placeholder: "Try typing kiwi",
+    emptyState: (
+      <div className="u-align--center" style={{ padding: "0.75rem 1rem" }}>
+        <strong>No ingredient matches.</strong>
+        <p style={{ margin: "0.25rem 0 0" }}>Use a broader term.</p>
+      </div>
     ),
   },
 };

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -152,9 +152,8 @@ export const HelpText: Story = {
   },
 };
 
-const FormikControlledSearchAndLifecycleTemplate = () => {
+const FormikCallbacksAndEmptyStateTemplate = () => {
   const [selectedItems, setSelectedItems] = useState<MultiSelectItem[]>([]);
-  const [searchValue, setSearchValue] = useState("");
   const [events, setEvents] = useState<string[]>([]);
 
   const addEvent = (eventName: string) => {
@@ -173,14 +172,11 @@ const FormikControlledSearchAndLifecycleTemplate = () => {
           items={groupedItems}
           selectedItems={selectedItems}
           onItemsUpdate={setSelectedItems}
-          searchValue={searchValue}
           onSearchChange={(value: string) => {
-            setSearchValue(value);
             addEvent(`onSearchChange("${value}")`);
           }}
           onOpen={() => addEvent("onOpen()")}
           onClose={() => addEvent("onClose()")}
-          onResetSearch={() => addEvent("onResetSearch()")}
           emptyMessage="No ingredients found"
         />
       </Formik>
@@ -194,8 +190,8 @@ const FormikControlledSearchAndLifecycleTemplate = () => {
   );
 };
 
-export const FormikControlledSearchAndLifecycle: Story = {
-  render: FormikControlledSearchAndLifecycleTemplate,
+export const FormikCallbacksAndEmptyState: Story = {
+  render: FormikCallbacksAndEmptyStateTemplate,
 };
 
 export const EmptyMessage: Story = {

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -97,6 +97,86 @@ it("can filter option list", async () => {
   await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(2));
 });
 
+it("supports controlled search input", async () => {
+  const ControlledMultiSelect = () => {
+    const [searchValue, setSearchValue] = React.useState("");
+
+    return (
+      <MultiSelect
+        variant="search"
+        items={items}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+      />
+    );
+  };
+
+  render(<ControlledMultiSelect />);
+
+  await userEvent.click(screen.getByRole("combobox"));
+  await userEvent.type(screen.getByRole("combobox"), "item");
+
+  expect(screen.getByRole("combobox")).toHaveValue("item");
+  await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(2));
+});
+
+it("calls search lifecycle callbacks", async () => {
+  const onOpen = jest.fn();
+  const onClose = jest.fn();
+  const onResetSearch = jest.fn();
+
+  render(
+    <MultiSelect
+      variant="search"
+      items={items}
+      onOpen={onOpen}
+      onClose={onClose}
+      onResetSearch={onResetSearch}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole("combobox"));
+  expect(onOpen).toHaveBeenCalledTimes(1);
+
+  await userEvent.type(screen.getByRole("combobox"), "item");
+  await userEvent.click(document.body);
+
+  await waitFor(() => expect(onClose).toHaveBeenCalled());
+  expect(onResetSearch).toHaveBeenCalledTimes(1);
+  expect(screen.getByRole("combobox")).toHaveValue("");
+});
+
+it("renders emptyMessage when no items match", async () => {
+  render(
+    <MultiSelect
+      variant="search"
+      items={items}
+      emptyMessage="No results found"
+    />,
+  );
+
+  await userEvent.click(screen.getByRole("combobox"));
+  await userEvent.type(screen.getByRole("combobox"), "does not exist");
+
+  expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+  expect(screen.getByText("No results found")).toBeInTheDocument();
+});
+
+it("renders emptyState when no items match", async () => {
+  render(
+    <MultiSelect
+      variant="search"
+      items={items}
+      emptyState={<div>No custom items</div>}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole("combobox"));
+  await userEvent.type(screen.getByRole("combobox"), "does not exist");
+
+  expect(screen.getByText("No custom items")).toBeInTheDocument();
+});
+
 it("can display a custom dropdown header and footer", async () => {
   render(
     <MultiSelect

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -97,33 +97,29 @@ it("can filter option list", async () => {
   await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(2));
 });
 
-it("supports controlled search input", async () => {
-  const ControlledMultiSelect = () => {
-    const [searchValue, setSearchValue] = React.useState("");
-
-    return (
-      <MultiSelect
-        variant="search"
-        items={items}
-        searchValue={searchValue}
-        onSearchChange={setSearchValue}
-      />
-    );
-  };
-
-  render(<ControlledMultiSelect />);
+it("tracks search changes via onSearchChange callback", async () => {
+  const onSearchChange = jest.fn();
+  render(
+    <MultiSelect
+      variant="search"
+      items={items}
+      onSearchChange={onSearchChange}
+    />,
+  );
 
   await userEvent.click(screen.getByRole("combobox"));
   await userEvent.type(screen.getByRole("combobox"), "item");
 
   expect(screen.getByRole("combobox")).toHaveValue("item");
-  await waitFor(() => expect(screen.getAllByRole("listitem")).toHaveLength(2));
+  expect(onSearchChange).toHaveBeenCalledWith("i");
+  expect(onSearchChange).toHaveBeenCalledWith("it");
+  expect(onSearchChange).toHaveBeenCalledWith("ite");
+  expect(onSearchChange).toHaveBeenCalledWith("item");
 });
 
-it("calls search lifecycle callbacks", async () => {
+it("calls lifecycle callbacks", async () => {
   const onOpen = jest.fn();
   const onClose = jest.fn();
-  const onResetSearch = jest.fn();
 
   render(
     <MultiSelect
@@ -131,7 +127,6 @@ it("calls search lifecycle callbacks", async () => {
       items={items}
       onOpen={onOpen}
       onClose={onClose}
-      onResetSearch={onResetSearch}
     />,
   );
 
@@ -142,7 +137,6 @@ it("calls search lifecycle callbacks", async () => {
   await userEvent.click(document.body);
 
   await waitFor(() => expect(onClose).toHaveBeenCalled());
-  expect(onResetSearch).toHaveBeenCalledTimes(1);
   expect(screen.getByRole("combobox")).toHaveValue("");
 });
 

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -31,12 +31,19 @@ export type MultiSelectProps = {
   renderItem?: (item: MultiSelectItem) => ReactNode;
   dropdownHeader?: ReactNode;
   dropdownFooter?: ReactNode;
+  emptyState?: ReactNode;
+  emptyMessage?: string;
   showDropdownFooter?: boolean;
   variant?: "condensed" | "search";
   scrollOverflow?: boolean;
   isSortedAlphabetically?: boolean;
   hasSelectedItemsFirst?: boolean;
   id?: string;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  onOpen?: () => void;
+  onClose?: () => void;
+  onResetSearch?: () => void;
 };
 
 type ValueSet = Set<MultiSelectItem["value"]>;
@@ -54,6 +61,8 @@ type MultiSelectDropdownProps = {
   onDeselectItem?: (item: MultiSelectItem) => void;
   onSelectItem?: (item: MultiSelectItem) => void;
   footer?: ReactNode;
+  emptyState?: ReactNode;
+  emptyMessage?: string;
   groupFn?: GroupFn;
   sortFn?: SortFn;
   hasSelectedItemsFirst?: boolean;
@@ -98,6 +107,8 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
   onDeselectItem,
   isOpen,
   footer,
+  emptyState,
+  emptyMessage,
   sortFn = sortAlphabetically,
   groupFn = getGroupedItems,
   hasSelectedItemsFirst = true,
@@ -122,6 +133,7 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
   }, [isOpen]);
 
   const hasGroup = useMemo(() => items.some((item) => item.group), [items]);
+  const hasItems = items.length > 0;
   const groupedItems = useMemo(
     () => (hasGroup ? groupFn(items) : [{ group: "Ungrouped", items }]),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -147,34 +159,42 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
     <FadeInDown isVisible={isOpen}>
       <div className="multi-select__dropdown" role="listbox" {...props}>
         {header ? header : null}
-        {groupedItems.map(({ group, items }) => (
-          <div className="multi-select__group" key={group}>
-            {hasGroup ? (
-              <h5 className="multi-select__dropdown-header">{group}</h5>
-            ) : null}
-            <ul className="multi-select__dropdown-list" aria-label={group}>
-              {items
-                .toSorted(sortFn)
-                .toSorted(
-                  hasSelectedItemsFirst
-                    ? createSortSelectedItems(previouslySelectedItemValues)
-                    : () => 0,
-                )
-                .map((item) => (
-                  <li key={item.value} className="multi-select__dropdown-item">
-                    <CheckboxInput
-                      disabled={disabledItemValues.has(item.value)}
-                      label={item.label}
-                      checked={selectedItemValues.has(item.value)}
-                      value={item.value}
-                      onChange={handleOnChange}
-                      key={item.value}
-                    />
-                  </li>
-                ))}
-            </ul>
-          </div>
-        ))}
+        {hasItems
+          ? groupedItems.map(({ group, items }) => (
+              <div className="multi-select__group" key={group}>
+                {hasGroup ? (
+                  <h5 className="multi-select__dropdown-header">{group}</h5>
+                ) : null}
+                <ul className="multi-select__dropdown-list" aria-label={group}>
+                  {items
+                    .toSorted(sortFn)
+                    .toSorted(
+                      hasSelectedItemsFirst
+                        ? createSortSelectedItems(previouslySelectedItemValues)
+                        : () => 0,
+                    )
+                    .map((item) => (
+                      <li
+                        key={item.value}
+                        className="multi-select__dropdown-item"
+                      >
+                        <CheckboxInput
+                          disabled={disabledItemValues.has(item.value)}
+                          label={item.label}
+                          checked={selectedItemValues.has(item.value)}
+                          value={item.value}
+                          onChange={handleOnChange}
+                          key={item.value}
+                        />
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            ))
+          : (emptyState ??
+            (emptyMessage ? (
+              <p className="multi-select__empty-state">{emptyMessage}</p>
+            ) : null))}
         {footer ? <div className="multi-select__footer">{footer}</div> : null}
       </div>
     </FadeInDown>
@@ -201,24 +221,48 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   disabledItems = [],
   dropdownHeader,
   dropdownFooter,
+  emptyState,
+  emptyMessage,
   showDropdownFooter = true,
   variant = "search",
   scrollOverflow = false,
   isSortedAlphabetically = true,
   hasSelectedItemsFirst = true,
   id,
+  searchValue,
+  onSearchChange,
+  onOpen,
+  onClose,
+  onResetSearch,
   help,
   helpClassName,
 }: MultiSelectProps) => {
   const buttonRef = useRef(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [filter, setFilter] = useState("");
+  const [internalSearchValue, setInternalSearchValue] = useState("");
+  const previousOpenState = useRef(isDropdownOpen);
+  const filter = searchValue ?? internalSearchValue;
 
   const [internalSelectedItems, setInternalSelectedItems] = useState<
     MultiSelectItem[]
   >([]);
   const selectedItems = externalSelectedItems || internalSelectedItems;
   const helpId = useId();
+
+  const updateSearchValue = (value: string) => {
+    if (searchValue === undefined) {
+      setInternalSearchValue(value);
+    }
+    onSearchChange?.(value);
+  };
+
+  const resetSearch = () => {
+    if (!filter.length) {
+      return;
+    }
+    updateSearchValue("");
+    onResetSearch?.();
+  };
 
   const updateItems = (newItems: MultiSelectItem[]) => {
     const uniqueItems = Array.from(new Set(newItems));
@@ -228,6 +272,20 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
 
   const dropdownId = useId();
   const inputId = useId();
+
+  useEffect(() => {
+    if (previousOpenState.current === isDropdownOpen) {
+      return;
+    }
+
+    if (isDropdownOpen) {
+      onOpen?.();
+    } else {
+      onClose?.();
+    }
+    previousOpenState.current = isDropdownOpen;
+  }, [isDropdownOpen, onClose, onOpen]);
+
   const selectedItemsLabel = selectedItems
     .filter((selectedItem) =>
       items.some((item) => item.value === selectedItem.value),
@@ -278,7 +336,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         className="multi-select"
         onToggleMenu={(isOpen) => {
           if (!isOpen) {
-            setFilter("");
+            resetSearch();
           }
           // Handle syncing the state when toggling the menu from within the
           // contextual menu component e.g. when clicking outside.
@@ -300,10 +358,11 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               disabled={disabled}
               autoComplete="off"
               onChange={(value) => {
-                setFilter(value);
+                updateSearchValue(value);
                 // reopen if dropdown has been closed via ESC
                 setIsDropdownOpen(true);
               }}
+              onClear={resetSearch}
               onFocus={() => setIsDropdownOpen(true)}
               placeholder={placeholder ?? "Search"}
               required={required}
@@ -368,6 +427,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
           onSelectItem={onSelectItem}
           onDeselectItem={onDeselectItem}
           footer={footer}
+          emptyState={emptyState}
+          emptyMessage={emptyMessage}
           sortFn={isSortedAlphabetically ? sortAlphabetically : () => 0}
           hasSelectedItemsFirst={hasSelectedItemsFirst}
         />

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -39,11 +39,9 @@ export type MultiSelectProps = {
   isSortedAlphabetically?: boolean;
   hasSelectedItemsFirst?: boolean;
   id?: string;
-  searchValue?: string;
   onSearchChange?: (value: string) => void;
   onOpen?: () => void;
   onClose?: () => void;
-  onResetSearch?: () => void;
 };
 
 type ValueSet = Set<MultiSelectItem["value"]>;
@@ -229,19 +227,24 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   isSortedAlphabetically = true,
   hasSelectedItemsFirst = true,
   id,
-  searchValue,
   onSearchChange,
   onOpen,
   onClose,
-  onResetSearch,
   help,
   helpClassName,
 }: MultiSelectProps) => {
   const buttonRef = useRef(null);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [internalSearchValue, setInternalSearchValue] = useState("");
-  const previousOpenState = useRef(isDropdownOpen);
-  const filter = searchValue ?? internalSearchValue;
+  const [filter, setFilter] = useState("");
+
+  const handleSetDropdownOpen = (newState: boolean) => {
+    if (newState && !isDropdownOpen) {
+      onOpen?.();
+    } else if (!newState && isDropdownOpen) {
+      onClose?.();
+    }
+    setIsDropdownOpen(newState);
+  };
 
   const [internalSelectedItems, setInternalSelectedItems] = useState<
     MultiSelectItem[]
@@ -249,10 +252,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   const selectedItems = externalSelectedItems || internalSelectedItems;
   const helpId = useId();
 
-  const updateSearchValue = (value: string) => {
-    if (searchValue === undefined) {
-      setInternalSearchValue(value);
-    }
+  const updateFilter = (value: string) => {
+    setFilter(value);
     onSearchChange?.(value);
   };
 
@@ -260,8 +261,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
     if (!filter.length) {
       return;
     }
-    updateSearchValue("");
-    onResetSearch?.();
+    updateFilter("");
   };
 
   const updateItems = (newItems: MultiSelectItem[]) => {
@@ -272,19 +272,6 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
 
   const dropdownId = useId();
   const inputId = useId();
-
-  useEffect(() => {
-    if (previousOpenState.current === isDropdownOpen) {
-      return;
-    }
-
-    if (isDropdownOpen) {
-      onOpen?.();
-    } else {
-      onClose?.();
-    }
-    previousOpenState.current = isDropdownOpen;
-  }, [isDropdownOpen, onClose, onOpen]);
 
   const selectedItemsLabel = selectedItems
     .filter((selectedItem) =>
@@ -341,7 +328,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
           // Handle syncing the state when toggling the menu from within the
           // contextual menu component e.g. when clicking outside.
           if (isOpen !== isDropdownOpen) {
-            setIsDropdownOpen(isOpen);
+            handleSetDropdownOpen(isOpen);
           }
         }}
         position="left"
@@ -358,12 +345,12 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               disabled={disabled}
               autoComplete="off"
               onChange={(value) => {
-                updateSearchValue(value);
+                updateFilter(value);
                 // reopen if dropdown has been closed via ESC
-                setIsDropdownOpen(true);
+                handleSetDropdownOpen(true);
               }}
               onClear={resetSearch}
-              onFocus={() => setIsDropdownOpen(true)}
+              onFocus={() => handleSetDropdownOpen(true)}
               placeholder={placeholder ?? "Search"}
               required={required}
               type="text"
@@ -379,7 +366,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               aria-expanded={isDropdownOpen}
               className="multi-select__select-button"
               onClick={() => {
-                setIsDropdownOpen(!isDropdownOpen);
+                handleSetDropdownOpen(!isDropdownOpen);
               }}
               onMouseDown={(event) => {
                 // If the dropdown is open when this button is clicked the


### PR DESCRIPTION
## Done

- Exposed search text as controlled/uncontrolled:
  - onSearchChange(value: string)
- Expose lifecycle callbacks:
  - onOpen
  - onClose
- Add native empty state support:
  - emptyState node or emptyMessage string
- New tests and stories for this functionality

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Review that the newly exposed values and callbacks are actually available (check storybook)
