### PR TITLE
feat: add segmented control component

### DIFF
--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+
+import { Meta, StoryObj } from "@storybook/react";
+import SegmentedControl from "./SegmentedControl";
+
+const meta: Meta<typeof SegmentedControl> = {
+  component: SegmentedControl,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SegmentedControl>;
+
+export const Default: Story = {
+  name: "Default",
+
+  args: {
+    segments: [
+      {
+        label: "OLM",
+        segmentContent: (
+          <p>
+            A system to help you move from configuration management to
+            application management across your hybrid cloud estate - through
+            sharable, reusable, tiny applications called Charmed Operators.
+          </p>
+        ),
+      },
+      {
+        label: "SDK",
+        segmentContent: (
+          <p>
+            A set of tools to help you write Charmed Operators and to package
+            them as Charms.
+          </p>
+        ),
+      },
+      {
+        label: "Charmhub",
+        segmentContent: (
+          <p>
+            A repository for charms - from Observability to Data to Identity and
+            more.
+          </p>
+        ),
+      },
+    ],
+  },
+};
+
+/**
+ * The buttons take up a more compact apperance by adding the modifier is-dense
+ */
+
+export const Dense: Story = {
+  name: "Dense",
+
+  args: {
+    className: "is-dense",
+    segments: [
+      {
+        label: "OLM",
+        segmentContent: (
+          <p>
+            A system to help you move from configuration management to
+            application management across your hybrid cloud estate - through
+            sharable, reusable, tiny applications called Charmed Operators.
+          </p>
+        ),
+      },
+      {
+        label: "SDK",
+        segmentContent: (
+          <p>
+            A set of tools to help you write Charmed Operators and to package
+            them as Charms.
+          </p>
+        ),
+      },
+      {
+        label: "Charmhub",
+        segmentContent: (
+          <p>
+            A repository for charms - from Observability to Data to Identity and
+            more.
+          </p>
+        ),
+      },
+    ],
+  },
+};
+/**
+ * The pattern also supports the use of icons within each button.
+ *
+ * Icons : If any icons are used, all buttons within the pattern should have an icon, to avoid any potential confusion that could arise from a mix of buttons with and without an icon.
+ */
+export const WithIcon: Story = {
+  name: "With Icon",
+  args: {
+    segments: [
+      {
+        label: "OLM",
+        segmentContent: (
+          <p>
+            A system to help you move from configuration management to
+            application management across your hybrid cloud estate - through
+            sharable, reusable, tiny applications called Charmed Operators.
+          </p>
+        ),
+        segmentIcon: <i className="p-icon--information"></i>,
+      },
+      {
+        label: "SDK",
+        segmentContent: (
+          <p>
+            A set of tools to help you write Charmed Operators and to package
+            them as Charms.
+          </p>
+        ),
+        segmentIcon: <i className="p-icon--information"></i>,
+      },
+      {
+        label: "Charmhub",
+        segmentContent: (
+          <p>
+            A repository for charms - from Observability to Data to Identity and
+            more.
+          </p>
+        ),
+        segmentIcon: <i className="p-icon--information"></i>,
+      },
+    ],
+  },
+};

--- a/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -19,7 +19,7 @@ export const Default: Story = {
     segments: [
       {
         label: "OLM",
-        segmentContent: (
+        content: (
           <p>
             A system to help you move from configuration management to
             application management across your hybrid cloud estate - through
@@ -29,7 +29,7 @@ export const Default: Story = {
       },
       {
         label: "SDK",
-        segmentContent: (
+        content: (
           <p>
             A set of tools to help you write Charmed Operators and to package
             them as Charms.
@@ -38,7 +38,7 @@ export const Default: Story = {
       },
       {
         label: "Charmhub",
-        segmentContent: (
+        content: (
           <p>
             A repository for charms - from Observability to Data to Identity and
             more.
@@ -61,7 +61,7 @@ export const Dense: Story = {
     segments: [
       {
         label: "OLM",
-        segmentContent: (
+        content: (
           <p>
             A system to help you move from configuration management to
             application management across your hybrid cloud estate - through
@@ -71,7 +71,7 @@ export const Dense: Story = {
       },
       {
         label: "SDK",
-        segmentContent: (
+        content: (
           <p>
             A set of tools to help you write Charmed Operators and to package
             them as Charms.
@@ -80,7 +80,7 @@ export const Dense: Story = {
       },
       {
         label: "Charmhub",
-        segmentContent: (
+        content: (
           <p>
             A repository for charms - from Observability to Data to Identity and
             more.
@@ -101,34 +101,34 @@ export const WithIcon: Story = {
     segments: [
       {
         label: "OLM",
-        segmentContent: (
+        content: (
           <p>
             A system to help you move from configuration management to
             application management across your hybrid cloud estate - through
             sharable, reusable, tiny applications called Charmed Operators.
           </p>
         ),
-        segmentIcon: <i className="p-icon--information"></i>,
+        iconName: "information",
       },
       {
         label: "SDK",
-        segmentContent: (
+        content: (
           <p>
             A set of tools to help you write Charmed Operators and to package
             them as Charms.
           </p>
         ),
-        segmentIcon: <i className="p-icon--information"></i>,
+        iconName: "information",
       },
       {
         label: "Charmhub",
-        segmentContent: (
+        content: (
           <p>
             A repository for charms - from Observability to Data to Identity and
             more.
           </p>
         ),
-        segmentIcon: <i className="p-icon--information"></i>,
+        iconName: "information",
       },
     ],
   },

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import SegmentedControl from "./SegmentedControl";
+
+describe("SegmentedControl", () => {
+  it("renders", () => {
+    const { container } = render(
+      <SegmentedControl
+        segments={[
+          {
+            label: "label1",
+            segmentContent: <p>content1</p>,
+          },
+        ]}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it("can set className correctly", () => {
+    render(
+      <SegmentedControl
+        className="is-dense"
+        segments={[
+          {
+            label: "label1",
+            segmentContent: <p>content1</p>,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId("segmented-control-div")).toHaveClass("is-dense");
+  });
+
+  it("can set active segment on segment click", async () => {
+    render(
+      <SegmentedControl
+        segments={[
+          {
+            label: "label1",
+            segmentContent: <p>content1</p>,
+          },
+          {
+            label: "label2",
+            segmentContent: <p>content2</p>,
+          },
+        ]}
+      />,
+    );
+    const segment = screen.getByRole("tab", { name: "label2" });
+    await userEvent.click(segment);
+    expect(screen.getByRole("tab", { name: "label2" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("content2");
+  });
+});

--- a/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -11,7 +11,7 @@ describe("SegmentedControl", () => {
         segments={[
           {
             label: "label1",
-            segmentContent: <p>content1</p>,
+            content: <p>content1</p>,
           },
         ]}
       />,
@@ -20,18 +20,20 @@ describe("SegmentedControl", () => {
   });
 
   it("can set className correctly", () => {
-    render(
+    const { container } = render(
       <SegmentedControl
         className="is-dense"
         segments={[
           {
             label: "label1",
-            segmentContent: <p>content1</p>,
+            content: <p>content1</p>,
           },
         ]}
       />,
     );
-    expect(screen.getByTestId("segmented-control-div")).toHaveClass("is-dense");
+    expect(container.querySelector(".p-segmented-control")).toHaveClass(
+      "is-dense",
+    );
   });
 
   it("can set active segment on segment click", async () => {
@@ -40,11 +42,11 @@ describe("SegmentedControl", () => {
         segments={[
           {
             label: "label1",
-            segmentContent: <p>content1</p>,
+            content: <p>content1</p>,
           },
           {
             label: "label2",
-            segmentContent: <p>content2</p>,
+            content: <p>content2</p>,
           },
         ]}
       />,
@@ -55,6 +57,8 @@ describe("SegmentedControl", () => {
       "aria-selected",
       "true",
     );
-    expect(screen.getByRole("tabpanel")).toHaveTextContent("content2");
+    expect(screen.getByRole("tabpanel", { name: "label2" })).toHaveTextContent(
+      "content2",
+    );
   });
 });

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,74 @@
+import classNames from "classnames";
+import React, { ReactNode, HTMLProps, useState } from "react";
+import type { ClassName } from "types";
+
+export type Segments<P = null> = {
+  /**
+   * Label to be displayed inside the segment.
+   */
+  label: ReactNode;
+  /**
+   * Content to be displayed inside the segment.
+   */
+  segmentContent: ReactNode;
+  /**
+   * Icon to be displayed alongside the label of the segment.
+   */
+  segmentIcon?: ReactNode;
+} & (HTMLProps<HTMLElement> | P);
+
+export type Props<P = null> = {
+  /**
+   * Optional classes applied to the parent element.
+   */
+  className?: ClassName;
+  /**
+   * List of segments present in the element.
+   */
+  segments: Segments<P>[];
+};
+/**
+ * This is the [React](https://reactjs.org/) component for Vanilla [SegmentedControl](https://vanillaframework.io/docs/patterns/segmented-control).
+SegmentedControl organises and allows navigation between groups of content that are related and at the same level
+of hierarchy.
+ */
+const SegmentedControl = ({
+  className,
+  segments,
+}: Props): React.JSX.Element => {
+  const [activeIndex, setActiveIndex] = useState<number>(0);
+  return (
+    <div
+      className={classNames("p-segmented-control", className)}
+      data-testid="segmented-control-div"
+    >
+      <div className={classNames("p-segmented-control__list")} role="tablist">
+        {segments.map((segment, i) => {
+          return (
+            <button
+              aria-selected={activeIndex === i}
+              className={classNames("p-segmented-control__button")}
+              role="tab"
+              key={i}
+              onClick={() => setActiveIndex(i)}
+            >
+              {segment.segmentIcon ? (
+                <>
+                  {segment.segmentIcon}
+                  <span>{segment.label}</span>
+                </>
+              ) : (
+                segment.label
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div tabIndex={activeIndex} role="tabpanel" data-testid="text-content">
+        {segments[activeIndex].segmentContent}
+      </div>
+    </div>
+  );
+};
+
+export default SegmentedControl;

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -63,11 +63,7 @@ const SegmentedControl = ({
           );
         })}
       </div>
-      <div
-        tabIndex={activeIndex}
-        role="tabpanel"
-        aria-labelledby={segments[activeIndex].label}
-      >
+      <div role="tabpanel" aria-labelledby={segments[activeIndex].label}>
         {segments[activeIndex].content}
       </div>
     </div>

--- a/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,23 +1,24 @@
 import classNames from "classnames";
-import React, { ReactNode, HTMLProps, useState } from "react";
-import type { ClassName } from "types";
+import Icon, { ICONS } from "components/Icon";
+import React, { ReactNode, useState } from "react";
+import type { ClassName, ValueOf } from "types";
 
-export type Segments<P = null> = {
+export type Segments = {
   /**
    * Label to be displayed inside the segment.
    */
-  label: ReactNode;
+  label: string;
   /**
    * Content to be displayed inside the segment.
    */
-  segmentContent: ReactNode;
+  content: ReactNode;
   /**
    * Icon to be displayed alongside the label of the segment.
    */
-  segmentIcon?: ReactNode;
-} & (HTMLProps<HTMLElement> | P);
+  iconName?: ValueOf<typeof ICONS> | string;
+};
 
-export type Props<P = null> = {
+export type Props = {
   /**
    * Optional classes applied to the parent element.
    */
@@ -25,7 +26,7 @@ export type Props<P = null> = {
   /**
    * List of segments present in the element.
    */
-  segments: Segments<P>[];
+  segments: Segments[];
 };
 /**
  * This is the [React](https://reactjs.org/) component for Vanilla [SegmentedControl](https://vanillaframework.io/docs/patterns/segmented-control).
@@ -38,10 +39,7 @@ const SegmentedControl = ({
 }: Props): React.JSX.Element => {
   const [activeIndex, setActiveIndex] = useState<number>(0);
   return (
-    <div
-      className={classNames("p-segmented-control", className)}
-      data-testid="segmented-control-div"
-    >
+    <div className={classNames("p-segmented-control", className)}>
       <div className={classNames("p-segmented-control__list")} role="tablist">
         {segments.map((segment, i) => {
           return (
@@ -49,12 +47,13 @@ const SegmentedControl = ({
               aria-selected={activeIndex === i}
               className={classNames("p-segmented-control__button")}
               role="tab"
-              key={i}
+              key={segment.label}
+              id={segment.label}
               onClick={() => setActiveIndex(i)}
             >
-              {segment.segmentIcon ? (
+              {segment.iconName ? (
                 <>
-                  {segment.segmentIcon}
+                  <Icon name={segment.iconName} />
                   <span>{segment.label}</span>
                 </>
               ) : (
@@ -64,8 +63,12 @@ const SegmentedControl = ({
           );
         })}
       </div>
-      <div tabIndex={activeIndex} role="tabpanel" data-testid="text-content">
-        {segments[activeIndex].segmentContent}
+      <div
+        tabIndex={activeIndex}
+        role="tabpanel"
+        aria-labelledby={segments[activeIndex].label}
+      >
+        {segments[activeIndex].content}
       </div>
     </div>
   );

--- a/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SegmentedControl renders 1`] = `
+<div>
+  <div
+    class="p-segmented-control"
+    data-testid="segmented-control-div"
+  >
+    <div
+      class="p-segmented-control__list"
+      role="tablist"
+    >
+      <button
+        aria-selected="true"
+        class="p-segmented-control__button"
+        role="tab"
+      >
+        label1
+      </button>
+    </div>
+    <div
+      data-testid="text-content"
+      role="tabpanel"
+      tabindex="0"
+    >
+      <p>
+        content1
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`SegmentedControl renders 1`] = `
 <div>
   <div
     class="p-segmented-control"
-    data-testid="segmented-control-div"
   >
     <div
       class="p-segmented-control__list"
@@ -13,13 +12,14 @@ exports[`SegmentedControl renders 1`] = `
       <button
         aria-selected="true"
         class="p-segmented-control__button"
+        id="label1"
         role="tab"
       >
         label1
       </button>
     </div>
     <div
-      data-testid="text-content"
+      aria-labelledby="label1"
       role="tabpanel"
       tabindex="0"
     >

--- a/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/src/components/SegmentedControl/__snapshots__/SegmentedControl.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`SegmentedControl renders 1`] = `
     <div
       aria-labelledby="label1"
       role="tabpanel"
-      tabindex="0"
     >
       <p>
         content1

--- a/src/components/SegmentedControl/index.ts
+++ b/src/components/SegmentedControl/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./SegmentedControl";
+export type { Props as SegmentedControlProps } from "./SegmentedControl";

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export { default as ScrollableContainer } from "./components/ScrollableContainer
 export { default as ScrollableTable } from "./components/ScrollableTable";
 export { default as SearchAndFilter } from "./components/SearchAndFilter";
 export { default as SearchBox } from "./components/SearchBox";
+export { default as SegmentedControl } from "./components/SegmentedControl";
 export { default as Select } from "./components/Select";
 export { default as SideNavigation } from "./components/SideNavigation";
 export { default as SideNavigationItem } from "./components/SideNavigation/SideNavigationItem";
@@ -194,6 +195,7 @@ export type { ScrollableTableProps } from "./components/ScrollableTable";
 export type { ScrollableContainerProps } from "./components/ScrollableContainer";
 export type { SearchAndFilterProps } from "./components/SearchAndFilter";
 export type { SearchBoxProps } from "./components/SearchBox";
+export type { SegmentedControlProps } from "./components/SegmentedControl";
 export type { SelectProps } from "./components/Select";
 export type { SideNavigationProps } from "./components/SideNavigation";
 export type { SideNavigationItemProps } from "./components/SideNavigation/SideNavigationItem";


### PR DESCRIPTION
## Done

- This PR implements the Segmented Control component from Vanilla Framework in RC.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```
<img width="1833" height="749" alt="segmented-control" src="https://github.com/user-attachments/assets/dd3aa513-8d3d-430f-9533-854321fc680e" />


### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

`yarn build` and `npm back` is successfull.
Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- List any expected visual change in Percy, or write something like "No visual changes expected" if none is expected.

## Fixes

Fixes: #1365  .
