### PR TITLE
fix(step): ensure step status icon style is not overwritten by icon's

### DIFF
--- a/src/components/Stepper/Step/Step.scss
+++ b/src/components/Stepper/Step/Step.scss
@@ -39,9 +39,9 @@
 }
 
 .step-status-icon {
-  height: 1.6rem;
-  margin-left: 0.4rem;
-  width: 1.6rem;
+  height: 1.6rem !important;
+  margin-left: 0.4rem !important;
+  width: 1.6rem !important;
 }
 
 .step-selected {
@@ -69,7 +69,7 @@
   }
 
   .step-status-icon {
-    margin-left: 0;
+    margin-left: 0 !important;
   }
 
   .step-number {


### PR DESCRIPTION
## Done

- Ensured that the step status icon style is not overwritten by the icon's.

# Before

<img width="844" height="347" alt="image" src="https://github.com/user-attachments/assets/fe5f9f0d-4918-440b-b9c1-075015c1ba6a" />

# After

<img width="844" height="347" alt="image" src="https://github.com/user-attachments/assets/e2976c20-4dce-4923-b7b5-00fad2e2a9ea" />