### PR TITLE
fix(CheckboxInput & RadioInput): add Field to expose error help and other props used by Input

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.stories.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.stories.tsx
@@ -52,7 +52,41 @@ export const Default: Story = {
   name: "Default",
 };
 
-export const Children: Story = {
+export const Caution: Story = {
+  render: () => (
+    <CheckboxInput label="Caution" caution="This is a caution message" />
+  ),
+  name: "Caution",
+};
+
+export const Disabled: Story = {
+  render: () => <CheckboxInput label="Disabled" disabled />,
+  name: "Disabled",
+};
+
+export const Error: Story = {
+  render: () => (
+    <CheckboxInput label="Error" error="This is an error message" />
+  ),
+  name: "Error",
+};
+
+export const Help: Story = {
+  render: () => <CheckboxInput label="Help" help="This is a help message" />,
+  name: "Help",
+};
+
+export const Indeterminate: Story = {
+  render: () => <CheckboxInput label="Indeterminate" indeterminate />,
+  name: "Indeterminate",
+};
+
+export const Inline: Story = {
+  render: () => <CheckboxInput inline label="Inline" />,
+  name: "Inline",
+};
+
+export const LabelWithChildElements: Story = {
   render: () => (
     <CheckboxInput
       label={
@@ -67,22 +101,14 @@ export const Children: Story = {
   name: "Label with child elements",
 };
 
-export const Disabled: Story = {
-  render: () => <CheckboxInput label="Disabled" disabled />,
-  name: "Disabled",
-};
-
 export const Required: Story = {
   render: () => <CheckboxInput label="Required" required />,
   name: "Required",
 };
 
-export const Inline: Story = {
-  render: () => <CheckboxInput label="Inline" inline />,
-  name: "Inline",
-};
-
-export const Indeterminate: Story = {
-  render: () => <CheckboxInput label="Indeterminate" indeterminate />,
-  name: "Indeterminate",
+export const Success: Story = {
+  render: () => (
+    <CheckboxInput label="Success" success="This is a success message" />
+  ),
+  name: "Success",
 };

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -1,9 +1,20 @@
-import React from "react";
+import React, { ReactNode, useId } from "react";
+import classnames from "classnames";
 
 import CheckableInput from "./CheckableInput";
 import type { CheckableInputProps } from "./CheckableInput";
+import Field from "components/Field";
 
-export type Props = Omit<CheckableInputProps, "inputType">;
+export type Props = Omit<CheckableInputProps, "inputType"> & {
+  caution?: ReactNode;
+  className?: string;
+  error?: ReactNode;
+  help?: ReactNode;
+  helpClassName?: string;
+  id?: string;
+  inline?: boolean;
+  success?: ReactNode;
+};
 
 /**
  * This is a [React](https://reactjs.org/) component for the Vanilla [Checkbox input](https://docs.vanillaframework.io/base/forms#checkbox).
@@ -13,15 +24,48 @@ export type Props = Omit<CheckableInputProps, "inputType">;
 const CheckboxInput = ({
   label,
   indeterminate = false,
+  caution,
+  className,
+  error,
+  help,
+  helpClassName,
+  id,
+  inline,
+  success,
   ...checkboxProps
 }: Props): React.JSX.Element => {
+  const defaultInputId = useId();
+  const inputId = id || defaultInputId;
+  const validationId = useId();
+  const helpId = useId();
+  const hasError = !!error;
+
   return (
-    <CheckableInput
-      label={label}
-      inputType="checkbox"
-      indeterminate={indeterminate}
-      {...checkboxProps}
-    ></CheckableInput>
+    <Field
+      caution={caution}
+      className={classnames(className, { "p-checkbox--inline": inline })}
+      error={error}
+      forId={inputId}
+      help={help}
+      helpClassName={helpClassName}
+      helpId={helpId}
+      inline={inline}
+      isTickElement={true}
+      success={success}
+      validationId={validationId}
+    >
+      <CheckableInput
+        {...checkboxProps}
+        aria-describedby={help ? helpId : undefined}
+        aria-errormessage={hasError ? validationId : undefined}
+        aria-invalid={hasError}
+        id={inputId}
+        indeterminate={indeterminate}
+        inline={inline}
+        inputType="checkbox"
+        label={label}
+      ></CheckableInput>
+    </Field>
   );
 };
 

--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -48,6 +48,10 @@ export type Props = {
    */
   helpId?: string;
   /**
+   * Whether the component is inline.
+   */
+  inline?: boolean;
+  /**
    * Whether the component is wrapping a select element.
    */
   isSelect?: boolean;
@@ -164,22 +168,30 @@ const generateContent = ({
   success,
   validationId,
   helpAfterLabel,
+  inline,
 }: Partial<Props> & {
   labelNode: React.JSX.Element | null;
   validationId: string;
   help: ReactNode;
-}) => (
-  <div className="p-form__control u-clearfix">
-    {isSelect ? (
-      <div className="p-form-validation__select-wrapper">{children}</div>
-    ) : (
-      children
-    )}
-    {!labelFirst && labelNode}
-    {helpAfterLabel ? null : help}
-    {generateError(error, caution, success, validationId)}
-  </div>
-);
+}) => {
+  const WrapperComponent = inline ? "span" : "div";
+  return (
+    <WrapperComponent
+      className={classNames("p-form__control", {
+        "u-clearfix": !inline,
+      })}
+    >
+      {isSelect ? (
+        <div className="p-form-validation__select-wrapper">{children}</div>
+      ) : (
+        children
+      )}
+      {!labelFirst && labelNode}
+      {helpAfterLabel ? null : help}
+      {generateError(error, caution, success, validationId)}
+    </WrapperComponent>
+  );
+};
 
 const Field = ({
   caution,
@@ -191,6 +203,7 @@ const Field = ({
   helpClassName,
   helpAfterLabel,
   helpId,
+  inline,
   isSelect,
   isTickElement,
   label,
@@ -232,9 +245,12 @@ const Field = ({
     success,
     validationId,
     helpAfterLabel,
+    inline,
   });
+
+  const WrapperComponent = inline ? "span" : "div";
   return (
-    <div
+    <WrapperComponent
       className={classNames("p-form__group", "p-form-validation", className, {
         "is-error": error,
         "is-caution": caution,
@@ -245,7 +261,7 @@ const Field = ({
     >
       {labelFirst && labelNode}
       {stacked ? <Col size={stackedFieldColumns}>{content}</Col> : content}
-    </div>
+    </WrapperComponent>
   );
 };
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -113,7 +113,6 @@ const Input = ({
   ...inputProps
 }: Props): React.JSX.Element => {
   const inputRef = useRef(null);
-  const fieldLabel = !["checkbox", "radio"].includes(type) ? label : "";
   const defaultInputId = useId();
   const inputId = id || defaultInputId;
   const validationId = useId();
@@ -142,29 +141,34 @@ const Input = ({
     }
   }, [takeFocus, takeFocusDelay]);
 
-  let input: ReactNode;
   if (type === "checkbox") {
-    input = (
+    return (
       <CheckboxInput
         label={label}
         labelClassName={labelClassName}
+        caution={caution}
+        className={wrapperClassName}
+        error={error}
+        help={help}
+        helpClassName={helpClassName}
+        required={required}
+        success={success}
         {...commonProps}
       />
     );
-  } else if (type === "radio") {
-    input = (
+  }
+  if (type === "radio") {
+    return (
       <RadioInput
         label={label}
         labelClassName={labelClassName}
-        {...commonProps}
-      />
-    );
-  } else {
-    input = (
-      <input
-        className={classNames("p-form-validation__input", className)}
-        ref={inputRef}
-        type={type}
+        caution={caution}
+        className={wrapperClassName}
+        error={error}
+        help={help}
+        helpClassName={helpClassName}
+        required={required}
+        success={success}
         {...commonProps}
       />
     );
@@ -179,8 +183,7 @@ const Input = ({
       helpAfterLabel={helpAfterLabel}
       helpClassName={helpClassName}
       helpId={helpId}
-      isTickElement={type === "checkbox" || type === "radio"}
-      label={fieldLabel}
+      label={label}
       labelClassName={labelClassName}
       required={required}
       stacked={stacked}
@@ -189,7 +192,12 @@ const Input = ({
       success={success}
       validationId={validationId}
     >
-      {input}
+      <input
+        className={classNames("p-form-validation__input", className)}
+        ref={inputRef}
+        type={type}
+        {...commonProps}
+      />
     </Field>
   );
 };

--- a/src/components/RadioInput/RadioInput.stories.tsx
+++ b/src/components/RadioInput/RadioInput.stories.tsx
@@ -53,6 +53,13 @@ export const Default: Story = {
   name: "Default",
 };
 
+export const Caution: Story = {
+  render: () => (
+    <RadioInput label="Caution" caution="This is a caution message" />
+  ),
+  name: "Caution",
+};
+
 export const Children: Story = {
   render: () => (
     <RadioInput
@@ -73,12 +80,29 @@ export const Disabled: Story = {
   name: "Disabled",
 };
 
+export const Error: Story = {
+  render: () => <RadioInput label="Error" error="This is an error message" />,
+  name: "Error",
+};
+
+export const Help: Story = {
+  render: () => <RadioInput label="Help" help="This is a help message" />,
+  name: "Help",
+};
+
+export const Inline: Story = {
+  render: () => <RadioInput inline label="Inline" />,
+  name: "Inline",
+};
+
 export const Required: Story = {
   render: () => <RadioInput label="Required" name="RadioInput" required />,
   name: "Required",
 };
 
-export const Inline: Story = {
-  render: () => <RadioInput label="Inline" name="RadioInput" inline />,
-  name: "Inline",
+export const Success: Story = {
+  render: () => (
+    <RadioInput label="Success" success="This is a success message" />
+  ),
+  name: "Success",
 };

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -1,22 +1,70 @@
-import React from "react";
+import React, { ReactNode, useId } from "react";
+import classnames from "classnames";
 
 import CheckableInput from "../CheckboxInput/CheckableInput";
 import type { CheckableInputProps } from "../CheckboxInput/CheckableInput";
+import Field from "components/Field";
 
-export type Props = Omit<CheckableInputProps, "inputType">;
+export type Props = Omit<CheckableInputProps, "inputType"> & {
+  caution?: ReactNode;
+  className?: string;
+  error?: ReactNode;
+  help?: ReactNode;
+  helpClassName?: string;
+  id?: string;
+  inline?: boolean;
+  success?: ReactNode;
+  wrapperClassName?: string;
+};
 
 /**
  * This is a [React](https://reactjs.org/) component for the Vanilla [Radio input](https://docs.vanillaframework.io/base/forms#radio-button).
  *
  * Use radio buttons to select one of the given set of options.
  */
-const RadioInput = ({ label, ...radioProps }: Props): React.JSX.Element => {
+const RadioInput = ({
+  label,
+  caution,
+  className,
+  error,
+  help,
+  helpClassName,
+  id,
+  inline,
+  success,
+  ...radioProps
+}: Props): React.JSX.Element => {
+  const defaultInputId = useId();
+  const inputId = id || defaultInputId;
+  const validationId = useId();
+  const helpId = useId();
+  const hasError = !!error;
+
   return (
-    <CheckableInput
-      inputType="radio"
-      label={label}
-      {...radioProps}
-    ></CheckableInput>
+    <Field
+      caution={caution}
+      className={classnames(className, { "p-radio--inline": inline })}
+      error={error}
+      forId={inputId}
+      help={help}
+      helpClassName={helpClassName}
+      helpId={helpId}
+      isTickElement={true}
+      success={success}
+      validationId={validationId}
+      inline={inline}
+    >
+      <CheckableInput
+        {...radioProps}
+        aria-describedby={help ? helpId : undefined}
+        aria-errormessage={hasError ? validationId : undefined}
+        aria-invalid={hasError}
+        id={inputId}
+        inline={inline}
+        inputType="radio"
+        label={label}
+      ></CheckableInput>
+    </Field>
   );
 };
 


### PR DESCRIPTION
## Done

- Add Field wrapper around `CheckboxInput` and `RadioInput` to expose `error`, `help` and other props used by Input.
This enhancement will allow us to stop using `<Input type="checkbox" />` and `<Input type="radio" />` and only use the dedicated components `CheckboxInput` and `RadioInput` instead.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- No visual changes expected on existing stories.
- New stories added for CheckboxInput and RadioInput

