### PR TITLE
fix: searchbox cta warnings in form

### DIFF
--- a/src/components/CustomSelect/CustomSelectDropdown/__snapshots__/CustomSelectDropdown.test.tsx.snap
+++ b/src/components/CustomSelect/CustomSelectDropdown/__snapshots__/CustomSelectDropdown.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CustomSelectDropdown renders 1`] = `
 <div>
@@ -32,6 +32,7 @@ exports[`CustomSelectDropdown renders 1`] = `
         />
         <button
           class="p-search-box__button"
+          type="submit"
         >
           <i
             class="p-icon--search"

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -456,3 +456,12 @@ it("can add custom classNames to dropdown (search variant)", async () => {
     "custom-footer-class",
   );
 });
+
+it("can change search button type to 'button'", async () => {
+  render(
+    <MultiSelect variant="search" items={items} searchButtonType="button" />,
+  );
+  await userEvent.click(screen.getByRole("combobox"));
+  const searchButton = screen.getByRole("button", { name: /search/i });
+  expect(searchButton).toHaveAttribute("type", "button");
+});

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -432,3 +432,27 @@ it("can add additional classes to help", () => {
     "additional-help-text-class",
   );
 });
+
+it("can add custom classNames to dropdown (search variant)", async () => {
+  render(
+    <MultiSelect
+      variant="search"
+      items={items}
+      dropdownClassName="custom-dropdown-class"
+      inputClassName="custom-input-class"
+      footerClassName="custom-footer-class"
+    />,
+  );
+  const input = screen.getByRole("combobox");
+  expect(input.closest(".multi-select__input")).toHaveClass(
+    "custom-input-class",
+  );
+
+  await userEvent.click(input);
+  expect(document.querySelector(".multi-select__dropdown")).toHaveClass(
+    "custom-dropdown-class",
+  );
+  expect(document.querySelector(".multi-select__footer")).toHaveClass(
+    "custom-footer-class",
+  );
+});

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -31,6 +31,9 @@ export type MultiSelectProps = {
   renderItem?: (item: MultiSelectItem) => ReactNode;
   dropdownHeader?: ReactNode;
   dropdownFooter?: ReactNode;
+  footerClassName?: string;
+  inputClassName?: string;
+  dropdownClassName?: string;
   emptyState?: ReactNode;
   emptyMessage?: string;
   showDropdownFooter?: boolean;
@@ -59,6 +62,8 @@ type MultiSelectDropdownProps = {
   onDeselectItem?: (item: MultiSelectItem) => void;
   onSelectItem?: (item: MultiSelectItem) => void;
   footer?: ReactNode;
+  footerClassName?: string;
+  dropdownClassName?: string;
   emptyState?: ReactNode;
   emptyMessage?: string;
   groupFn?: GroupFn;
@@ -105,6 +110,8 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
   onDeselectItem,
   isOpen,
   footer,
+  dropdownClassName,
+  footerClassName,
   emptyState,
   emptyMessage,
   sortFn = sortAlphabetically,
@@ -155,7 +162,11 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
 
   return (
     <FadeInDown isVisible={isOpen}>
-      <div className="multi-select__dropdown" role="listbox" {...props}>
+      <div
+        className={classNames("multi-select__dropdown", dropdownClassName)}
+        role="listbox"
+        {...props}
+      >
         {header ? header : null}
         {hasItems
           ? groupedItems.map(({ group, items }) => (
@@ -193,7 +204,11 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
             (emptyMessage ? (
               <p className="multi-select__empty-state">{emptyMessage}</p>
             ) : null))}
-        {footer ? <div className="multi-select__footer">{footer}</div> : null}
+        {footer ? (
+          <div className={classNames("multi-select__footer", footerClassName)}>
+            {footer}
+          </div>
+        ) : null}
       </div>
     </FadeInDown>
   );
@@ -219,6 +234,9 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   disabledItems = [],
   dropdownHeader,
   dropdownFooter,
+  footerClassName,
+  dropdownClassName,
+  inputClassName,
   emptyState,
   emptyMessage,
   showDropdownFooter = true,
@@ -355,7 +373,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               required={required}
               type="text"
               value={filter}
-              className="multi-select__input"
+              className={classNames("multi-select__input", inputClassName)}
             />
           ) : (
             <button
@@ -414,6 +432,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
           onSelectItem={onSelectItem}
           onDeselectItem={onDeselectItem}
           footer={footer}
+          footerClassName={footerClassName}
+          dropdownClassName={dropdownClassName}
           emptyState={emptyState}
           emptyMessage={emptyMessage}
           sortFn={isSortedAlphabetically ? sortAlphabetically : () => 0}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -45,6 +45,7 @@ export type MultiSelectProps = {
   onSearchChange?: (value: string) => void;
   onOpen?: () => void;
   onClose?: () => void;
+  searchButtonType?: "submit" | "button";
 };
 
 type ValueSet = Set<MultiSelectItem["value"]>;
@@ -239,6 +240,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   inputClassName,
   emptyState,
   emptyMessage,
+  searchButtonType = "submit",
   showDropdownFooter = true,
   variant = "search",
   scrollOverflow = false,
@@ -373,6 +375,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               required={required}
               type="text"
               value={filter}
+              searchButtonType={searchButtonType}
               className={classNames("multi-select__input", inputClassName)}
             />
           ) : (

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -45,6 +45,10 @@ export type Props = PropsWithSpread<
      */
     placeholder?: string;
     /**
+     * Whether the search button should be a button or submit type.
+     */
+    searchButtonType?: "submit" | "button";
+    /**
      * Whether the search input should lose focus when searching.
      */
     shouldBlurOnSearch?: boolean;
@@ -77,6 +81,7 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
       onChange,
       onSearch,
       onClear,
+      searchButtonType = "submit",
       placeholder = "Search",
       shouldBlurOnSearch = true,
       shouldRefocusAfterReset,
@@ -159,6 +164,7 @@ const SearchBox = React.forwardRef<HTMLInputElement, Props>(
           className="p-search-box__button"
           disabled={disabled}
           onClick={triggerSearch}
+          type={searchButtonType}
         >
           <Icon name="search">{Label.Search}</Icon>
         </button>

--- a/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchBox  renders 1`] = `
 <div
@@ -20,6 +20,7 @@ exports[`SearchBox  renders 1`] = `
   />
   <button
     class="p-search-box__button"
+    type="submit"
   >
     <i
       class="p-icon--search"


### PR DESCRIPTION
## Done

The `SearchBox` component and consequently the `MultiSelect` component were throwing warnings when rendered within a formik form. This was due to the fact that the search button within `SearchBox` was being rendered without an explicit `type="submit"` prop.

- Resolved the above by setting `type="submit"` by default on `SearchBox` search button
- Exposed a `searchButtonType` prop in case the button type needs to change
- Exposed `dropdownClassName`, `inputClassName` and `footerClassName` props to fine tune `MultiSelect` as needed. This is because the dropdown is being rendered within a portal, making global override the only other solution.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- View the storybook story to verify that the custom classname props work
- Change the `FormikField` to render multiselect and try clicking the search button on it. The following error should not appear in console:
```
Warning: You submitted a Formik form using a button with an unspecified type attribute. Most browsers default button elements to type="submit". If this is not a submit button, please add type="button"
```

