### PR TITLE
fix(CheckboxInput & RadioInput): add className to wrapper

### DIFF
--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -43,7 +43,9 @@ const CheckboxInput = ({
   return (
     <Field
       caution={caution}
-      className={classnames(className, { "p-checkbox--inline": inline })}
+      className={classnames("p-checkbox-wrapper", className, {
+        "p-checkbox--inline": inline,
+      })}
       error={error}
       forId={inputId}
       help={help}

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -43,7 +43,9 @@ const RadioInput = ({
   return (
     <Field
       caution={caution}
-      className={classnames(className, { "p-radio--inline": inline })}
+      className={classnames("p-radio-wrapper", className, {
+        "p-radio--inline": inline,
+      })}
       error={error}
       forId={inputId}
       help={help}


### PR DESCRIPTION
## Done

- Add a classname to CheckboxInput and RadioInput to easily target them in CSS.
- In preparation of a fix in vanilla framework: https://github.com/canonical/vanilla-framework/pull/5818

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: # .
