### PR TITLE
fix: don't reset search on click within input in multiselect

### DIFF
--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -228,7 +228,7 @@ it("closes the dropdown when clicking outside of the dropdown", async () => {
 });
 
 it("closes the dropdown when clicking on the button", async () => {
-  render(<MultiSelect items={items} />);
+  render(<MultiSelect items={items} variant="condensed" />);
   await userEvent.click(screen.getByRole("combobox"));
   expect(screen.getByRole("listbox")).toBeInTheDocument();
   await userEvent.click(screen.getByRole("combobox"));
@@ -351,6 +351,14 @@ it("opens and closes the dropdown on click", async () => {
   expect(screen.getByRole("listbox")).toBeInTheDocument();
   await userEvent.click(screen.getByRole("combobox"));
   expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+});
+
+it("doesn't clear the input on click", async () => {
+  render(<MultiSelect variant="search" items={items} />);
+  const input = screen.getByRole("combobox");
+  await userEvent.type(input, "hello");
+  await userEvent.click(input);
+  expect(input).toHaveValue("hello");
 });
 
 it("can render without sorting alphabetically", async () => {

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -254,7 +254,6 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   helpClassName,
 }: MultiSelectProps) => {
   const buttonRef = useRef(null);
-  const searchMouseDownRef = useRef(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [filter, setFilter] = useState("");
 
@@ -344,11 +343,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         className="multi-select"
         onToggleMenu={(isOpen) => {
           if (!isOpen) {
-            if (searchMouseDownRef.current) {
-              searchMouseDownRef.current = false;
-            } else {
-              resetSearch();
-            }
+            resetSearch();
           }
           // Handle syncing the state when toggling the menu from within the
           // contextual menu component e.g. when clicking outside.
@@ -369,8 +364,12 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               aria-label={label || placeholder || "Search"}
               disabled={disabled}
               autoComplete="off"
-              onMouseDown={() => {
-                if (isDropdownOpen) searchMouseDownRef.current = true;
+              onMouseDown={(event) => {
+                // When displayed as an input, clicking inside the input should not clear
+                // the text (e.g. if the user wants to edit what they've typed).
+                if (variant === "search") {
+                  event.stopPropagation();
+                }
               }}
               onChange={(value) => {
                 updateFilter(value);

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -254,6 +254,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   helpClassName,
 }: MultiSelectProps) => {
   const buttonRef = useRef(null);
+  const searchMouseDownRef = useRef(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [filter, setFilter] = useState("");
 
@@ -343,7 +344,11 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         className="multi-select"
         onToggleMenu={(isOpen) => {
           if (!isOpen) {
-            resetSearch();
+            if (searchMouseDownRef.current) {
+              searchMouseDownRef.current = false;
+            } else {
+              resetSearch();
+            }
           }
           // Handle syncing the state when toggling the menu from within the
           // contextual menu component e.g. when clicking outside.
@@ -364,6 +369,9 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               aria-label={label || placeholder || "Search"}
               disabled={disabled}
               autoComplete="off"
+              onMouseDown={() => {
+                if (isDropdownOpen) searchMouseDownRef.current = true;
+              }}
               onChange={(value) => {
                 updateFilter(value);
                 // reopen if dropdown has been closed via ESC


### PR DESCRIPTION
## Done

- Fixed the issue where if you type in the search box and then click somewhere inside the input to try and edit the text the input gets cleared (PFA)

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Go to the `MultiSelect` search variant story
- Type something in the search input
- Now, try to click within this input as if to edit the text you just entered
- The search text should not be reset

### Details
Before:

https://github.com/user-attachments/assets/1c481c2c-e6bf-4cbc-a602-1a0255a5abbc

