### PR TITLE
feat(MultiSelect): Allow ReactNode to be used as checkbox label

### DIFF
--- a/src/components/MultiSelect/MultiSelect.scss
+++ b/src/components/MultiSelect/MultiSelect.scss
@@ -89,6 +89,7 @@ $dropdown-max-height: 20rem;
 
   &,
   .p-checkbox {
+    max-width: 100%;
     width: 100%;
   }
 }

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -43,6 +43,7 @@ export const CondensedExample: Story = {
       ...Array.from({ length: 26 }, (_, i) => ({
         label: `${String.fromCharCode(i + 65)}`,
         value: `${String.fromCharCode(i + 65)}`,
+        node: <span style={{ display: "inline flex", justifyContent: "space-between", textIndent: 0, width: "100%" }}><span>{String.fromCharCode(i + 65)}</span><span className="u-text--muted">20 instances</span></span>
       })),
       ...Array.from({ length: 26 }, (_, i) => ({
         label: `Item ${i + 1}`,

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -43,7 +43,19 @@ export const CondensedExample: Story = {
       ...Array.from({ length: 26 }, (_, i) => ({
         label: `${String.fromCharCode(i + 65)}`,
         value: `${String.fromCharCode(i + 65)}`,
-        node: <span style={{ display: "inline flex", justifyContent: "space-between", textIndent: 0, width: "100%" }}><span>{String.fromCharCode(i + 65)}</span><span className="u-text--muted">20 instances</span></span>
+        node: (
+          <span
+            style={{
+              display: "inline flex",
+              justifyContent: "space-between",
+              textIndent: 0,
+              width: "100%",
+            }}
+          >
+            <span>{String.fromCharCode(i + 65)}</span>
+            <span className="u-text--muted">20 instances</span>
+          </span>
+        ),
       })),
       ...Array.from({ length: 26 }, (_, i) => ({
         label: `Item ${i + 1}`,

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -10,6 +10,7 @@ import { FadeInDown } from "./FadeInDown";
 export type MultiSelectItem = {
   label: string;
   value: string | number;
+  node?: ReactNode;
   group?: string;
 };
 
@@ -190,7 +191,7 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
                       >
                         <CheckboxInput
                           disabled={disabledItemValues.has(item.value)}
-                          label={item.label}
+                          label={item.node ?? item.label}
                           checked={selectedItemValues.has(item.value)}
                           value={item.value}
                           onChange={handleOnChange}


### PR DESCRIPTION
## Done

- Add a `node` prop to `MultiSelectItem` which overrides the `label` prop for the checkbox label. The `label` will still be used for alphabetical sorting and showing the list of selected items. This prop is intended to show additional information about the item beyond just its name.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### Percy steps

- Added a informational label to some items in the default story.