### PR TITLE
feat(SearchAndFilter): use Chip's appearance

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -130,9 +130,9 @@ const Chip = ({
   );
 
   const chipClassName = classNames(
+    "p-chip",
     {
       [`p-chip--${appearance}`]: !!appearance,
-      "p-chip": !appearance,
       "is-dense": isDense,
       "is-readonly": isReadOnly,
       "is-inline": isInline,

--- a/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.tsx
+++ b/src/components/SearchAndFilter/FilterPanelSection/FilterPanelSection.tsx
@@ -127,6 +127,7 @@ const FilterPanelSection = ({
                     key={`${chip.lead}+${chip.value}`}
                     lead={chip.lead}
                     value={chip.value}
+                    appearance={chip.appearance}
                     selected={isChipInArray(chip, searchData)}
                     subString={searchTerm}
                     onClick={() => handleChipClick(chip)}

--- a/src/components/SearchAndFilter/SearchAndFilter.stories.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.stories.tsx
@@ -305,3 +305,49 @@ export const WithExistingSearchData: Story = {
     returnSearchData: () => {},
   },
 };
+
+export const WithChipAppearance: Story = {
+  name: "With chip appearance",
+
+  args: {
+    filterPanelData: [
+      {
+        id: 0,
+        heading: "Status",
+
+        chips: [
+          {
+            value: "new",
+          },
+          {
+            value: "acknowledged",
+          },
+          {
+            value: "resolved",
+          },
+        ],
+      },
+      {
+        id: 1,
+        heading: "Severity",
+
+        chips: [
+          {
+            value: "high",
+            appearance: "negative",
+          },
+          {
+            value: "moderate",
+            appearance: "caution",
+          },
+          {
+            value: "low",
+            appearance: "information",
+          },
+        ],
+      },
+    ],
+
+    returnSearchData: () => {},
+  },
+};

--- a/src/components/SearchAndFilter/SearchAndFilter.tsx
+++ b/src/components/SearchAndFilter/SearchAndFilter.tsx
@@ -261,6 +261,7 @@ const SearchAndFilter = ({
               lead={chip.lead}
               value={chip.value}
               key={`search-${chip.lead}+${chip.value}`}
+              appearance={chip.appearance}
               onDismiss={(event) => {
                 // Prevent filter chip dismissals from bubbling up and triggering the parent onClick handler
                 event.stopPropagation();

--- a/src/components/SearchAndFilter/types.ts
+++ b/src/components/SearchAndFilter/types.ts
@@ -1,4 +1,8 @@
+import type { ValueOf } from "index";
+import type { ChipType } from "../Chip/Chip";
+
 export type SearchAndFilterChip = {
+  appearance?: ValueOf<typeof ChipType>;
   id?: number;
   lead?: string;
   quoteValue?: boolean;


### PR DESCRIPTION
## Done

- Add optional use of Chip's `appearance` in SearchAndFilter

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

To see rendered examples of all react-components, run:

```shell
yarn start
```

### QA in your project

from `react-components` run:

```shell
yarn build
npm pack
```

Install the resulting tarball in your project with:

```shell
yarn add <path-to-tarball>
```

### QA steps

- Steps for QA.

### Percy steps

- New story for SearchAndFilter with Chip appearance

## Screenshots

<img width="1479" height="365" alt="Screenshot from 2026-08-10 17-16-04" src="https://github.com/user-attachments/assets/1240557c-ca11-4387-8e4d-0431537eb2d4" />

