### PR TITLE
fix(a11y-landmark): spread other html props over tabs nav item

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -51,9 +51,10 @@ const Tabs = <P,>({
   className,
   links,
   listClassName,
+  ...props
 }: Props<P>): React.JSX.Element => {
   return (
-    <nav className={classNames("p-tabs", className)}>
+    <nav className={classNames("p-tabs", className)} {...props}>
       <ul className={classNames("p-tabs__list", listClassName)}>
         {links.map((link, i) => {
           const {


### PR DESCRIPTION
## Done

- Since the Tabs component renders a "nav" item, it will most certainly conflict with other navs and create the "unique landmark" a11y violation.
- Added support for spreading other HTML attributes over the nav component of the Tabs component
- This would allow us to use a different semantic name for the nav itself through ```aria-label```

## QA

Pinging @canonical/react-library-maintainers for a review.

Make sure that, when you pass in a "aria-label" attribute to the Tabs component, it is actually rendered in the nav element

<img width="2871" height="167" alt="image" src="https://github.com/user-attachments/assets/c50737c6-2eab-41c1-ba31-edb057a4415c" />


### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA 


## Fixes

Fixes: #[AC-4738](https://warthogs.atlassian.net/browse/AC-4738)


[AC-4738]: https://warthogs.atlassian.net/browse/AC-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ