### PR TITLE
feat(DoughnutChart): add href to segment

### DIFF
--- a/src/components/DoughnutChart/DoughnutChart.stories.tsx
+++ b/src/components/DoughnutChart/DoughnutChart.stories.tsx
@@ -37,3 +37,37 @@ export const Default: Story = {
     size: 150,
   },
 };
+
+/**
+ * Segments can optionally include an `href` to make them navigable links.
+ */
+export const WithLinks: Story = {
+  name: "With links",
+  args: {
+    chartID: "with-links",
+    segmentHoverWidth: 45,
+    segmentThickness: 40,
+    segments: [
+      {
+        color: "#0E8420",
+        href: "https://www.example.com/running",
+        tooltip: "Running",
+        value: 10,
+      },
+      {
+        color: "#CC7900",
+        href: "https://www.example.com/stopped",
+        tooltip: "Stopped",
+        value: 15,
+      },
+      {
+        color: "#C7162B",
+        href: "https://www.example.com/frozen",
+        tooltip: "Frozen",
+        value: 5,
+      },
+      { color: "#000", tooltip: "Error", value: 5 },
+    ],
+    size: 150,
+  },
+};

--- a/src/components/DoughnutChart/DoughnutChart.test.tsx
+++ b/src/components/DoughnutChart/DoughnutChart.test.tsx
@@ -73,4 +73,19 @@ describe("DoughnutChart", () => {
     render(<DoughnutChart {...defaultProps} />);
     expect(screen.queryByText("Test Label")).not.toBeInTheDocument();
   });
+
+  it("renders a link when href is provided on a segment", () => {
+    const segments = [
+      { ...defaultProps.segments[0], href: "/some/path" },
+      ...defaultProps.segments.slice(1),
+    ];
+    render(<DoughnutChart {...defaultProps} segments={segments} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/some/path");
+  });
+
+  it("does not render a link when href is not provided", () => {
+    render(<DoughnutChart {...defaultProps} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/DoughnutChart/DoughnutChart.tsx
+++ b/src/components/DoughnutChart/DoughnutChart.tsx
@@ -9,6 +9,10 @@ export type Segment = {
    */
   color: string;
   /**
+   * An optional URL that makes the segment a link.
+   */
+  href?: string;
+  /**
    * The segment tooltip.
    */
   tooltip?: string;
@@ -113,17 +117,24 @@ const DoughnutChart: FC<Props> = ({
   // Map over the enriched data.
   const segmentNodes = segmentsWithOffsets.map(
     (
-      { color, tooltip, value, startPosition, segmentLength, remainingSpace },
+      {
+        color,
+        href,
+        tooltip,
+        value,
+        startPosition,
+        segmentLength,
+        remainingSpace,
+      },
       i,
     ) => {
-      return (
+      const circle = (
         <circle
           className="doughnut-chart__segment"
           cx={radius - segmentThickness / 2 - hoverIncrease}
           cy={radius + segmentThickness / 2 + hoverIncrease}
           data-testid={TestIds.Segment}
-          key={i}
-          tabIndex={0}
+          tabIndex={href ? undefined : 0}
           aria-label={tooltip ? `${tooltip}: ${value}` : `${value}`}
           onMouseOut={
             tooltip
@@ -160,6 +171,14 @@ const DoughnutChart: FC<Props> = ({
           // the chart.
           transform={`rotate(-90 ${radius},${radius})`}
         />
+      );
+
+      return href ? (
+        <a key={i} href={href}>
+          {circle}
+        </a>
+      ) : (
+        <React.Fragment key={i}>{circle}</React.Fragment>
       );
     },
   );


### PR DESCRIPTION
## Done

- DoughtnuChart: add optional href to segment

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- No visual changes expected
- Add one story for DoughtnutChart

## Fixes

Fixes: https://github.com/canonical/lxd-ui/pull/2019#discussion_r3534621769
