### PR TITLE
feat(ThemeSwitcher): update color-scheme in applyTheme

### DIFF
--- a/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -29,8 +29,10 @@ export const isDarkTheme = (theme: string) => {
 export const applyTheme = (theme: string): void => {
   if (isDarkTheme(theme)) {
     document.body.classList.add("is-dark");
+    document.documentElement.style.colorScheme = "dark";
   } else {
     document.body.classList.remove("is-dark");
+    document.documentElement.style.colorScheme = "light";
   }
 };
 


### PR DESCRIPTION
## Done

- Update `applyTheme` to toggle the document's native `color-scheme` style (in addition to the body's className)

This ensures modern components utilizing the native `light-dark()` CSS function, like pragma, adapt instantly to theme switches.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- No visual changes expected

