### PR TITLE
fix(contextual-menu): route Tab into the menu when opened with the mouse

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -371,6 +371,65 @@ describe("ContextualMenu ", () => {
       expect(screen.getByTestId("item-0")).not.toHaveFocus();
     });
 
+    it("routes Tab into the menu when it was opened by a mouse", async () => {
+      // A focusable element rendered after the menu: without routing, Tab
+      // walks the page instead of entering the open menu.
+      const links = [0, 1].map((i) => ({
+        "data-testid": `item-${i}`,
+        children: `Item ${i}`,
+      }));
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(
+        <>
+          <ContextualMenu
+            links={links}
+            dropdownProps={{ "data-testid": "dropdown" }}
+            toggleLabel={<span>toggle</span>}
+          />
+          <button data-testid="after" type="button">
+            after
+          </button>
+        </>,
+      );
+      const toggle = screen.getByRole("button", { name: /toggle/i });
+
+      await user.click(toggle);
+      jest.runOnlyPendingTimers();
+
+      expect(screen.getByTestId("item-0")).not.toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByTestId("item-0")).toHaveFocus();
+      expect(screen.getByTestId("after")).not.toHaveFocus();
+    });
+
+    it("leaves Tab alone when focus is not on the toggle", async () => {
+      const links = [0, 1].map((i) => ({
+        "data-testid": `item-${i}`,
+        children: `Item ${i}`,
+      }));
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      render(
+        <>
+          <button data-testid="outside" type="button">
+            outside
+          </button>
+          <ContextualMenu
+            links={links}
+            dropdownProps={{ "data-testid": "dropdown" }}
+            toggleLabel={<span>toggle</span>}
+          />
+        </>,
+      );
+      await user.click(screen.getByRole("button", { name: /toggle/i }));
+      jest.runOnlyPendingTimers();
+
+      // Move focus without clicking, so the menu does not close.
+      screen.getByTestId("outside").focus();
+      await user.tab();
+      expect(screen.getByTestId("item-0")).not.toHaveFocus();
+    });
+
     it("cleans up focus event listeners when unmounted", async () => {
       const { user, toggle, unmount } = setup();
 

--- a/src/components/ContextualMenu/ContextualMenu.tsx
+++ b/src/components/ContextualMenu/ContextualMenu.tsx
@@ -307,7 +307,7 @@ const ContextualMenu = <L,>({
   });
 
   /**
-   * Trap focus within the dropdown
+   * Trap focus within the dropdown and route keyboard focus into it.
    */
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -325,13 +325,25 @@ const ContextualMenu = <L,>({
         // Shift+Tab on the first item: wrap back to the last focusable item
         e.preventDefault();
         last.focus();
+      } else if (
+        !e.shiftKey &&
+        active ===
+          wrapper.current?.querySelector<HTMLElement>(
+            ".p-contextual-menu__toggle",
+          )
+      ) {
+        // The menu is open but focus is still on the toggle, e.g. the menu
+        // was opened with the mouse: Tab must enter the menu instead of
+        // walking the rest of the page.
+        e.preventDefault();
+        first.focus();
       }
     };
-    const dropdown = getDropdown();
-    if (!dropdown) return undefined;
-    dropdown.addEventListener("keydown", handleKeyDown);
+    // The toggle lives outside the dropdown element, so the listener is
+    // document level to catch both the wrap cases and the toggle case.
+    document.addEventListener("keydown", handleKeyDown);
     return () => {
-      dropdown.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keydown", handleKeyDown);
     };
   }, [getDropdown, getFocusableDropdownItems, isOpen]);
 


### PR DESCRIPTION
## Done

Fixes #1363, following the smaller-step direction suggested in the issue thread by @edlerd: focus the first item when Tab is pressed while the menu is open and no menu item is focused yet.

- `ContextualMenuDropdown` renders through a portal, so after opening the menu with the mouse the menu items sit after every other page element in tab order: pressing Tab walked the rest of the page instead of entering the menu. Keyboard-opened menus already moved focus to the first item (they satisfy the `detail === 0` gate), which is why the bug only reproduces after a mouse click.
- When the menu is open and Tab is pressed while focus is still on the toggle, focus now moves to the first menu item.
- Tab pressed anywhere else is untouched (guarded on `activeElement` being the toggle).
- Mouse behaviour is unchanged: no autofocus on click (the `does not autofocus when opened by a mouse` test still passes).
- The existing wrap-around logic is preserved and now lives in the same document-level listener, since the toggle sits outside the dropdown element.

The full ARIA menu pattern discussed in the issue (arrow-key navigation, roving tabindex) can build on this as a follow-up.

## QA

Pinging @canonical/react-library-maintainers for a review.

### Storybook

1. `yarn start`, open the ContextualMenu > Toggle story.
2. Click the toggle with the mouse (options must not take focus: unchanged).
3. Press Tab: focus now lands on the first menu option instead of walking the page.
4. Tab / Shift+Tab still wrap within the options; Escape still closes.

### Tests

`yarn jest src/components/ContextualMenu`:

```
Test Suites: 2 passed, 2 total
Tests:       51 passed, 51 total
```

New tests: `routes Tab into the menu when it was opened by a mouse` (fails before the fix, passes after) and `leaves Tab alone when focus is not on the toggle` (guards against over-eager routing). `eslint` and `tsc --noEmit` clean.