### PR TITLE
fix(modal): skip hidden elements when setting focus

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -262,4 +262,60 @@ describe("Modal ", () => {
     const proceedButton = screen.getByRole("button", { name: /^proceed$/i });
     expect(proceedButton).toHaveFocus();
   });
+
+  it("excludes hidden focusable elements from the focus trap", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Modal
+        title="Test"
+        close={jest.fn()}
+        buttonRow={
+          <>
+            <button id="test-cancel">Cancel</button>
+            <button id="test-hidden" style={{ display: "none" }}>
+              Hidden
+            </button>
+          </>
+        }
+      >
+        Bare bones
+      </Modal>,
+    );
+
+    const closeButton = container.querySelector("button.p-modal__close");
+    const cancelButton = container.querySelector("button#test-cancel");
+
+    expect(closeButton).toHaveFocus();
+    await user.tab({ shift: true });
+    expect(cancelButton).toHaveFocus();
+
+    await user.tab();
+    expect(closeButton).toHaveFocus();
+  });
+
+  it("initially focuses the first visible focusable element when the close button is hidden", () => {
+    const style = document.createElement("style");
+    style.innerHTML = ".p-modal__close { display: none; }";
+    document.head.appendChild(style);
+
+    try {
+      const { container } = render(
+        <Modal
+          title="Test"
+          close={jest.fn()}
+          buttonRow={<button id="test-cancel">Cancel</button>}
+        >
+          Bare bones
+        </Modal>,
+      );
+
+      const closeButton = container.querySelector("button.p-modal__close");
+      const cancelButton = container.querySelector("button#test-cancel");
+
+      expect(closeButton).not.toHaveFocus();
+      expect(cancelButton).toHaveFocus();
+    } finally {
+      document.head.removeChild(style);
+    }
+  });
 });

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -67,24 +67,46 @@ export const Modal = ({
 
   const modalRef: RefObject<HTMLDivElement> = useRef(null);
   const closeButtonRef: RefObject<HTMLButtonElement> = useRef(null);
+
+  // determines whether an element is visible by checking computed styles
+  // fails open: an element is only treated as hidden when getComputedStyle
+  // explicitly reports `display:none` or `visibility:hidden`
+  const isElementVisible = (element: Element): boolean => {
+    let current: Element | null = element;
+    while (current) {
+      const style = window.getComputedStyle(current);
+      if (style.display === "none" || style.visibility === "hidden") {
+        return false;
+      }
+      current = current.parentElement;
+    }
+    return true;
+  };
+
+  const getVisibleFocusableElements = (): HTMLElement[] => {
+    if (!modalRef.current) {
+      return [];
+    }
+    return Array.from(
+      modalRef.current.querySelectorAll<HTMLElement>(focusableElementSelectors),
+    ).filter(isElementVisible);
+  };
+
   const handleTabKey = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const focusableModalElements = modalRef.current.querySelectorAll(
-      focusableElementSelectors,
-    );
-    if (focusableModalElements.length > 0) {
-      const firstElement = focusableModalElements[0];
-      const lastElement =
-        focusableModalElements[focusableModalElements.length - 1];
+    const focusableModalElements = getVisibleFocusableElements();
+    if (focusableModalElements.length === 0) {
+      return;
+    }
+    const firstElement = focusableModalElements[0];
+    const lastElement =
+      focusableModalElements[focusableModalElements.length - 1];
 
-      if (!event.shiftKey && document.activeElement === lastElement) {
-        (firstElement as HTMLElement).focus();
-        event.preventDefault();
-      }
-
-      if (event.shiftKey && document.activeElement === firstElement) {
-        (lastElement as HTMLElement).focus();
-        return event.preventDefault();
-      }
+    if (event.shiftKey && document.activeElement === firstElement) {
+      lastElement.focus();
+      event.preventDefault();
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      firstElement.focus();
+      event.preventDefault();
     }
   };
 
@@ -103,13 +125,29 @@ export const Modal = ({
     }
   };
 
+  const focusModalWrapper = () => {
+    if (modalRef.current) {
+      modalRef.current.tabIndex = -1;
+      modalRef.current.focus();
+    }
+  };
+
   useEffect(() => {
     if (focusRef?.current) {
       focusRef.current.focus();
     } else if (closeButtonRef.current) {
-      closeButtonRef.current.focus();
+      if (isElementVisible(closeButtonRef.current)) {
+        closeButtonRef.current.focus();
+      } else {
+        const firstFocusable = getVisibleFocusableElements()[0];
+        if (firstFocusable) {
+          firstFocusable.focus();
+        } else {
+          focusModalWrapper();
+        }
+      }
     } else {
-      modalRef.current.focus();
+      focusModalWrapper();
     }
   }, [focusRef]);
 


### PR DESCRIPTION
## Done

- Modal focus management now ignores hidden elements. The focus trap and initial focus only consider elements that are actually visible, so a hidden close button (or any hidden focusable element) no longer traps focus or breaks keyboard navigation.
- Added tests covering the focus trap and initial focus behaviour when elements are hidden.


## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Verify the modal tests and confirm they pass.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: #[AC-4874](https://warthogs.atlassian.net/browse/AC-4874)


[AC-4874]: https://warthogs.atlassian.net/browse/AC-4874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ